### PR TITLE
Fix AuthConfig cleanup

### DIFF
--- a/testsuite/openshift/objects/__init__.py
+++ b/testsuite/openshift/objects/__init__.py
@@ -41,3 +41,7 @@ class OpenShiftObject(APIObject):
         self.create(["--save-config=true"])
         self.commited = True
         return self.refresh()
+
+    def delete(self, ignore_not_found=True, cmd_args=None):
+        """Deletes the resource, by default ignored not found"""
+        return super().delete(ignore_not_found, cmd_args)

--- a/testsuite/tests/kuadrant/authorino/operator/clusterwide/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/clusterwide/conftest.py
@@ -35,8 +35,7 @@ def client2(hostname2, envoy):
 
 # pylint: disable=unused-argument
 @pytest.fixture(scope="module", autouse=True)
-def commit(commit, authorization2):
+def commit(request, commit, authorization2):
     """Commits all important stuff before tests"""
+    request.addfinalizer(authorization2.delete)
     authorization2.commit()
-    yield
-    authorization2.delete()

--- a/testsuite/tests/kuadrant/conftest.py
+++ b/testsuite/tests/kuadrant/conftest.py
@@ -17,8 +17,7 @@ def authorization(authorino, envoy, blame, openshift):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def commit(authorization):
+def commit(request, authorization):
     """Commits all important stuff before tests"""
+    request.addfinalizer(authorization.delete)
     authorization.commit()
-    yield
-    authorization.delete()


### PR DESCRIPTION
- Should leave less trash when authorization.commit fails
- Ignore not found resources when deleting by default