### PR TITLE
Add note to Readme about Kubeconfig permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,5 @@ podman run \
 	-e KUADRANT_RHSSO__username="ADMIN_USERNAME" \
 	quay.io/kuadrant/testsuite:latest
 ```
+NOTE: For binding kubeconfig file, the "others" need to have permission to read, otherwise it will not work.
 The results and reports will be saved in `/test-run-results` in the container.


### PR DESCRIPTION
Kubeconfig needs o+r permission to work correctly while bound to the container.