### PR TITLE
Update Envoy

### DIFF
--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -24,3 +24,5 @@
 #    image: "quay.io/kuadrant/authorino:latest"  # If specified will override the authorino image
 #    deploy: false                               # If false, the testsuite will use already deployed authorino for testing
 #    url: ""                                     # URL for already deployed Authorino
+#  envoy:
+#    image: "docker.io/envoyproxy/envoy:v1.19-latest"  # Envoy image, the testsuite should use, only for Authorino tests now

--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -25,4 +25,4 @@
 #    deploy: false                               # If false, the testsuite will use already deployed authorino for testing
 #    url: ""                                     # URL for already deployed Authorino
 #  envoy:
-#    image: "docker.io/envoyproxy/envoy:v1.19-latest"  # Envoy image, the testsuite should use, only for Authorino tests now
+#    image: "docker.io/envoyproxy/envoy:v1.23-latest"  # Envoy image, the testsuite should use, only for Authorino tests now

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -11,3 +11,5 @@ default:
       password: "testPassword"
   authorino:
     deploy: true
+  envoy:
+    image: "docker.io/envoyproxy/envoy:v1.19-latest"

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -12,4 +12,4 @@ default:
   authorino:
     deploy: true
   envoy:
-    image: "docker.io/envoyproxy/envoy:v1.19-latest"
+    image: "docker.io/envoyproxy/envoy:v1.23-latest"

--- a/testsuite/resources/envoy.yaml
+++ b/testsuite/resources/envoy.yaml
@@ -51,14 +51,14 @@ objects:
                         cluster_name: external_auth
                       timeout: 1s
                 - name: envoy.filters.http.router
-                  typed_config: {}
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                 use_remote_address: true
         clusters:
         - name: external_auth
           connect_timeout: 0.25s
           type: strict_dns
           lb_policy: round_robin
-          http2_protocol_options: {}
           load_assignment:
             cluster_name: external_auth
             endpoints:
@@ -68,6 +68,13 @@ objects:
                     socket_address:
                       address: ${AUTHORINO_URL}
                       port_value: 50051
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              upstream_http_protocol_options:
+                auto_sni: true
+              explicit_http_config:
+                http2_protocol_options: {}
         - name: httpbin
           connect_timeout: 0.25s
           type: strict_dns
@@ -82,7 +89,6 @@ objects:
                       address: ${UPSTREAM_URL}
                       port_value: 8080
       admin:
-        access_log_path: "/tmp/admin_access.log"
         address:
           socket_address:
             address: 0.0.0.0

--- a/testsuite/resources/envoy.yaml
+++ b/testsuite/resources/envoy.yaml
@@ -180,4 +180,3 @@ parameters:
   required: true
 - name: ENVOY_IMAGE
   required: false
-  value: envoyproxy/envoy:v1.19-latest

--- a/testsuite/resources/tls/envoy.yaml
+++ b/testsuite/resources/tls/envoy.yaml
@@ -63,14 +63,14 @@ objects:
                         cluster_name: external_auth
                       timeout: 1s
                 - name: envoy.filters.http.router
-                  typed_config: {}
+                  typed_config:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                 use_remote_address: true
         clusters:
         - name: external_auth
           connect_timeout: 0.25s
           type: strict_dns
           lb_policy: round_robin
-          http2_protocol_options: {}
           load_assignment:
             cluster_name: external_auth
             endpoints:
@@ -80,6 +80,13 @@ objects:
                     socket_address:
                       address: ${AUTHORINO_URL}
                       port_value: 50051
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              upstream_http_protocol_options:
+                auto_sni: true
+              explicit_http_config:
+                http2_protocol_options: {}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -102,7 +109,6 @@ objects:
                       address: ${UPSTREAM_URL}
                       port_value: 8080
       admin:
-        access_log_path: "/tmp/admin_access.log"
         address:
           socket_address:
             address: 0.0.0.0

--- a/testsuite/resources/tls/envoy.yaml
+++ b/testsuite/resources/tls/envoy.yaml
@@ -227,5 +227,4 @@ parameters:
   description: "Secret containing CA for communication with Authorino, only public cert is required"
   required: true
 - name: ENVOY_IMAGE
-  required: false
-  value: envoyproxy/envoy:v1.19-latest
+  required: true

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -136,9 +136,9 @@ def backend(request, openshift, blame, label):
 
 
 @pytest.fixture(scope="module")
-def envoy(request, authorino, openshift, blame, backend, module_label):
+def envoy(request, authorino, openshift, blame, backend, module_label, testconfig):
     """Deploys Envoy that wire up the Backend behind the reverse-proxy and Authorino instance"""
-    envoy = Envoy(openshift, authorino, blame("envoy"), module_label, backend.url)
+    envoy = Envoy(openshift, authorino, blame("envoy"), module_label, backend.url, testconfig["envoy"]["image"])
     request.addfinalizer(envoy.delete)
     envoy.commit()
     return envoy

--- a/testsuite/tests/kuadrant/authorino/operator/sharding/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/sharding/conftest.py
@@ -6,11 +6,11 @@ from testsuite.openshift.objects.auth_config import AuthConfig
 
 
 @pytest.fixture(scope="module")
-def envoy(request, authorino, openshift, blame, backend):
+def envoy(request, authorino, openshift, blame, backend, testconfig):
     """Envoy"""
 
     def _envoy(auth=authorino):
-        envoy = Envoy(openshift, auth, blame("envoy"), blame("label"), backend.url)
+        envoy = Envoy(openshift, auth, blame("envoy"), blame("label"), backend.url, testconfig["envoy"]["image"])
         request.addfinalizer(envoy.delete)
         envoy.commit()
         return envoy

--- a/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
@@ -98,13 +98,13 @@ def invalid_cert(invalid_authority, cfssl, wildcard_domain):
 
 @pytest.fixture(scope="module")
 def envoy(request, authorino, openshift, create_secret, blame, label, backend,
-          authorino_authority, envoy_authority, envoy_cert):
+          authorino_authority, envoy_authority, envoy_cert, testconfig):
     """Envoy + Httpbin backend"""
     authorino_secret = create_secret(authorino_authority, "authca")
     envoy_ca_secret = create_secret(envoy_authority, "backendca")
     envoy_secret = create_secret(envoy_cert, "envoycert")
 
-    envoy = TLSEnvoy(openshift, authorino, blame("backend"), label, backend.url,
+    envoy = TLSEnvoy(openshift, authorino, blame("backend"), label, backend.url, testconfig["envoy"]["image"],
                      authorino_secret, envoy_ca_secret, envoy_secret)
     request.addfinalizer(envoy.delete)
     envoy.commit()


### PR DESCRIPTION
- Enable overriding the Envoy image
- Remove deprecated Envoy config options
- Use Envoy 1.23
  - The original Envoy 1.19 is EOL 