### PR TITLE
Separate envoy into its separate module

### DIFF
--- a/testsuite/openshift/envoy.py
+++ b/testsuite/openshift/envoy.py
@@ -1,0 +1,89 @@
+"""Module containing all Envoy Classes"""
+from functools import cached_property
+from importlib import resources
+
+from testsuite.httpx import HttpxBackoffClient
+from testsuite.objects import LifecycleObject
+from testsuite.openshift.client import OpenShiftClient
+
+
+class Envoy(LifecycleObject):
+    """Envoy deployed from template"""
+    def __init__(self, openshift: OpenShiftClient, authorino, name, label, httpbin_hostname) -> None:
+        self.openshift = openshift
+        self.authorino = authorino
+        self.name = name
+        self.label = label
+        self.httpbin_hostname = httpbin_hostname
+
+        self.envoy_objects = None
+
+    @cached_property
+    def route(self):
+        """Returns route for object"""
+        with self.openshift.context:
+            return self.envoy_objects.narrow("route").object()
+
+    def create_route(self, name):
+        """Creates another route pointing to this Envoy"""
+        route = self.openshift.routes.expose(name, f"envoy-{self.name}")
+        with self.openshift.context:
+            self.envoy_objects = self.envoy_objects.union(route.self_selector())
+        return route
+
+    @cached_property
+    def hostname(self):
+        """Returns hostname of this envoy"""
+        return self.route.model.spec.host
+
+    def client(self, **kwargs):
+        """Return Httpx client for the requests to this backend"""
+        return HttpxBackoffClient(base_url=f"http://{self.hostname}", **kwargs)
+
+    def commit(self):
+        """Deploy all required objects into OpenShift"""
+        with resources.path("testsuite.resources", "envoy.yaml") as path:
+            self.envoy_objects = self.openshift.new_app(path, {
+                "NAME": f"envoy-{self.name}",
+                "LABEL": self.label,
+                "AUTHORINO_URL": self.authorino.authorization_url,
+                "UPSTREAM_URL": self.httpbin_hostname
+            })
+        with self.openshift.context:
+            assert self.openshift.is_ready(self.envoy_objects.narrow("deployment")), "Envoy wasn't ready in time"
+
+    def delete(self):
+        """Destroy all objects this instance created"""
+        with self.openshift.context:
+            if self.envoy_objects:
+                self.envoy_objects.delete()
+        self.envoy_objects = None
+
+
+class TLSEnvoy(Envoy):
+    """Envoy with TLS enabled and all required certificates set up, requires using a client certificate"""
+    def __init__(self, openshift, authorino, name, label, httpbin_hostname,
+                 authorino_ca_secret, envoy_ca_secret, envoy_cert_secret) -> None:
+        super().__init__(openshift, authorino, name, label, httpbin_hostname)
+        self.authorino_ca_secret = authorino_ca_secret
+        self.backend_ca_secret = envoy_ca_secret
+        self.envoy_cert_secret = envoy_cert_secret
+
+    def client(self, **kwargs):
+        """Return Httpx client for the requests to this backend"""
+        return HttpxBackoffClient(base_url=f"https://{self.hostname}", **kwargs)
+
+    def commit(self):
+        with resources.path("testsuite.resources.tls", "envoy.yaml") as path:
+            self.envoy_objects = self.openshift.new_app(path, {
+                "NAME": f"envoy-{self.name}",
+                "LABEL": self.label,
+                "AUTHORINO_URL": self.authorino.authorization_url,
+                "UPSTREAM_URL": self.httpbin_hostname,
+                "AUTHORINO_CA_SECRET": self.authorino_ca_secret,
+                "ENVOY_CA_SECRET": self.backend_ca_secret,
+                "ENVOY_CERT_SECRET": self.envoy_cert_secret,
+            })
+
+        with self.openshift.context:
+            assert self.openshift.is_ready(self.envoy_objects.narrow("deployment")), "Envoy wasn't ready in time"

