### PR TITLE
Add modify decorator

### DIFF
--- a/testsuite/openshift/objects/__init__.py
+++ b/testsuite/openshift/objects/__init__.py
@@ -1,0 +1,43 @@
+"""Base classes/methods for our own APIObjects"""
+import functools
+
+from openshift import APIObject
+
+
+def modify(func):
+    """Wraps method of a subclass of OpenShiftObject to use modify_and_apply when the object
+     is already committed to the server, or run it normally if it isn't.
+     All methods modifying the target object in any way should be decorated by this"""
+    def _custom_partial(func, *args, **kwargs):
+        """Custom partial function which makes sure that self is always assigned correctly"""
+
+        def _func(self):
+            func(self, *args, **kwargs)
+
+        return _func
+
+    @functools.wraps(func)
+    def _wrap(self, *args, **kwargs):
+        if self.commited:
+            result, _ = self.modify_and_apply(_custom_partial(func, *args, **kwargs))
+            assert result.status
+        else:
+            func(self, *args, **kwargs)
+
+    return _wrap
+
+
+class OpenShiftObject(APIObject):
+    """Custom APIObjects which tracks if the object was already committed to the server or not"""
+    def __init__(self, dict_to_model=None, string_to_model=None, context=None):
+        super().__init__(dict_to_model, string_to_model, context)
+        self.commited = False
+
+    def commit(self):
+        """
+        Creates object on the server and returns created entity.
+        It will be the same class but attributes might differ, due to server adding/rejecting some of them.
+        """
+        self.create(["--save-config=true"])
+        self.commited = True
+        return self.refresh()

--- a/testsuite/openshift/objects/api_key.py
+++ b/testsuite/openshift/objects/api_key.py
@@ -1,11 +1,10 @@
 """API Key Secret CR object"""
 
-from openshift import APIObject
-
 from testsuite.openshift.client import OpenShiftClient
+from testsuite.openshift.objects import OpenShiftObject
 
 
-class APIKey(APIObject):
+class APIKey(OpenShiftObject):
     """Represents API Key Secret CR for Authorino"""
 
     @classmethod
@@ -29,11 +28,3 @@ class APIKey(APIObject):
         }
 
         return cls(model, context=openshift.context)
-
-    def commit(self):
-        """
-        Creates object on the server and returns created entity.
-        It will be the same class but attributes might differ, due to server adding/rejecting some of them.
-        """
-        self.create(["--save-config=true"])
-        return self.refresh()

--- a/testsuite/openshift/objects/auth_config.py
+++ b/testsuite/openshift/objects/auth_config.py
@@ -1,13 +1,12 @@
 """AuthConfig CR object"""
 from typing import Dict
 
-from openshift import APIObject
-
 from testsuite.objects import Authorization
 from testsuite.openshift.client import OpenShiftClient
+from testsuite.openshift.objects import OpenShiftObject, modify
 
 
-class AuthConfig(APIObject, Authorization):
+class AuthConfig(OpenShiftObject, Authorization):
     """Represents AuthConfig CR from Authorino"""
 
     @classmethod
@@ -30,23 +29,19 @@ class AuthConfig(APIObject, Authorization):
 
         return cls(model, context=openshift.context)
 
-    def commit(self):
-        """
-        Creates object on the server and returns created entity.
-        It will be the same class but attributes might differ, due to server adding/rejecting some of them.
-        """
-        self.create(["--save-config=true"])
-        return self.refresh()
-
+    @modify
     def add_host(self, hostname):
         self.model.spec.hosts.append(hostname)
 
+    @modify
     def remove_host(self, hostname):
         self.model.spec.hosts.remove(hostname)
 
+    @modify
     def remove_all_hosts(self):
         self.model.spec.hosts = []
 
+    @modify
     def add_oidc_identity(self, name, endpoint):
         """Adds OIDC identity"""
         identities = self.model.spec.setdefault("identity", [])
@@ -57,6 +52,7 @@ class AuthConfig(APIObject, Authorization):
             }
         })
 
+    @modify
     def add_api_key_identity(self, name, label):
         """Adds API Key identity"""
         identities = self.model.spec.setdefault("identity", [])

--- a/testsuite/openshift/objects/authorino.py
+++ b/testsuite/openshift/objects/authorino.py
@@ -2,13 +2,14 @@
 from typing import Any, Dict, List
 
 import openshift
-from openshift import APIObject, selector
+from openshift import selector
 
 from testsuite.objects import Authorino
 from testsuite.openshift.client import OpenShiftClient
+from testsuite.openshift.objects import OpenShiftObject
 
 
-class AuthorinoCR(APIObject, Authorino):
+class AuthorinoCR(OpenShiftObject, Authorino):
     """Represents Authorino CR objects from Authorino-operator"""
 
     @classmethod
@@ -54,14 +55,6 @@ class AuthorinoCR(APIObject, Authorino):
             )
             assert success, "Authorino did got get ready in time"
             self.refresh()
-
-    def commit(self):
-        """
-        Creates object on the server and returns created entity.
-        It will be the same class but attributes might differ, due to server adding/rejecting some of them.
-        """
-        self.create(["--save-config=true"])
-        return self.refresh()
 
     @property
     def deployment(self):


### PR DESCRIPTION
- Add `@modify` decorator, which ensures the same methods can be used even if the object is already committed to the server.
  - Currently, the methods would modify the inner state of the object but wouldn't be propagated to the server. This enables them to modify their inner state before commitment and apply it even when it is already committed.  
- Create parent class for all our APIObjects