### PR TITLE
Fix typo in OpenShiftObject.committed

### DIFF
--- a/testsuite/openshift/objects/__init__.py
+++ b/testsuite/openshift/objects/__init__.py
@@ -18,7 +18,7 @@ def modify(func):
 
     @functools.wraps(func)
     def _wrap(self, *args, **kwargs):
-        if self.commited:
+        if self.committed:
             result, _ = self.modify_and_apply(_custom_partial(func, *args, **kwargs))
             assert result.status
         else:
@@ -31,7 +31,7 @@ class OpenShiftObject(APIObject):
     """Custom APIObjects which tracks if the object was already committed to the server or not"""
     def __init__(self, dict_to_model=None, string_to_model=None, context=None):
         super().__init__(dict_to_model, string_to_model, context)
-        self.commited = False
+        self.committed = False
 
     def commit(self):
         """
@@ -39,7 +39,7 @@ class OpenShiftObject(APIObject):
         It will be the same class but attributes might differ, due to server adding/rejecting some of them.
         """
         self.create(["--save-config=true"])
-        self.commited = True
+        self.committed = True
         return self.refresh()
 
     def delete(self, ignore_not_found=True, cmd_args=None):


### PR DESCRIPTION
Now it has the correct spelling