### PR TITLE
Auth credentials

### DIFF
--- a/testsuite/objects/__init__.py
+++ b/testsuite/objects/__init__.py
@@ -37,7 +37,7 @@ class Authorization(LifecycleObject):
         """Adds OIDC identity provider"""
 
     @abc.abstractmethod
-    def add_api_key_identity(self, name, all_namespaces, match_label, match_expression):
+    def add_api_key_identity(self, name, all_namespaces, match_label, match_expression,  credentials, selector):
         """Adds API Key identity"""
 
     @abc.abstractmethod

--- a/testsuite/objects/__init__.py
+++ b/testsuite/objects/__init__.py
@@ -33,7 +33,7 @@ class Authorization(LifecycleObject):
     """Object containing Authorization rules and configuration for either Authorino or Kuadrant"""
 
     @abc.abstractmethod
-    def add_oidc_identity(self, name, endpoint):
+    def add_oidc_identity(self, name, endpoint, credentials, selector):
         """Adds OIDC identity provider"""
 
     @abc.abstractmethod

--- a/testsuite/openshift/objects/auth_config.py
+++ b/testsuite/openshift/objects/auth_config.py
@@ -71,7 +71,8 @@ class AuthConfig(OpenShiftObject, Authorization):
 
     @modify
     def add_api_key_identity(self, name, all_namespaces: bool = False,
-                             match_label=None, match_expression: MatchExpression = None):
+                             match_label=None, match_expression: MatchExpression = None,
+                             credentials="authorization_header", selector="APIKEY"):
         """
         Adds API Key identity
         Args:
@@ -79,6 +80,8 @@ class AuthConfig(OpenShiftObject, Authorization):
             :param all_namespaces: a location of the API keys can be in another namespace (only works for cluster-wide)
             :param match_label: labels that are accepted by AuthConfig
             :param match_expression: instance of the MatchExpression
+            :param credentials: locations where credentials are passed
+            :param selector: selector for credentials
         """
         if not (match_label is None) ^ (match_expression is None):
             raise AttributeError("`match_label` xor `match_expression` argument must be used")
@@ -104,8 +107,8 @@ class AuthConfig(OpenShiftObject, Authorization):
                 "allNamespaces": all_namespaces
             },
             "credentials": {
-                "in": "authorization_header",
-                "keySelector": "APIKEY"
+                "in": credentials,
+                "keySelector": selector
             }
         })
 

--- a/testsuite/openshift/objects/auth_config.py
+++ b/testsuite/openshift/objects/auth_config.py
@@ -55,13 +55,17 @@ class AuthConfig(OpenShiftObject, Authorization):
         self.model.spec.hosts = []
 
     @modify
-    def add_oidc_identity(self, name, endpoint):
+    def add_oidc_identity(self, name, endpoint, credentials="authorization_header", selector="Bearer"):
         """Adds OIDC identity"""
         identities = self.model.spec.setdefault("identity", [])
         identities.append({
             "name": name,
             "oidc": {
                 "endpoint": endpoint
+            },
+            "credentials": {
+                "in": credentials,
+                "keySelector": selector
             }
         })
 
@@ -83,8 +87,8 @@ class AuthConfig(OpenShiftObject, Authorization):
         if match_label:
             matcher.update({
                 "matchLabels": {
-                        "group": match_label
-                    }
+                    "group": match_label
+                }
             })
 
         if match_expression:

--- a/testsuite/tests/kuadrant/authorino/identity/api_key/test_auth_credentials.py
+++ b/testsuite/tests/kuadrant/authorino/identity/api_key/test_auth_credentials.py
@@ -1,0 +1,49 @@
+"""Test for API key auth credentials"""
+import pytest
+
+from testsuite.openshift.objects.auth_config import AuthConfig
+
+
+@pytest.fixture(scope="module", params=[
+    "authorization_header",
+    "custom_header",
+    "query",
+    "cookie"
+])
+def credentials(request):
+    """Location where are auth credentials passed"""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def authorization(openshift, blame, envoy, module_label, credentials):
+    """Add API key identity to AuthConfig"""
+    authorization = AuthConfig.create_instance(openshift, blame("ac"),
+                                               envoy.hostname, labels={"testRun": module_label})
+    authorization.add_api_key_identity("api_key", match_label=module_label, credentials=credentials,
+                                       selector="API_KEY")
+    return authorization
+
+
+def test_custom_selector(client, auth, credentials):
+    """Test if auth credentials are stored in right place"""
+    response = client.get("/get", headers={'authorization': "API_KEY " + auth.api_key})
+    assert response.status_code == 200 if credentials == "authorization_header" else 401
+
+
+def test_custom_header(client, auth, credentials):
+    """Test if auth credentials are stored in right place"""
+    response = client.get("/get", headers={'API_KEY': auth.api_key})
+    assert response.status_code == 200 if credentials == "custom_header" else 401
+
+
+def test_query(client, auth, credentials):
+    """Test if auth credentials are stored in right place"""
+    response = client.get("/get", params={'API_KEY': auth.api_key})
+    assert response.status_code == 200 if credentials == "query" else 401
+
+
+def test_cookie(client, auth, credentials):
+    """Test if auth credentials are stored in right place"""
+    response = client.get("/get", cookies={'API_KEY': auth.api_key})
+    assert response.status_code == 200 if credentials == "cookie" else 401

--- a/testsuite/tests/kuadrant/authorino/identity/rhsso/test_auth_credentials.py
+++ b/testsuite/tests/kuadrant/authorino/identity/rhsso/test_auth_credentials.py
@@ -1,0 +1,48 @@
+"""Test for RHSSO auth credentials"""
+import pytest
+
+from testsuite.openshift.objects.auth_config import AuthConfig
+
+
+@pytest.fixture(scope="module", params=[
+    "authorization_header",
+    "custom_header",
+    "query",
+    "cookie"
+])
+def credentials(request):
+    """Location where are auth credentials passed"""
+    return request.param
+
+
+@pytest.fixture(scope="module")
+def authorization(rhsso, openshift, blame, envoy, module_label, credentials):
+    """Add RHSSO identity to AuthConfig"""
+    authorization = AuthConfig.create_instance(openshift, blame("ac"),
+                                               envoy.hostname, labels={"testRun": module_label})
+    authorization.add_oidc_identity("rhsso", rhsso.well_known["issuer"], credentials, "Token")
+    return authorization
+
+
+def test_custom_selector(client, auth, credentials):
+    """Test if auth credentials are stored in right place"""
+    response = client.get("/get", headers={'authorization': "Token " + auth.token.access_token})
+    assert response.status_code == 200 if credentials == "authorization_header" else 401
+
+
+def test_custom_header(client, auth, credentials):
+    """Test if auth credentials are stored in right place"""
+    response = client.get("/get", headers={'Token': auth.token.access_token})
+    assert response.status_code == 200 if credentials == "custom_header" else 401
+
+
+def test_query(client, auth, credentials):
+    """Test if auth credentials are stored in right place"""
+    response = client.get("/get", params={'Token': auth.token.access_token})
+    assert response.status_code == 200 if credentials == "query" else 401
+
+
+def test_cookie(client, auth, credentials):
+    """Test if auth credentials are stored in right place"""
+    response = client.get("/get", cookies={'Token': auth.token.access_token})
+    assert response.status_code == 200 if credentials == "cookie" else 401


### PR DESCRIPTION
Add test for RHSSO and API key auth credentials location. Tests are for authorization_header with custom prefix, custom header, query and cookies.
Closes #107 