### PR TITLE
Created API key variable for API key openshift object

### DIFF
--- a/testsuite/httpx/auth.py
+++ b/testsuite/httpx/auth.py
@@ -4,6 +4,7 @@ from typing import Generator
 
 from httpx import Auth, Request, URL, Response
 
+from testsuite.openshift.objects.api_key import APIKey
 from testsuite.rhsso import Client
 
 
@@ -39,9 +40,9 @@ class HttpxOidcClientAuth(Auth):
 class HeaderApiKeyAuth(Auth):
     """Auth class for authentication with API key"""
 
-    def __init__(self, api_key: str, prefix: str = "APIKEY") -> None:
+    def __init__(self, api_key: APIKey, prefix: str = "APIKEY") -> None:
         super().__init__()
-        self.api_key = api_key
+        self.api_key = str(api_key)
         self.prefix = prefix
 
     def auth_flow(self, request: Request) -> typing.Generator[Request, Response, None]:

--- a/testsuite/openshift/objects/api_key.py
+++ b/testsuite/openshift/objects/api_key.py
@@ -1,4 +1,5 @@
 """API Key Secret CR object"""
+import base64
 
 from testsuite.openshift.client import OpenShiftClient
 from testsuite.openshift.objects import OpenShiftObject
@@ -6,6 +7,9 @@ from testsuite.openshift.objects import OpenShiftObject
 
 class APIKey(OpenShiftObject):
     """Represents API Key Secret CR for Authorino"""
+
+    def __str__(self):
+        return base64.b64decode(self.model.data["api_key"]).decode("utf-8")
 
     @classmethod
     def create_instance(cls, openshift: OpenShiftClient, name, label, api_key):

--- a/testsuite/tests/kuadrant/authorino/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/conftest.py
@@ -61,7 +61,7 @@ def create_api_key(blame, request, openshift):
     def _create_secret(name, label_selector, api_key, ocp: OpenShiftClient = openshift):
         secret_name = blame(name)
         secret = APIKey.create_instance(ocp, secret_name, label_selector, api_key)
-        request.addfinalizer(secret.delete)
+        request.addfinalizer(lambda: secret.delete(ignore_not_found=True))
         secret.commit()
-        return secret_name
+        return secret
     return _create_secret

--- a/testsuite/tests/kuadrant/authorino/identity/api_key/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/identity/api_key/conftest.py
@@ -8,8 +8,7 @@ from testsuite.httpx.auth import HeaderApiKeyAuth
 def api_key(create_api_key, module_label):
     """Creates API key Secret"""
     api_key = "api_key_value"
-    create_api_key("api-key", module_label, api_key)
-    return api_key
+    return create_api_key("api-key", module_label, api_key)
 
 
 @pytest.fixture(scope="module")
@@ -28,11 +27,10 @@ def invalid_label_selector():
 def invalid_api_key(create_api_key, invalid_label_selector):
     """Creates API key Secret with label that does not match any of the labelSelectors defined by AuthConfig"""
     api_key = "invalid_api_key"
-    create_api_key("invalid-api-key", invalid_label_selector, api_key)
-    return api_key
+    return create_api_key("invalid-api-key", invalid_label_selector, api_key)
 
 
 @pytest.fixture(scope="module")
 def invalid_auth(invalid_api_key):
-    """Invalid key Auth"""
+    """Invalid API key Auth"""
     return HeaderApiKeyAuth(invalid_api_key)

--- a/testsuite/tests/kuadrant/authorino/identity/api_key/test_match_label.py
+++ b/testsuite/tests/kuadrant/authorino/identity/api_key/test_match_label.py
@@ -21,13 +21,13 @@ def test_no_auth(client):
     assert response.status_code == 401
 
 
-def test_invalid_api_key(client, invalid_auth):
-    """Tests request with wrong API key"""
-    response = client.get("/get", auth=invalid_auth)
+def test_invalid_api_key(client):
+    """Tests request with wrong invalid API key"""
+    response = client.get("/get", headers={"Authorization": "APIKEY invalid_api_key_string"})
     assert response.status_code == 401
 
 
-def test_invalid_api_key_secret(client, invalid_api_key):
+def test_invalid_api_key_secret(client, invalid_auth):
     """Tests request that uses API key secret that is wrongly labeled"""
-    response = client.get("/get", headers={"Authorization": f"APIKEY {invalid_api_key}"})
+    response = client.get("/get", auth=invalid_auth)
     assert response.status_code == 401


### PR DESCRIPTION
Added API key to our openshift object api_key.py that represents Secret in the OCP. 
The benefit is that it is now possible to get the API key directly from the API key secret object: `api_key_secret.api_key` 