### PR TITLE
Add cluster-wide API key identity tests

### DIFF
--- a/testsuite/objects/__init__.py
+++ b/testsuite/objects/__init__.py
@@ -37,7 +37,7 @@ class Authorization(LifecycleObject):
         """Adds OIDC identity provider"""
 
     @abc.abstractmethod
-    def add_api_key_identity(self, name, match_label, match_expression):
+    def add_api_key_identity(self, name, all_namespaces, match_label, match_expression):
         """Adds API Key identity"""
 
     @abc.abstractmethod

--- a/testsuite/openshift/objects/auth_config.py
+++ b/testsuite/openshift/objects/auth_config.py
@@ -66,11 +66,13 @@ class AuthConfig(OpenShiftObject, Authorization):
         })
 
     @modify
-    def add_api_key_identity(self, name, match_label=None, match_expression: MatchExpression = None):
+    def add_api_key_identity(self, name, all_namespaces: bool = False,
+                             match_label=None, match_expression: MatchExpression = None):
         """
         Adds API Key identity
         Args:
             :param name: the name of API key identity
+            :param all_namespaces: a location of the API keys can be in another namespace (only works for cluster-wide)
             :param match_label: labels that are accepted by AuthConfig
             :param match_expression: instance of the MatchExpression
         """
@@ -94,7 +96,8 @@ class AuthConfig(OpenShiftObject, Authorization):
         identities.append({
             "name": name,
             "apiKey": {
-                "selector": matcher
+                "selector": matcher,
+                "allNamespaces": all_namespaces
             },
             "credentials": {
                 "in": "authorization_header",

--- a/testsuite/tests/kuadrant/authorino/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/conftest.py
@@ -3,6 +3,7 @@ import pytest
 from weakget import weakget
 
 from testsuite.httpx.auth import HttpxOidcClientAuth
+from testsuite.openshift.client import OpenShiftClient
 from testsuite.openshift.objects.api_key import APIKey
 from testsuite.openshift.objects.auth_config import AuthConfig
 from testsuite.objects import Authorino, Authorization, PreexistingAuthorino
@@ -57,9 +58,9 @@ def client(authorization, envoy):
 @pytest.fixture(scope="module")
 def create_api_key(blame, request, openshift):
     """Creates API key Secret"""
-    def _create_secret(name, label_selector, api_key):
+    def _create_secret(name, label_selector, api_key, ocp: OpenShiftClient = openshift):
         secret_name = blame(name)
-        secret = APIKey.create_instance(openshift, secret_name, label_selector, api_key)
+        secret = APIKey.create_instance(ocp, secret_name, label_selector, api_key)
         request.addfinalizer(secret.delete)
         secret.commit()
         return secret_name

--- a/testsuite/tests/kuadrant/authorino/identity/api_key/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/identity/api_key/conftest.py
@@ -5,12 +5,6 @@ from testsuite.httpx.auth import HeaderApiKeyAuth
 
 
 @pytest.fixture(scope="module")
-def invalid_label_selector():
-    """Label for API key secret that is different from the one specified in AuthConfig"""
-    return "invalid_api_label"
-
-
-@pytest.fixture(scope="module")
 def api_key(create_api_key, module_label):
     """Creates API key Secret"""
     api_key = "api_key_value"
@@ -22,6 +16,12 @@ def api_key(create_api_key, module_label):
 def auth(api_key):
     """Valid API Key Auth"""
     return HeaderApiKeyAuth(api_key)
+
+
+@pytest.fixture(scope="module")
+def invalid_label_selector():
+    """Label for API key secret that is different from the one specified in AuthConfig"""
+    return "invalid_api_label"
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/kuadrant/authorino/operator/clusterwide/test_all_namespace_api_key.py
+++ b/testsuite/tests/kuadrant/authorino/operator/clusterwide/test_all_namespace_api_key.py
@@ -1,0 +1,60 @@
+"""
+Tests for API key identity for AuthConfig configured with all_namespaces=true for cluster-wide
+API key secret placement.
+"""
+import pytest
+
+from testsuite.httpx.auth import HeaderApiKeyAuth
+
+
+@pytest.fixture(scope="module")
+def api_key(create_api_key, module_label, openshift2):
+    """Creates API key Secret"""
+    api_key = "cluster_wide_api_key"
+    create_api_key("wide-api-key", module_label, api_key, openshift2)
+    return api_key
+
+
+@pytest.fixture(scope="module")
+def auth(api_key):
+    """Valid API Key Auth"""
+    return HeaderApiKeyAuth(api_key)
+
+
+@pytest.fixture(scope="module")
+def invalid_label_selector():
+    """Label for API key secret that is different from the one specified in AuthConfig"""
+    return "invalid_api_label"
+
+
+@pytest.fixture(scope="module")
+def invalid_api_key(create_api_key, invalid_label_selector, openshift2):
+    """Creates API key Secret with label that does not match any of the labelSelectors defined by AuthConfig"""
+    api_key = "invalid_api_key"
+    create_api_key("invalid-api-key", invalid_label_selector, api_key, openshift2)
+    return api_key
+
+
+@pytest.fixture(scope="module")
+def invalid_auth(invalid_api_key):
+    """Invalid key Auth"""
+    return HeaderApiKeyAuth(invalid_api_key)
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization, module_label):
+    """Creates AuthConfig with API key identity"""
+    authorization.add_api_key_identity("api_key", all_namespaces=True, match_label=module_label)
+    return authorization
+
+
+def test_correct_auth(client, auth):
+    """Tests request with correct API key"""
+    response = client.get("/get", auth=auth)
+    assert response.status_code == 200
+
+
+def test_invalid_api_key(client, invalid_auth):
+    """Tests request with wrong API key"""
+    response = client.get("/get", auth=invalid_auth)
+    assert response.status_code == 401


### PR DESCRIPTION
These tests contain duplicate code from API key identity match label tests. Once the enhancement described in https://github.com/Kuadrant/testsuite/issues/62 is solved, this duplication can be easily removed and this test will be part of identity/api_key/test_match_labels.py