### PR TITLE
Add advanced mtls tests

### DIFF
--- a/testsuite/httpx/__init__.py
+++ b/testsuite/httpx/__init__.py
@@ -33,12 +33,12 @@ class HttpxBackoffClient(Client):
         self.retry_codes = {503}
         _verify = None
         if isinstance(verify, Certificate):
-            verify_file = create_tmp_file(verify.certificate)
+            verify_file = create_tmp_file(verify.chain)
             self.files.append(verify_file)
             _verify = verify_file.name
         _cert = None
         if cert:
-            cert_file = create_tmp_file(cert.certificate)
+            cert_file = create_tmp_file(cert.chain)
             self.files.append(cert_file)
             key_file = create_tmp_file(cert.key)
             self.files.append(key_file)

--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -142,7 +142,7 @@ class OpenShiftClient:
                 'name': name,
             },
             'stringData': {
-                "tls.crt": certificate.chain or certificate.certificate,
+                "tls.crt": certificate.chain,
                 "tls.key": certificate.key
             },
             "type": "kubernetes.io/tls"

--- a/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
@@ -20,8 +20,12 @@ def cert_attributes() -> Dict[str, str]:
 
 @pytest.fixture(scope="session")
 def cert_attributes_other(cert_attributes) -> Dict[str, str]:
-    """Certificate attributes that are different from the default ones"""
-    return {k: f"{v}-other" for k, v in cert_attributes.items()}
+    """Certificate attributes that are partially different from the default ones"""
+    return dict(O="Other Organization",
+                OU="Other Unit",
+                L=cert_attributes["L"],
+                ST=cert_attributes["ST"],
+                C=cert_attributes["C"])
 
 
 @pytest.fixture(scope="session")

--- a/testsuite/tests/kuadrant/authorino/operator/tls/mtls/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/mtls/conftest.py
@@ -1,0 +1,50 @@
+"""Conftest for all mTLS tests"""
+import pytest
+
+from testsuite.certificates import CertInfo
+from testsuite.utils import cert_builder
+from testsuite.objects import Rule
+
+
+@pytest.fixture(scope="module", autouse=True)
+def authorization(authorization, blame, selector_params, cert_attributes):
+    """Create AuthConfig with mtls identity and pattern matching rule"""
+    authorization.identity.mtls(blame("mtls"), *selector_params)
+
+    rule_organization = Rule("auth.identity.Organization", "incl", cert_attributes["O"])
+    authorization.authorization.auth_rule(blame("redhat"), rule_organization)
+
+    return authorization
+
+
+@pytest.fixture(scope="session")
+def certificates(cfssl, authorino_domain, wildcard_domain, cert_attributes, cert_attributes_other):
+    """Certificate hierarchy used for the mTLS tests"""
+    chain = {
+        "envoy_ca": CertInfo(children={
+            "envoy_cert": None,
+            "valid_cert": CertInfo(names=[cert_attributes]),
+            "custom_cert": CertInfo(names=[cert_attributes_other]),
+            "intermediate_ca": CertInfo(children={
+                "intermediate_valid_cert": CertInfo(names=[cert_attributes]),
+                "intermediate_custom_cert": CertInfo(names=[cert_attributes_other])
+            }),
+            "intermediate_ca_unlabeled": CertInfo(children={
+                "intermediate_cert_unlabeled": CertInfo(names=[cert_attributes])
+            })
+        }),
+        "authorino_ca": CertInfo(children={
+            "authorino_cert": CertInfo(hosts=authorino_domain),
+        }),
+        "invalid_ca": CertInfo(children={
+            "invalid_cert": None
+        }),
+        "self_signed_cert": None
+    }
+    return cert_builder(cfssl, chain, wildcard_domain)
+
+
+@pytest.fixture(scope="module")
+def self_signed_cert(certificates):
+    """Self-signed certificate"""
+    return certificates["self_signed_cert"]

