### PR TITLE
Add implicit_optional to mypy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+implicit_optional = True
 
 [mypy-dynaconf.*]
 ignore_missing_imports = True


### PR DESCRIPTION
* mypy 990 (https://mypy-lang.blogspot.com/2022/11/mypy-0990-released.html) make strict optional as default, meaning Types that have default value of None are no longer implicitly Optional
  * It is technically forbidden by PEP, but I wont change it now, it is a bigger change and it causes the type to be longer
