### PR TITLE
Change how are OpenShifts processed in the settings

### DIFF
--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -1,8 +1,11 @@
 #default:
 #  skip_cleanup: false
 #  openshift:
-#    project: "authorino"
-#    second_project: "authorino2"
+#    project: "kuadrant"                       # Optional: namespace for tests to run, if None uses current project
+#    api_url: "https://api.openshift.com"      # Optional: OpenShift API URL, if None it will OpenShift that you are logged in
+#    token: "KUADRANT_RULEZ"                   # Optional: OpenShift Token, if None it will OpenShift that you are logged in
+#  openshift2:
+#    project: "kuadrant2"                      # Required: Secondary OpenShift project, for running tests across projects
 #  rhsso:
 #    url: "SSO_URL"
 #    username: "SSO_ADMIN_USERNAME"

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,10 +1,9 @@
 default:
   skip_cleanup: false
   dynaconf_merge: true
-  openshift:
-    project: "authorino"
   cfssl: "cfssl"
   rhsso:
+    username: "admin"
     test_user:
       username: "testUser"
       password: "testPassword"

--- a/testsuite/config/__init__.py
+++ b/testsuite/config/__init__.py
@@ -1,4 +1,4 @@
-"""Testsuite configuration"""
+"""Module which initializes Dynaconf"""
 from dynaconf import Dynaconf, Validator
 
 settings = Dynaconf(
@@ -9,6 +9,7 @@ settings = Dynaconf(
     envvar_prefix="KUADRANT",
     merge_enabled=True,
     validators=[
-        Validator("authorino.deploy", eq=True) | Validator("authorino.url", must_exist=True)
-    ]
+        Validator("authorino.deploy", eq=True) | Validator("authorino.url", must_exist=True),
+    ],
+    loaders=["testsuite.config.openshift_loader", "dynaconf.loaders.env_loader"]
 )

--- a/testsuite/config/openshift_loader.py
+++ b/testsuite/config/openshift_loader.py
@@ -1,0 +1,21 @@
+"""Custom dynaconf loader for loading OpenShift settings and converting them to OpenshiftClients"""
+from weakget import weakget
+
+from testsuite.openshift.client import OpenShiftClient
+
+
+# pylint: disable=unused-argument
+def load(obj, env=None, silent=True, key=None, filename=None):
+    """Creates all OpenShift clients"""
+    config = weakget(obj)
+    section = config["openshift"]
+    client = OpenShiftClient(
+        section["project"] % None,
+        section["api_url"] % None,
+        section["token"] % None)
+    obj["openshift"] = client
+
+    openshift2 = None
+    if "openshift2" in obj and "project" in obj["openshift2"]:
+        openshift2 = client.change_project(obj["openshift2"]["project"])
+    obj["openshift2"] = openshift2

--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -33,6 +33,10 @@ class OpenShiftClient:
         self._api_url = api_url
         self.token = token
 
+    def change_project(self, project):
+        """Return new OpenShiftClient with a different project"""
+        return OpenShiftClient(project, self._api_url, self.token)
+
     @cached_property
     def context(self):
         """Prepare context for command execution"""

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -1,10 +1,8 @@
 """Root conftest"""
 import pytest
 from keycloak import KeycloakAuthenticationError
-from weakget import weakget
 
 from testsuite.config import settings
-from testsuite.openshift.client import OpenShiftClient
 from testsuite.openshift.httpbin import Httpbin, Envoy
 from testsuite.rhsso import RHSSO, Realm, RHSSOServiceConfiguration
 from testsuite.utils import randomize, _whoami
@@ -19,23 +17,18 @@ def testconfig():
 @pytest.fixture(scope="session")
 def openshift(testconfig):
     """OpenShift client for the primary namespace"""
-    section = weakget(testconfig)["openshift"]
-    client = OpenShiftClient(
-        section["project"] % None,
-        section["api_url"] % None,
-        section["token"] % None)
+    client = testconfig["openshift"]
     if not client.connected:
         pytest.fail("You are not logged into Openshift or the namespace doesn't exist")
     return client
 
 
 @pytest.fixture(scope="session")
-def openshift2(openshift, testconfig):
+def openshift2(testconfig):
     """OpenShift client for the secondary namespace located on the same cluster as primary Openshift"""
-    if "second_project" not in testconfig.get("openshift", {}):
+    client = testconfig["openshift2"]
+    if client is None:
         pytest.skip("Openshift2 required but second_project was not set")
-    # pylint: disable=protected-access
-    client = OpenShiftClient(testconfig["openshift"]["second_project"], openshift._api_url, openshift.token)
     if not client.connected:
         pytest.fail("You are not logged into Openshift or the namespace for Openshift2 doesn't exist")
     return client


### PR DESCRIPTION
Change how the OpenShift is loaded in testsuite, now all the processing (e.g. converting it to OpenShiftClient) occurs in the new dynaconf loader and the respective sections in the testconfig are already processed OpenShiftClients.

### Breaking change
Config structure regarding the second OpenShift project was changed.