### PR TITLE
Make validators even more lazy

### DIFF
--- a/testsuite/config/__init__.py
+++ b/testsuite/config/__init__.py
@@ -29,10 +29,10 @@ settings = Dynaconf(
     merge_enabled=True,
     validators=[
         Validator("authorino.deploy", must_exist=True, eq=True) | Validator("authorino.url", must_exist=True),
-        DefaultValueValidator("rhsso.url", must_exist=True, default=fetch_route("no-ssl-sso")),
-        DefaultValueValidator("rhsso.password",
-                              must_exist=True, default=fetch_secret("credential-sso", "ADMIN_PASSWORD")),
-        DefaultValueValidator("mockserver.url", must_exist=True, default=fetch_route("no-ssl-mockserver")),
+        DefaultValueValidator("rhsso.url", default=fetch_route("no-ssl-sso")),
+        DefaultValueValidator("rhsso.password", default=fetch_secret("credential-sso", "ADMIN_PASSWORD")),
+        DefaultValueValidator("mockserver.url", default=fetch_route("no-ssl-mockserver")),
     ],
+    validate_only=["authorino"],
     loaders=["testsuite.config.openshift_loader", "dynaconf.loaders.env_loader"]
 )

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -55,8 +55,9 @@ def openshift2(testconfig):
 @pytest.fixture(scope="session")
 def rhsso(request, testconfig, blame):
     """RHSSO OIDC Provider fixture"""
-    cnf = testconfig["rhsso"]
     try:
+        testconfig.validators.validate(only="rhsso")
+        cnf = testconfig["rhsso"]
         info = RHSSO(cnf["url"], cnf["username"], cnf["password"], blame("realm"), blame("client"),
                      cnf["test_user"]["username"], cnf["test_user"]["password"])
 

--- a/testsuite/tests/kuadrant/authorino/authorization/opa/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/authorization/opa/conftest.py
@@ -1,5 +1,6 @@
 """Conftest for Open Policy Agent (OPA)"""
 import pytest
+from dynaconf import ValidationError
 
 from testsuite.mockserver import Mockserver
 from testsuite.utils import rego_allow_header
@@ -15,9 +16,10 @@ def header():
 def mockserver(request, testconfig, module_label, header):
     """Returns mockserver and creates Expectation that returns Rego query"""
     try:
+        testconfig.validators.validate(only=["mockserver"])
         mockserver = Mockserver(testconfig["mockserver"]["url"])
         request.addfinalizer(lambda: mockserver.clear_expectation(module_label))
         mockserver.create_expectation(module_label, "/opa", rego_allow_header(*header))
         return mockserver
-    except KeyError as exc:
+    except (KeyError, ValidationError) as exc:
         return pytest.skip(f"Mockserver configuration item is missing: {exc}")

--- a/testsuite/tests/kuadrant/authorino/authorization/opa/test_external_registry.py
+++ b/testsuite/tests/kuadrant/authorino/authorization/opa/test_external_registry.py
@@ -4,7 +4,7 @@ import pytest
 
 
 @pytest.fixture(scope="module")
-def authorization(authorization, mockserver):
+def authorization(mockserver, authorization):
     """
     Adds OPA policy. Rego query is located on external registry (Mockserver).
     Policy accepts requests that contain `header`.

--- a/testsuite/tests/kuadrant/authorino/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/conftest.py
@@ -3,10 +3,10 @@ import pytest
 from weakget import weakget
 
 from testsuite.httpx.auth import HttpxOidcClientAuth
+from testsuite.objects import Authorino, Authorization, PreexistingAuthorino
 from testsuite.openshift.client import OpenShiftClient
 from testsuite.openshift.objects.api_key import APIKey
 from testsuite.openshift.objects.auth_config import AuthConfig
-from testsuite.objects import Authorino, Authorization, PreexistingAuthorino
 from testsuite.openshift.objects.authorino import AuthorinoCR
 
 
@@ -42,7 +42,7 @@ def authorino(authorino, openshift, blame, request, testconfig, module_label, au
 
 # pylint: disable=unused-argument
 @pytest.fixture(scope="module")
-def authorization(authorization, authorino, envoy, blame, openshift, module_label, oidc_provider) -> Authorization:
+def authorization(authorization, oidc_provider, authorino, envoy, blame, openshift, module_label) -> Authorization:
     """In case of Authorino, AuthConfig used for authorization"""
     if authorization is None:
         authorization = AuthConfig.create_instance(openshift, blame("ac"),


### PR DESCRIPTION
* Current state is that all validators are executed immediately
  * This means all config options e.g RHSSO and Mockserver need to present and will be fetched if missing even for a single test which doesn't need it
  * This PR improves it by moving validation to the individual fixtures that load it
* Switched fixture loading order to ensure that config loading happens as soon as possible to fail quickly.  