### PR TITLE
Add tools 

### DIFF
--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -6,6 +6,8 @@
 #    token: "KUADRANT_RULEZ"                   # Optional: OpenShift Token, if None it will OpenShift that you are logged in
 #  openshift2:
 #    project: "kuadrant2"                      # Required: Secondary OpenShift project, for running tests across projects
+#  tools:
+#    project: "tools"                          # Optional: OpenShift project, where external tools are located
 #  rhsso:
 #    url: "SSO_URL"
 #    username: "SSO_ADMIN_USERNAME"

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,6 +1,8 @@
 default:
   skip_cleanup: false
   dynaconf_merge: true
+  tools:
+    project: "tools"
   cfssl: "cfssl"
   rhsso:
     username: "admin"

--- a/testsuite/config/openshift_loader.py
+++ b/testsuite/config/openshift_loader.py
@@ -15,6 +15,11 @@ def load(obj, env=None, silent=True, key=None, filename=None):
         section["token"] % None)
     obj["openshift"] = client
 
+    tools = None
+    if "tools" in obj and "project" in obj["tools"]:
+        tools = client.change_project(obj["tools"]["project"])
+    obj["tools"] = tools
+
     openshift2 = None
     if "openshift2" in obj and "project" in obj["openshift2"]:
         openshift2 = client.change_project(obj["openshift2"]["project"])

--- a/testsuite/config/tools.py
+++ b/testsuite/config/tools.py
@@ -1,0 +1,33 @@
+"""Dynaconf loader for fetching data from tools namespace"""
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def fetch_route(name):
+    """Fetches the URL of a route with specific name"""
+    def _fetcher(settings, _):
+        try:
+            openshift = settings["tools"]
+            route = openshift.routes[name]
+            if "tls" in route.model.spec:
+                return "https://" + route.model.spec.host
+            return "http://" + route.model.spec.host
+        # pylint: disable=broad-except
+        except Exception:
+            logger.warning("Unable to fetch route %s from tools", name)
+            return None
+    return _fetcher
+
+
+def fetch_secret(name, key):
+    """Fetches the key out of a secret with specific name"""
+    def _fetcher(settings, _):
+        try:
+            openshift = settings["tools"]
+            return openshift.secrets[name][key]
+        # pylint: disable=broad-except
+        except Exception:
+            logger.warning("Unable to fetch secret %s[%s] from tools", name, key)
+            return None
+    return _fetcher


### PR DESCRIPTION
- Lazily loads required info from OpenShift
- For now only loads RHSSO details, if not present

This is an alternative to #71, does the same, from the user perspective works the same but is implemented differently using Validators instead of a loader.