### PR TITLE
Added logLevel debug for authorino

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -11,5 +11,6 @@ default:
       password: "testPassword"
   authorino:
     deploy: true
+    log_level: "debug"
   envoy:
     image: "docker.io/envoyproxy/envoy:v1.23-latest"

--- a/testsuite/openshift/objects/authorino.py
+++ b/testsuite/openshift/objects/authorino.py
@@ -14,7 +14,8 @@ class AuthorinoCR(OpenShiftObject, Authorino):
 
     @classmethod
     def create_instance(cls, openshift: OpenShiftClient, name, image=None,
-                        cluster_wide=False, label_selectors: List[str] = None, listener_certificate_secret=None):
+                        cluster_wide=False, label_selectors: List[str] = None, listener_certificate_secret=None,
+                        log_level=None):
         """Creates base instance"""
         model: Dict[str, Any] = {
             "apiVersion": "operator.authorino.kuadrant.io/v1beta1",
@@ -25,6 +26,7 @@ class AuthorinoCR(OpenShiftObject, Authorino):
             },
             "spec": {
                 "clusterWide": cluster_wide,
+                "logLevel": log_level,
                 "listener": {
                     "tls": {
                         "enabled": False

--- a/testsuite/tests/kuadrant/authorino/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/conftest.py
@@ -33,6 +33,7 @@ def authorino(authorino, openshift, blame, request, testconfig, module_label, au
     authorino = AuthorinoCR.create_instance(openshift,
                                             blame("authorino"),
                                             image=weakget(testconfig)["authorino"]["image"] % None,
+                                            log_level=weakget(testconfig)["authorino"]["log_level"] % None,
                                             **authorino_parameters)
     request.addfinalizer(lambda: authorino.delete(ignore_not_found=True))
     authorino.commit()


### PR DESCRIPTION
Temporarily adding debug log level for Authorino. 
When we add logs to the test results in the future, we can set this as an optional option for test runs.