### PR TITLE
Enable running on already deployed Authorino

### DIFF
--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -9,3 +9,7 @@
 #    test_user:
 #      username: "testUser"
 #      password: "testPassword"
+#  authorino:
+#    image: "quay.io/kuadrant/authorino:latest"  # If specified will override the authorino image
+#    deploy: false                               # If false, the testsuite will use already deployed authorino for testing
+#    url: ""                                     # URL for already deployed Authorino

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -7,3 +7,5 @@ default:
     test_user:
       username: "testUser"
       password: "testPassword"
+  authorino:
+    deploy: true

--- a/testsuite/config.py
+++ b/testsuite/config.py
@@ -1,5 +1,5 @@
 """Testsuite configuration"""
-from dynaconf import Dynaconf
+from dynaconf import Dynaconf, Validator
 
 settings = Dynaconf(
     environments=True,
@@ -8,4 +8,7 @@ settings = Dynaconf(
     settings_files=["config/settings.yaml", "config/secrets.yaml"],
     envvar_prefix="KUADRANT",
     merge_enabled=True,
+    validators=[
+        Validator("authorino.deploy", eq=True) | Validator("authorino.url", must_exist=True)
+    ]
 )

--- a/testsuite/objects/__init__.py
+++ b/testsuite/objects/__init__.py
@@ -35,3 +35,24 @@ class Authorization(LifecycleObject):
     @abc.abstractmethod
     def add_oidc_identity(self, name, endpoint):
         """Adds OIDC identity provider"""
+
+
+class PreexistingAuthorino(Authorino):
+    """Authorino which is already deployed prior to the testrun"""
+
+    def __init__(self, authorization_url) -> None:
+        super().__init__()
+        self._authorization_url = authorization_url
+
+    def wait_for_ready(self):
+        return True
+
+    @property
+    def authorization_url(self):
+        return self._authorization_url
+
+    def commit(self):
+        return
+
+    def delete(self):
+        return

--- a/testsuite/tests/kuadrant/authorino/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/conftest.py
@@ -2,15 +2,18 @@
 import pytest
 
 from testsuite.openshift.objects.auth_config import AuthConfig
-from testsuite.objects import Authorino, Authorization
+from testsuite.objects import Authorino, Authorization, PreexistingAuthorino
 from testsuite.openshift.objects.authorino import AuthorinoCR
 
 
 @pytest.fixture(scope="session")
-def authorino(authorino, openshift, blame, request) -> Authorino:
+def authorino(authorino, openshift, blame, request, testconfig) -> Authorino:
     """Authorino instance"""
     if authorino:
         return authorino
+
+    if not testconfig["authorino"]["deploy"]:
+        return PreexistingAuthorino(testconfig["authorino"]["url"])
 
     authorino = AuthorinoCR.create_instance(openshift, blame("authorino"))
     request.addfinalizer(lambda: authorino.delete(ignore_not_found=True))

--- a/testsuite/tests/kuadrant/authorino/operator/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/conftest.py
@@ -5,8 +5,11 @@ from testsuite.openshift.objects.authorino import AuthorinoCR
 
 
 @pytest.fixture(scope="session")
-def authorino(openshift, blame, request) -> AuthorinoCR:
+def authorino(openshift, blame, request, testconfig) -> AuthorinoCR:
     """Custom deployed Authorino instance"""
+    if not testconfig["authorino"]["deploy"]:
+        return pytest.skip("Operator tests don't work with already deployed Authorino")
+
     authorino = AuthorinoCR.create_instance(openshift, blame("authorino"))
     request.addfinalizer(lambda: authorino.delete(ignore_not_found=True))
     authorino.commit()


### PR DESCRIPTION
* The operator test will be skipped if that's the case.
* You can set it up by settings `authorino.deploy` to false
   * You also need to specify the authorization URL for it through `authorino.url`
   * Details can be found in `settings.local.yamp.tpl`
 