### PR TITLE
Do not expect hosts in ingress

### DIFF
--- a/testsuite/tests/glbc/test_ingress_reconciliation.py
+++ b/testsuite/tests/glbc/test_ingress_reconciliation.py
@@ -1,6 +1,4 @@
 """Basic tests for ingress reconciliation"""
-import time
-
 import backoff
 import httpx
 import pytest
@@ -29,18 +27,15 @@ def backend_ingress(request, backend, blame):
 @backoff.on_exception(backoff.fibo, exception=httpx.ConnectError, max_time=600)
 def test_ingress_host_add(backend_ingress):
     """Creates ingress for a backend and checks for host field filled by glbc, checks host points to backend"""
-    rules = backend_ingress.rules
-    assert len(rules) == 1
-
-    backend_ingress.wait_for_hosts()
-    host = rules[0].get("host")
+    backend_ingress.wait_for_ready()
+    host = backend_ingress.host
 
     assert host
 
-    # needed because of negative dns caching
-    # once https://github.com/kcp-dev/kcp-glbc/issues/354 is implemented this can be removed and reimplemented
-    time.sleep(20)  # wait until dns record is propagated
+    # # needed because of negative dns caching
+    # # once https://github.com/kcp-dev/kcp-glbc/issues/354 is implemented this can be removed and reimplemented
+    # time.sleep(20)  # wait until dns record is propagated
 
-    response = httpx.get(f"http://{host}")
+    response = httpx.get(f"http://{host}", follow_redirects=True)
 
     assert response.status_code == 200


### PR DESCRIPTION
With the recent change, the GLBC stopped adding a host into the Ingress, it can instead be read from the annotations. This is a hot fix to resolve that. It works but will be replaced by a better solution along the way.