--- a/testsuite/openshift/envoy.py
+++ b/testsuite/openshift/envoy.py
@@ -22,7 +22,10 @@ class Envoy(LifecycleObject):
     def route(self):
         """Returns route for object"""
         with self.openshift.context:
-            return self.envoy_objects.narrow("route").object()
+            return self.envoy_objects\
+                .narrow("route")\
+                .narrow(lambda route: route.model.metadata.name == self.name)\
+                .object()
 
     def create_route(self, name):
         """Creates another route pointing to this Envoy"""

--- a/testsuite/openshift/envoy.py
+++ b/testsuite/openshift/envoy.py
@@ -26,7 +26,7 @@ class Envoy(LifecycleObject):
 
     def create_route(self, name):
         """Creates another route pointing to this Envoy"""
-        route = self.openshift.routes.expose(name, f"envoy-{self.name}")
+        route = self.openshift.routes.expose(name, self.name)
         with self.openshift.context:
             self.envoy_objects = self.envoy_objects.union(route.self_selector())
         return route
@@ -44,7 +44,7 @@ class Envoy(LifecycleObject):
         """Deploy all required objects into OpenShift"""
         with resources.path("testsuite.resources", "envoy.yaml") as path:
             self.envoy_objects = self.openshift.new_app(path, {
-                "NAME": f"envoy-{self.name}",
+                "NAME": self.name,
                 "LABEL": self.label,
                 "AUTHORINO_URL": self.authorino.authorization_url,
                 "UPSTREAM_URL": self.httpbin_hostname
@@ -76,7 +76,7 @@ class TLSEnvoy(Envoy):
     def commit(self):
         with resources.path("testsuite.resources.tls", "envoy.yaml") as path:
             self.envoy_objects = self.openshift.new_app(path, {
-                "NAME": f"envoy-{self.name}",
+                "NAME": self.name,
                 "LABEL": self.label,
                 "AUTHORINO_URL": self.authorino.authorization_url,
                 "UPSTREAM_URL": self.httpbin_hostname,

--- a/testsuite/openshift/httpbin.py
+++ b/testsuite/openshift/httpbin.py
@@ -1,64 +1,8 @@
-"""Httpbin backend combined with Envoy proxy"""
-from functools import cached_property
+"""Module for Httpbin backend classes"""
 from importlib import resources
 
-from testsuite.httpx import HttpxBackoffClient
 from testsuite.objects import LifecycleObject
 from testsuite.openshift.client import OpenShiftClient
-
-
-class Envoy(LifecycleObject):
-    """Envoy deployed from template"""
-    def __init__(self, openshift: "OpenShiftClient", authorino, name, label, httpbin_hostname) -> None:
-        self.openshift = openshift
-        self.authorino = authorino
-        self.name = name
-        self.label = label
-        self.httpbin_hostname = httpbin_hostname
-
-        self.envoy_objects = None
-
-    @cached_property
-    def route(self):
-        """Returns route for object"""
-        with self.openshift.context:
-            return self.envoy_objects.narrow("route").object()
-
-    def create_route(self, name):
-        """Creates another route pointing to this Envoy"""
-        service_name = f"envoy-{self.name}"
-        route = self.openshift.routes.expose(name, service_name)
-        with self.openshift.context:
-            self.envoy_objects = self.envoy_objects.union(route.self_selector())
-        return route
-
-    @cached_property
-    def hostname(self):
-        """Returns hostname of this envoy"""
-        return self.route.model.spec.host
-
-    def client(self, **kwargs):
-        """Return Httpx client for the requests to this backend"""
-        return HttpxBackoffClient(base_url=f"http://{self.hostname}", **kwargs)
-
-    def commit(self):
-        """Deploy all required objects into OpenShift"""
-        with resources.path("testsuite.resources", "envoy.yaml") as path:
-            self.envoy_objects = self.openshift.new_app(path, {
-                "NAME": f"envoy-{self.name}",
-                "LABEL": self.label,
-                "AUTHORINO_URL": self.authorino.authorization_url,
-                "UPSTREAM_URL": self.httpbin_hostname
-            })
-        with self.openshift.context:
-            assert self.openshift.is_ready(self.envoy_objects.narrow("deployment")), "Envoy wasn't ready in time"
-
-    def delete(self):
-        """Destroy all objects this instance created"""
-        with self.openshift.context:
-            if self.envoy_objects:
-                self.envoy_objects.delete()
-        self.envoy_objects = None
 
 
 class Httpbin(LifecycleObject):
@@ -88,32 +32,3 @@ class Httpbin(LifecycleObject):
             if self.httpbin_objects:
                 self.httpbin_objects.delete()
         self.httpbin_objects = None
-
-
-class TLSEnvoy(Envoy):
-    """Envoy with TLS enabled and all required certificates set up, requires using a client certificate"""
-    def __init__(self, openshift, authorino, name, label, httpbin_hostname,
-                 authorino_ca_secret, envoy_ca_secret, envoy_cert_secret) -> None:
-        super().__init__(openshift, authorino, name, label, httpbin_hostname)
-        self.authorino_ca_secret = authorino_ca_secret
-        self.backend_ca_secret = envoy_ca_secret
-        self.envoy_cert_secret = envoy_cert_secret
-
-    def client(self, **kwargs):
-        """Return Httpx client for the requests to this backend"""
-        return HttpxBackoffClient(base_url=f"https://{self.hostname}", **kwargs)
-
-    def commit(self):
-        with resources.path("testsuite.resources.tls", "envoy.yaml") as path:
-            self.envoy_objects = self.openshift.new_app(path, {
-                "NAME": f"envoy-{self.name}",
-                "LABEL": self.label,
-                "AUTHORINO_URL": self.authorino.authorization_url,
-                "UPSTREAM_URL": self.httpbin_hostname,
-                "AUTHORINO_CA_SECRET": self.authorino_ca_secret,
-                "ENVOY_CA_SECRET": self.backend_ca_secret,
-                "ENVOY_CERT_SECRET": self.envoy_cert_secret,
-            })
-
-        with self.openshift.context:
-            assert self.openshift.is_ready(self.envoy_objects.narrow("deployment")), "Envoy wasn't ready in time"

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -3,7 +3,8 @@ import pytest
 from keycloak import KeycloakAuthenticationError
 
 from testsuite.config import settings
-from testsuite.openshift.httpbin import Httpbin, Envoy
+from testsuite.openshift.httpbin import Httpbin
+from testsuite.openshift.envoy import Envoy
 from testsuite.rhsso import RHSSO, Realm, RHSSOServiceConfiguration
 from testsuite.utils import randomize, _whoami
 

--- a/testsuite/tests/kuadrant/authorino/operator/test_sharding.py
+++ b/testsuite/tests/kuadrant/authorino/operator/test_sharding.py
@@ -1,7 +1,7 @@
 """Test for authorino sharding"""
 import pytest
 
-from testsuite.openshift.httpbin import Envoy
+from testsuite.openshift.envoy import Envoy
 from testsuite.openshift.objects.auth_config import AuthConfig
 
 

--- a/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
@@ -3,7 +3,7 @@
 import pytest
 
 from testsuite.certificates import CFSSLClient, Certificate, CertInfo
-from testsuite.openshift.httpbin import TLSEnvoy
+from testsuite.openshift.envoy import TLSEnvoy
 from testsuite.utils import cert_builder
 
 


### PR DESCRIPTION
* All envoy classes are not in one envoy module, instead of httpbin one
* Change naming of envoy instances, previously there was envoy mentioned twice
* Fix route() property of envoy to accurately select route even if it was called after another route was requested