### PR TITLE
Add module_label

### DIFF
--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -109,6 +109,12 @@ def label(blame):
     return blame("testrun")
 
 
+@pytest.fixture(scope="module")
+def module_label(label):
+    """Module scope label for all resources"""
+    return randomize(label)
+
+
 @pytest.fixture(scope="session")
 def backend(request, openshift, blame, label):
     """Deploys Httpbin backend"""
@@ -119,9 +125,9 @@ def backend(request, openshift, blame, label):
 
 
 @pytest.fixture(scope="module")
-def envoy(request, authorino, openshift, blame, backend, label):
+def envoy(request, authorino, openshift, blame, backend, module_label):
     """Deploys Envoy that wire up the Backend behind the reverse-proxy and Authorino instance"""
-    envoy = Envoy(openshift, authorino, blame("envoy"), label, backend.url)
+    envoy = Envoy(openshift, authorino, blame("envoy"), module_label, backend.url)
     request.addfinalizer(envoy.delete)
     envoy.commit()
     return envoy

--- a/testsuite/tests/kuadrant/authorino/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/conftest.py
@@ -9,7 +9,7 @@ from testsuite.openshift.objects.authorino import AuthorinoCR
 
 
 @pytest.fixture(scope="module")
-def authorino(authorino, openshift, blame, request, testconfig, label) -> Authorino:
+def authorino(authorino, openshift, blame, request, testconfig, module_label) -> Authorino:
     """Authorino instance"""
     if authorino:
         return authorino
@@ -20,7 +20,7 @@ def authorino(authorino, openshift, blame, request, testconfig, label) -> Author
     authorino = AuthorinoCR.create_instance(openshift,
                                             blame("authorino"),
                                             image=weakget(testconfig)["authorino"]["image"] % None,
-                                            label_selectors=[f"testRun={label}"])
+                                            label_selectors=[f"testRun={module_label}"])
     request.addfinalizer(lambda: authorino.delete(ignore_not_found=True))
     authorino.commit()
     authorino.wait_for_ready()
@@ -29,10 +29,11 @@ def authorino(authorino, openshift, blame, request, testconfig, label) -> Author
 
 # pylint: disable=unused-argument
 @pytest.fixture(scope="module")
-def authorization(authorization, authorino, envoy, blame, openshift, label, rhsso_service_info) -> Authorization:
+def authorization(authorization, authorino, envoy, blame, openshift, module_label, rhsso_service_info) -> Authorization:
     """In case of Authorino, AuthConfig used for authorization"""
     if authorization is None:
-        authorization = AuthConfig.create_instance(openshift, blame("ac"), envoy.hostname, labels={"testRun": label})
+        authorization = AuthConfig.create_instance(openshift, blame("ac"),
+                                                   envoy.hostname, labels={"testRun": module_label})
     authorization.add_oidc_identity("rhsso", rhsso_service_info.issuer_url())
     return authorization
 

--- a/testsuite/tests/kuadrant/authorino/operator/clusterwide/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/clusterwide/conftest.py
@@ -17,9 +17,9 @@ def hostname2(envoy, blame):
 
 
 @pytest.fixture(scope="module")
-def authorization2(hostname2, blame, openshift2, label, rhsso_service_info):
+def authorization2(hostname2, blame, openshift2, module_label, rhsso_service_info):
     """Second valid hostname"""
-    auth = AuthConfig.create_instance(openshift2, blame("ac"), hostname2, labels={"testRun": label})
+    auth = AuthConfig.create_instance(openshift2, blame("ac"), hostname2, labels={"testRun": module_label})
     auth.add_oidc_identity("rhsso", rhsso_service_info.issuer_url())
     return auth
 

--- a/testsuite/tests/kuadrant/authorino/operator/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/conftest.py
@@ -18,12 +18,12 @@ def cluster_wide():
 
 
 @pytest.fixture(scope="module")
-def authorino(openshift, blame, request, testconfig, cluster_wide, label, authorino_parameters) -> AuthorinoCR:
+def authorino(openshift, blame, request, testconfig, cluster_wide, module_label, authorino_parameters) -> AuthorinoCR:
     """Custom deployed Authorino instance"""
     if not testconfig["authorino"]["deploy"]:
         return pytest.skip("Operator tests don't work with already deployed Authorino")
 
-    parameters = {"label_selectors": [f"testRun={label}"],
+    parameters = {"label_selectors": [f"testRun={module_label}"],
                   **authorino_parameters}
     authorino = AuthorinoCR.create_instance(openshift,
                                             blame("authorino"),


### PR DESCRIPTION
Previously we had only one label, which lasted the entire test run, meaning different modules could share resources. This eliminates it.