--- a/testsuite/tests/kuadrant/authorino/operator/tls/mtls/test_mtls_attributes.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/mtls/test_mtls_attributes.py
@@ -1,0 +1,27 @@
+"""Tests on mTLS authentication with multiple attributes"""
+import pytest
+
+from testsuite.objects import Rule
+
+
+@pytest.fixture(scope="module", autouse=True)
+def authorization(authorization, blame, cert_attributes):
+    """Add second pattern matching rule to the AuthConfig"""
+    rule_country = Rule("auth.identity.Country", "incl", cert_attributes["C"])
+    authorization.authorization.auth_rule(blame("redhat"), rule_country)
+
+    return authorization
+
+
+def test_mtls_multiple_attributes_success(envoy_authority, valid_cert, envoy):
+    """Test successful mtls authentication with two matching attributes"""
+    with envoy.client(verify=envoy_authority, cert=valid_cert) as client:
+        response = client.get("/get")
+        assert response.status_code == 200
+
+
+def test_mtls_multiple_attributes_fail(envoy_authority, custom_cert, envoy):
+    """Test mtls authentication with one matched and one unmatched attributes"""
+    with envoy.client(verify=envoy_authority, cert=custom_cert) as client:
+        response = client.get("/get")
+        assert response.status_code == 403

--- a/testsuite/tests/kuadrant/authorino/operator/tls/mtls/test_mtls_trust_chain.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/mtls/test_mtls_trust_chain.py
@@ -1,0 +1,30 @@
+"""mTLS trust chain tests"""
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def create_intermediate_authority_secrets(create_secret, authorino_labels, certificates):
+    """Create Intermediate Certification Authority (CA) tls secrets"""
+    create_secret(certificates["intermediate_ca"], "interca", labels=authorino_labels)
+    create_secret(certificates["intermediate_ca_unlabeled"], "interunld")
+
+
+def test_mtls_trust_chain_success(envoy_authority, certificates, envoy):
+    """Test mtls verification with certificate signed by intermediate authority in the trust chain"""
+    with envoy.client(verify=envoy_authority, cert=certificates["intermediate_valid_cert"]) as client:
+        response = client.get("/get")
+        assert response.status_code == 200
+
+
+def test_mtls_trust_chain_fail(envoy_authority, certificates, envoy):
+    """Test mtls verification on intermediate certificate with unmatched attribute"""
+    with envoy.client(verify=envoy_authority, cert=certificates["intermediate_custom_cert"]) as client:
+        response = client.get("/get")
+        assert response.status_code == 403
+
+
+def test_mtls_trust_chain_rejected_cert(envoy_authority, certificates, envoy):
+    """Test mtls verification with intermediate certificate accepted in Envoy, but rejected by Authorino"""
+    with envoy.client(verify=envoy_authority, cert=certificates["intermediate_cert_unlabeled"]) as client:
+        response = client.get("/get")
+        assert response.status_code == 401

--- a/testsuite/utils.py
+++ b/testsuite/utils.py
@@ -70,7 +70,7 @@ def cert_builder(cfssl: CFSSLClient, chain: dict, hosts: Union[str, Collection[s
         else:
             cert = cfssl.create(name, names=info.names,
                                 hosts=parsed_hosts, certificate_authority=parent)  # type: ignore
-        cert.chain = cert.certificate + parent.chain if parent else cert.certificate  # type: ignore
+
         if info.children is not None:
             result.update(cert_builder(cfssl, info.children, parsed_hosts, cert))
         result[name] = cert

--- a/testsuite/utils.py
+++ b/testsuite/utils.py
@@ -69,7 +69,7 @@ def cert_builder(cfssl: CFSSLClient, chain: dict, hosts: Union[str, Collection[s
                                           hosts=parsed_hosts, certificate_authority=parent)
         else:
             cert = cfssl.create(name, names=info.names,
-                                hosts=parsed_hosts, certificate_authority=parent)  # type: ignore
+                                hosts=parsed_hosts, certificate_authority=parent)
 
         if info.children is not None:
             result.update(cert_builder(cfssl, info.children, parsed_hosts, cert))


### PR DESCRIPTION
New test cases:
- [X] Request with a self-signed certificate
- [X] Request without a certificate
- [x] Compare multiple certificate attributes at once success
- [x] Compare multiple certificate attributes at once fail
- [x] Certificates trust chain
- [x] Certificate is accepted in Envoy, but rejected by Authorino

Certificate building data for the CFSSL is moved to the separate builder function.
Added possibility to create self-signed certificates.