### PR TITLE
Add webhooks test

### DIFF
--- a/testsuite/objects/sections.py
+++ b/testsuite/objects/sections.py
@@ -26,6 +26,10 @@ class Authorizations(abc.ABC):
     def auth_rule(self, name: str, rule: "Rule", when: "Rule", metrics: bool, priority: int):
         """Adds JSON pattern-matching authorization rule (authorization.json)"""
 
+    @abc.abstractmethod
+    def kubernetes(self, name: str, when: list, kube_attrs: dict, priority: int):
+        """Adds kubernetes authorization rule."""
+
 
 class Identities(abc.ABC):
     """Identities configuration"""
@@ -45,6 +49,10 @@ class Identities(abc.ABC):
     @abc.abstractmethod
     def anonymous(self, name):
         """Adds anonymous identity"""
+
+    @abc.abstractmethod
+    def kubernetes(self, name, authjson):
+        """Adds kubernetes identity"""
 
     @abc.abstractmethod
     def remove_all(self):

--- a/testsuite/openshift/objects/auth_config/sections.py
+++ b/testsuite/openshift/objects/auth_config/sections.py
@@ -115,6 +115,11 @@ class IdentitySection(Section, Identities):
         self.add_item(name, {"anonymous": {}})
 
     @modify
+    def kubernetes(self, name, authjson):
+        """Adds kubernetes identity"""
+        self.add_item(name, {"plain": {"authJSON": authjson}})
+
+    @modify
     def remove_all(self):
         """Removes all identities from AuthConfig"""
         self.section.clear()
@@ -216,4 +221,22 @@ class AuthorizationsSection(Section, Authorizations):
                     "ttl": ttl
                 }
             }
+        })
+
+    @modify
+    def kubernetes(self, name: str, when: list, kube_attrs: dict, priority=0):
+        """Adds Kubernetes authorization
+
+        :param name: name of kubernetes authorization
+        :param when: list of conditions
+        :param kube_user: user in kubernetes authorization
+        :param kube_attrs: resource attributes in kubernetes authorization
+        :param priority: priority
+        """
+
+        kube_user = {'valueFrom': {'authJSON': 'auth.identity.username'}}
+        self.add_item(name, {
+            "priority": priority,
+            "kubernetes": {"user": kube_user, "resourceAttributes": kube_attrs},
+            "when": when
         })

