### PR TITLE
Separate Httpbin and Envoy

### DIFF
--- a/testsuite/tests/kuadrant/authorino/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/conftest.py
@@ -27,19 +27,19 @@ def authorino(authorino, openshift, blame, request, testconfig) -> Authorino:
 
 # pylint: disable=unused-argument
 @pytest.fixture(scope="module")
-def authorization(authorization, authorino, backend, blame, openshift) -> Authorization:
+def authorization(authorization, authorino, envoy, blame, openshift) -> Authorization:
     """In case of Authorino, AuthConfig used for authorization"""
     if authorization:
         return authorization
 
-    return AuthConfig.create_instance(openshift, blame("ac"), backend.hostname)
+    return AuthConfig.create_instance(openshift, blame("ac"), envoy.hostname)
 
 
 @pytest.fixture(scope="module")
-def client(authorization, backend):
+def client(authorization, envoy):
     """Returns httpx client to be used for requests, it also commit AuthConfig"""
     authorization.commit()
-    client = backend.client
+    client = envoy.client
     yield client
     client.close()
     authorization.delete()

--- a/testsuite/tests/kuadrant/conftest.py
+++ b/testsuite/tests/kuadrant/conftest.py
@@ -11,6 +11,6 @@ def authorino():
 
 # pylint: disable=unused-argument
 @pytest.fixture(scope="module")
-def authorization(authorino, backend, blame, openshift):
+def authorization(authorino, envoy, blame, openshift):
     """Authorization object (In case of Kuadrant AuthPolicy)"""
     return None


### PR DESCRIPTION
Httpbin is now session scope, while envoy is module scoped.

Closes #3 

Breaks #18 and #19 but I will rebase the PRs base on which gets approved first