### PR TITLE
Use Label selectors

### DIFF
--- a/testsuite/openshift/objects/auth_config.py
+++ b/testsuite/openshift/objects/auth_config.py
@@ -1,4 +1,6 @@
 """AuthConfig CR object"""
+from typing import Dict
+
 from openshift import APIObject
 
 from testsuite.objects import Authorization
@@ -9,9 +11,9 @@ class AuthConfig(APIObject, Authorization):
     """Represents AuthConfig CR from Authorino"""
 
     @classmethod
-    def create_instance(cls, openshift: OpenShiftClient, name, host):
+    def create_instance(cls, openshift: OpenShiftClient, name, host, labels: Dict[str, str] = None):
         """Creates base instance"""
-        model = {
+        model: Dict = {
             "apiVersion": "authorino.kuadrant.io/v1beta1",
             "kind": "AuthConfig",
             "metadata": {
@@ -22,6 +24,9 @@ class AuthConfig(APIObject, Authorization):
                 "hosts": [host]
             }
         }
+
+        if labels is not None:
+            model["metadata"]["labels"] = labels
 
         return cls(model, context=openshift.context)
 

--- a/testsuite/openshift/objects/authorino.py
+++ b/testsuite/openshift/objects/authorino.py
@@ -1,5 +1,5 @@
 """Authorino CR object"""
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import openshift
 from openshift import APIObject, selector
@@ -12,7 +12,8 @@ class AuthorinoCR(APIObject, Authorino):
     """Represents Authorino CR objects from Authorino-operator"""
 
     @classmethod
-    def create_instance(cls, openshift: OpenShiftClient, name, image=None, cluster_wide=False):
+    def create_instance(cls, openshift: OpenShiftClient, name, image=None,
+                        cluster_wide=False, label_selectors: List[str] = None):
         """Creates base instance"""
         model: Dict[str, Any] = {
             "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
@@ -37,6 +38,9 @@ class AuthorinoCR(APIObject, Authorino):
         }
         if image:
             model["spec"]["image"] = image
+
+        if label_selectors:
+            model["spec"]["authConfigLabelSelectors"] = ",".join(label_selectors)
 
         with openshift.context:
             return cls(model)

--- a/testsuite/tests/kuadrant/authorino/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/conftest.py
@@ -8,7 +8,7 @@ from testsuite.openshift.objects.authorino import AuthorinoCR
 
 
 @pytest.fixture(scope="session")
-def authorino(authorino, openshift, blame, request, testconfig) -> Authorino:
+def authorino(authorino, openshift, blame, request, testconfig, label) -> Authorino:
     """Authorino instance"""
     if authorino:
         return authorino
@@ -18,7 +18,8 @@ def authorino(authorino, openshift, blame, request, testconfig) -> Authorino:
 
     authorino = AuthorinoCR.create_instance(openshift,
                                             blame("authorino"),
-                                            image=weakget(testconfig)["authorino"]["image"] % None)
+                                            image=weakget(testconfig)["authorino"]["image"] % None,
+                                            label_selectors=[f"testRun={label}"])
     request.addfinalizer(lambda: authorino.delete(ignore_not_found=True))
     authorino.commit()
     authorino.wait_for_ready()
@@ -27,12 +28,12 @@ def authorino(authorino, openshift, blame, request, testconfig) -> Authorino:
 
 # pylint: disable=unused-argument
 @pytest.fixture(scope="module")
-def authorization(authorization, authorino, envoy, blame, openshift) -> Authorization:
+def authorization(authorization, authorino, envoy, blame, openshift, label) -> Authorization:
     """In case of Authorino, AuthConfig used for authorization"""
     if authorization:
         return authorization
 
-    return AuthConfig.create_instance(openshift, blame("ac"), envoy.hostname)
+    return AuthConfig.create_instance(openshift, blame("ac"), envoy.hostname, labels={"testRun": label})
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This should ensure that Authorino reconciles only its own AuthConfigs.

Depends on #21 