--- a/testsuite/tests/kuadrant/authorino/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/conftest.py
@@ -30,8 +30,9 @@ def authorino(authorino, openshift, blame, request, testconfig, module_label, au
     labels = authorino_parameters.setdefault("label_selectors", [])
     labels.append(f"testRun={module_label}")
 
+    authorino_parameters.setdefault('name', blame("authorino"))
+
     authorino = AuthorinoCR.create_instance(openshift,
-                                            blame("authorino"),
                                             image=weakget(testconfig)["authorino"]["image"] % None,
                                             log_level=weakget(testconfig)["authorino"]["log_level"] % None,
                                             **authorino_parameters)

--- a/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
@@ -157,4 +157,4 @@ def authorino_parameters(authorino_parameters, authorino_cert, create_secret):
     """Setup TLS for authorino"""
     authorino_secret_name = create_secret(authorino_cert, "authcert")
     authorino_parameters["listener_certificate_secret"] = authorino_secret_name
-    yield authorino_parameters
+    return authorino_parameters

--- a/testsuite/tests/kuadrant/authorino/operator/tls/test_webhook.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/test_webhook.py
@@ -1,0 +1,177 @@
+"""
+Test raw http authorization used in Kubernetes Validating Webhooks.
+"""
+import base64
+from typing import Any, Dict
+import pytest
+
+import openshift as oc
+from openshift import OpenShiftPythonException
+
+from testsuite.objects import Authorization
+from testsuite.certificates import CertInfo
+from testsuite.utils import cert_builder
+from testsuite.openshift.objects.ingress import Ingress
+
+OPA_POLICY = """
+    request := json.unmarshal(input.context.request.http.body).request
+    verb := request.operation
+    ingress := request.object { verb == "CREATE" }
+    ingress := request.oldObject { verb == "DELETE" }
+    forbidden { count(object.get(ingress.spec, "rules", [])) == 0 }
+    rules { count(ingress.spec.rules) == 1; ingress.spec.rules[0] == {} }
+    allow { rules; not forbidden }
+"""
+
+
+@pytest.fixture(scope="session")
+def specific_authorino_name(blame):
+    """Define specific name for authorino which matches with name in authorino certificate"""
+    return blame('authorino')
+
+
+@pytest.fixture(scope="session")
+def authorino_domain(openshift, specific_authorino_name):
+    """
+    Hostname of the upstream certificate sent to be validated by APIcast
+    May be overwritten to configure different test cases
+    """
+    return f"{specific_authorino_name}-authorino-authorization.{openshift.project}.svc"
+
+
+@pytest.fixture(scope="session")
+def certificates(cfssl, authorino_domain, wildcard_domain):
+    """Certificate hierarchy used for the tests.
+    Authorino certificate has *hosts* set to *authorino_domain* value.
+    """
+    chain = {
+        "envoy_ca": CertInfo(children={
+            "envoy_cert": None,
+            "valid_cert": None
+        }),
+        "authorino_ca": CertInfo(children={
+            "authorino_cert": CertInfo(hosts=authorino_domain),
+        }),
+        "invalid_ca": CertInfo(children={
+            "invalid_cert": None
+        })
+    }
+    return cert_builder(cfssl, chain, wildcard_domain)
+
+
+@pytest.fixture(scope="module")
+def authorino_parameters(authorino_parameters, specific_authorino_name):
+    """Setup TLS with specific name for authorino."""
+    authorino_parameters['name'] = specific_authorino_name
+    return authorino_parameters
+
+
+# pylint: disable=unused-argument
+@pytest.fixture(scope="module")
+def authorization(authorization, openshift, module_label, authorino_domain) -> Authorization:
+    """In case of Authorino, AuthConfig used for authorization"""
+
+    # Authorino should have specific url so it is accessible by k8s webhook
+    authorization.remove_all_hosts()
+    authorization.add_host(authorino_domain)
+
+    # get user info from admission webhook
+    authorization.identity.remove_all()
+    authorization.identity.kubernetes('k8s-userinfo',
+                                      'context.request.http.body.@fromstr|request.userInfo')
+
+    # add OPA policy to process admission webhook request
+    authorization.authorization.opa_policy('features', OPA_POLICY)
+
+    when = [{'selector': 'auth.authorization.features.allow', 'operator': 'eq', 'value': 'true'},
+            {'selector': 'auth.authorization.features.verb', 'operator': 'eq', 'value': 'CREATE'}]
+    kube_attrs = {
+                    'namespace': {'value': openshift.project},
+                    'group': {'value': 'networking.k8s.io'},
+                    'resources': {'value': 'Ingress'},
+                    'verb': {'value': 'create'}
+                 }
+    # add response for admission webhook for creating Ingress
+    authorization.authorization.kubernetes('ingress-authn-k8s-binding-create',
+                                           when, kube_attrs, 1)
+
+    when = [{'selector': 'auth.authorization.features.allow', 'operator': 'eq', 'value': 'true'},
+            {'selector': 'auth.authorization.features.verb', 'operator': 'eq', 'value': 'DELETE'}]
+    kube_attrs = {
+                    'namespace': {'value': openshift.project},
+                    'group': {'value': 'networking.k8s.io'},
+                    'resources': {'value': 'Ingress'},
+                    'verb': {'value': 'delete'}
+                 }
+    # add response for admission webhook for deleting Ingress
+    authorization.authorization.kubernetes('ingress-authn-k8s-binding-delete',
+                                           when, kube_attrs, 1)
+    return authorization
+
+
+@pytest.fixture(scope="module")
+def validating_webhook(openshift, authorino_domain, certificates, blame):
+    """Create validating webhook."""
+    name = blame('check-ingress') + '.authorino.kuadrant.io'
+    service_name = authorino_domain.split('.')[0]
+
+    cert_string = base64.b64encode(certificates['authorino_ca'].certificate.encode('ascii')).decode('ascii')
+    model: Dict[str, Any] = {
+        'apiVersion': 'admissionregistration.k8s.io/v1',
+        'kind': 'ValidatingWebhookConfiguration',
+        'metadata': {
+            'name': name,
+            'namespace': openshift.project
+        },
+        'webhooks': [
+            {
+                'name': name,
+                'clientConfig': {
+                    'service': {
+                        'namespace': openshift.project,
+                        'name': service_name,
+                        'port': 5001,
+                        'path': '/check'
+                    },
+                    'caBundle': cert_string,
+                },
+                'rules': [
+                    {
+                        'apiGroups': ['networking.k8s.io'],
+                        'apiVersions': ['v1'],
+                        'resources': ['ingresses'],
+                        'operations': ['CREATE', 'UPDATE', 'DELETE'],
+                        'scope': '*',
+                    }
+                ],
+                'sideEffects': 'None',
+                'admissionReviewVersions': ['v1']
+            }
+        ]
+    }
+
+    webhook = None
+    with openshift.context:
+        webhook = oc.create(model)
+    yield webhook
+    webhook.delete()
+
+
+# pylint: disable=unused-argument
+def test_authorized_via_http(authorization, openshift, authorino, authorino_domain,
+                             validating_webhook, blame):
+    """Test raw http authentization via webhooks."""
+    ingress = Ingress.create_instance(openshift, blame('minimal-ingress'), rules=[{}])
+    ingress.commit()
+    assert ingress.model.metadata.creationTimestamp
+    ingress.delete()
+
+
+# pylint: disable=unused-argument
+def test_unauthorized_via_http(authorization, openshift, authorino, authorino_domain,
+                               validating_webhook, blame):
+    """Test raw http authentization via webhooks but for unathorized object."""
+    ingress = Ingress.create_instance(openshift, blame('minimal-ingress'), rules=[{}, {}])
+    with pytest.raises(OpenShiftPythonException) as exc_info:
+        ingress.commit()
+        assert "Unauthorized" in exc_info.value.result.err()


### PR DESCRIPTION
This PR adds testcase for testing k8s Dynamic Admission Control webhooks, see https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/ which are used for calling Authorino service for authenticating of Ingress object creation.