### PR TITLE
Add tests for complex AuthConfig

### DIFF
--- a/testsuite/mockserver.py
+++ b/testsuite/mockserver.py
@@ -13,9 +13,9 @@ class Mockserver:
     def __init__(self, url):
         self.url = url
 
-    def create_expectation(self, expectation_id, path, opa_policy,
+    def create_expectation(self, expectation_id, path, body,
                            content_type: Union[ContentType, str] = ContentType.PLAIN_TEXT):
-        """Creates an Expectation - response with body that contains OPA policy (Rego query)"""
+        """Creates an Expectation - response with given body"""
         response = httpx.put(
             urljoin(self.url, "/mockserver/expectation"), verify=False, timeout=5, json={
                     "id": expectation_id,
@@ -26,7 +26,7 @@ class Mockserver:
                         "headers": {
                             "Content-Type": [str(content_type)]
                         },
-                        "body": opa_policy
+                        "body": body
                     }
                 }
             )

--- a/testsuite/oidc/rhsso/__init__.py
+++ b/testsuite/oidc/rhsso/__init__.py
@@ -19,6 +19,8 @@ class RHSSO(OIDCProvider, LifecycleObject):
                  test_username="testUser", test_password="testPassword") -> None:
         self.test_username = test_username
         self.test_password = test_password
+        self.username = username
+        self.password = password
         self.realm_name = realm_name
         self.client_name = client_name
         self.realm = None

--- a/testsuite/oidc/rhsso/objects.py
+++ b/testsuite/oidc/rhsso/objects.py
@@ -122,6 +122,10 @@ class User:
         return self.admin.assign_realm_roles(user_id=self.user_id,
                                              roles=role)
 
+    def assign_attribute(self, attribute):
+        """Assigns attribute to user"""
+        self.update_user(attributes=attribute)
+
     @property
     def properties(self):
         """Returns User information in a dict"""

--- a/testsuite/resources/dinosaur_config.yaml
+++ b/testsuite/resources/dinosaur_config.yaml
@@ -1,0 +1,292 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: dinosaur-template
+objects:
+- apiVersion: authorino.kuadrant.io/v1beta1
+  kind: AuthConfig
+  metadata:
+    name: ${NAME}
+    namespace: ${NAMESPACE}
+    labels:
+      testRun: ${LABEL}
+  spec:
+    hosts:
+      - ${HOST}
+    patterns:
+      api-route:
+        - selector: context.request.http.path
+          operator: matches
+          value: ^/anything/dinosaurs_mgmt/.+
+      v1-route:
+        - selector: "context.request.http.path.@extract:{\"sep\":\"/\",\"pos\":3}"
+          operator: eq
+          value: v1
+      dinosaurs-route:
+        - selector: "context.request.http.path.@extract:{\"sep\":\"/\",\"pos\":4}"
+          operator: eq
+          value: dinosaurs
+      dinosaur-resource-route:
+        - selector: context.request.http.path
+          operator: matches
+          value: /dinosaurs/[^/]+$
+      create-dinosaur-route:
+        - selector: context.request.http.path
+          operator: matches
+          value: /dinosaurs/?$
+        - selector: context.request.http.method
+          operator: eq
+          value: POST
+      metrics-federate-route:
+        - selector: "context.request.http.path.@extract:{\"sep\":\"/\",\"pos\":4}"
+          operator: eq
+          value: dinosaurs
+        - selector: context.request.http.path
+          operator: matches
+          value: /metrics/federate$
+      service-accounts-route:
+        - selector: "context.request.http.path.@extract:{\"sep\":\"/\",\"pos\":4}"
+          operator: eq
+          value: service_accounts
+      supported-instance-types-route:
+        - selector: "context.request.http.path.@extract:{\"sep\":\"/\",\"pos\":4}"
+          operator: eq
+          value: instance_types
+      agent-clusters-route:
+        - selector: "context.request.http.path.@extract:{\"sep\":\"/\",\"pos\":4}"
+          operator: eq
+          value: agent-clusters
+      admin-route:
+        - selector: "context.request.http.path.@extract:{\"sep\":\"/\",\"pos\":4}"
+          operator: eq
+          value: admin
+      acl-required:
+        - selector: "context.request.http.path.@extract:{\"sep\":\"/\",\"pos\":4}"
+          operator: neq
+          value: agent-clusters
+        - selector: "context.request.http.path.@extract:{\"sep\":\"/\",\"pos\":4}"
+          operator: neq
+          value: admin
+      redhat-sso:
+        - selector: auth.identity.iss
+          operator: eq
+          value: ${RHSSO_ISSUER}
+      admin-sso:
+        - selector: auth.identity.iss
+          operator: eq
+          value: ${ADMIN_ISSUER}
+      require-org-id:
+        - selector: auth.identity.org_id
+          operator: neq
+          value: ""
+    when:
+      - patternRef: api-route
+      - patternRef: v1-route
+    identity:
+      - name: redhat-sso
+        oidc:
+          endpoint: ${RHSSO_ISSUER}
+          ttl: 3600
+        extendedProperties:
+          - name: org_id
+            valueFrom: {authJSON: auth.identity.middle_name}
+      - name: admin-sso
+        when:
+        - patternRef: admin-route
+        oidc:
+          endpoint: ${ADMIN_ISSUER}
+          ttl: 3600
+    #TMP
+    response:
+      - json:
+          properties:
+            - name: auth
+              valueFrom:
+                authJSON: auth
+            - name: context
+              valueFrom:
+                authJSON: context
+        name: auth-json
+    metadata:
+      - name: terms-and-conditions
+        when:
+          - patternRef: create-dinosaur-route
+        http:
+          endpoint: ${TERMS_AND_CONDITIONS}
+          method: GET
+          contentType: application/json
+      - name: cluster-info
+        when:
+          - patternRef: agent-clusters-route
+        http:
+          endpoint: ${CLUSTER_INFO}
+          method: GET
+          contentType: application/json
+      - name: resource-info
+        when:
+          - patternRef: dinosaur-resource-route
+        http:
+          endpoint: ${RESOURCE_INFO}
+          method: GET
+          contentType: application/json
+    authorization:
+      - name: bearer-token
+        json:
+          rules:
+            - selector: auth.identity.typ
+              operator: eq
+              value: Bearer
+      - name: deny-list
+        when:
+          - patternRef: acl-required
+        opa:
+          inlineRego: |
+            list := [
+              "denied-test-user1@example.com"
+            ]
+            denied { list[_] == input.auth.identity.email }
+            allow { not denied }
+      - name: allow-list
+        when:
+          - patternRef: acl-required
+        opa:
+          inlineRego: |
+            list := [
+              "123"
+            ]
+            allow { list[_] == input.auth.identity.org_id }
+      - name: terms-and-conditions
+        when:
+          - patternRef: create-dinosaur-route
+        json:
+          rules:
+            - selector: auth.metadata.terms-and-conditions.terms_required
+              operator: eq
+              value: "false"
+      - name: dinosaurs
+        when:
+          - patternRef: dinosaurs-route
+        json:
+          rules:
+            - patternRef: redhat-sso
+            - patternRef: require-org-id
+      - name: metrics-federate
+        when:
+          - patternRef: metrics-federate-route
+        json:
+          rules:
+            - patternRef: redhat-sso
+            - patternRef: require-org-id
+      - name: service-accounts
+        when:
+          - patternRef: service-accounts-route
+        json:
+          rules:
+            - patternRef: redhat-sso
+            - patternRef: require-org-id
+      - name: supported-instance-types
+        when:
+          - patternRef: supported-instance-types-route
+        json:
+          rules:
+            - patternRef: redhat-sso
+            - patternRef: require-org-id
+      - name: agent-clusters
+        when:
+          - patternRef: agent-clusters-route
+        json:
+          rules:
+            - patternRef: redhat-sso
+      - name: cluster-id
+        when:
+          - patternRef: agent-clusters-route
+        opa:
+          inlineRego: |
+            allow { input.auth.identity.azp == object.get(input.auth.metadata, "cluster-info", {}).client_id }
+      - name: owner
+        when:
+          - patternRef: dinosaur-resource-route
+        opa:
+          inlineRego: |
+            org_id := input.auth.identity.org_id
+            filter_by_org { org_id }
+            is_org_admin := input.auth.identity.is_org_admin
+            resource_data := object.get(input.auth.metadata, "resource-info", {})
+            same_org { resource_data.org_id == org_id }
+            is_owner { resource_data.owner == input.auth.identity.azp }
+            has_permission { filter_by_org; same_org; is_org_admin }
+            has_permission { filter_by_org; same_org; is_owner }
+            has_permission { not filter_by_org; is_owner }
+            method := input.context.request.http.method
+            allow { method == "GET";    has_permission }
+            allow { method == "DELETE"; has_permission }
+            allow { method == "PATCH";  has_permission }
+      - name: admin-rbac
+        when:
+          - patternRef: admin-route
+          - patternRef: admin-sso
+        opa:
+          inlineRego: |
+            method := input.context.request.http.method
+            roles := input.auth.identity.realm_access.roles
+            allow { method == "GET";    roles[_] == "admin-full" }
+            allow { method == "GET";    roles[_] == "admin-read" }
+            allow { method == "GET";    roles[_] == "admin-write" }
+            allow { method == "PATCH";  roles[_] == "admin-full" }
+            allow { method == "PATCH";  roles[_] == "admin-write" }
+            allow { method == "DELETE"; roles[_] == "admin-full" }
+      - name: admin-redhat-rhsso
+        when:
+          - patternRef: admin-route
+          - patternRef: redhat-sso
+        opa:
+          inlineRego: |
+            allow { false }
+      - name: internal-endpoints
+        json:
+          rules:
+            - selector: "context.request.http.path.@extract:{\"sep\":\"/\",\"pos\":4}"
+              operator: neq
+              value: authz-metadata
+    denyWith:
+      unauthorized:
+        headers:
+          - name: content-type
+            value: "application/json"
+        body:
+          value: |
+            {
+              "kind": "Error",
+              "id": "403",
+              "href": "/api/dinosaurs_mgmt/v1/errors/403",
+              "code": "DINOSAURS-MGMT-403",
+              "reason": "Forbidden"
+            }
+parameters:
+- name: NAME
+  description: "Name for the resources created"
+  required: true
+- name: NAMESPACE
+  description: "Namespace of the resources created"
+  required: true
+- name: LABEL
+  description: "Test run label for all resources"
+  required: true
+- name: HOST
+  description: "Authorino host"
+  required: true
+- name: RHSSO_ISSUER
+  description: "Issuer url of RHSSO"
+  required: true
+- name: ADMIN_ISSUER
+  description: "Issuer url of admin RHSSO"
+  required: true
+- name: TERMS_AND_CONDITIONS
+  description: "URl for terms-and-conditions metadata"
+  required: true
+- name: CLUSTER_INFO
+  description: "URl for cluster-info metadata"
+  required: true
+- name: RESOURCE_INFO
+  description: "URl for resource-info metadata"
+  required: true

--- a/testsuite/tests/kuadrant/authorino/dinosaur/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/dinosaur/conftest.py
@@ -1,0 +1,149 @@
+"""
+Conftest for anonymized use cases tests
+"""
+from importlib import resources
+
+import pytest
+
+from testsuite.httpx.auth import HttpxOidcClientAuth
+from testsuite.oidc.rhsso import RHSSO
+from testsuite.utils import ContentType
+
+
+@pytest.fixture(scope="session")
+def admin_rhsso(request, testconfig, blame, rhsso):
+    """RHSSO OIDC Provider fixture"""
+
+    info = RHSSO(rhsso.server_url, rhsso.username, rhsso.password, blame("realm"), blame("client"),
+                 rhsso.test_username, rhsso.test_password)
+
+    if not testconfig["skip_cleanup"]:
+        request.addfinalizer(info.delete)
+    info.commit()
+    return info
+
+
+@pytest.fixture()
+def admin_auth(admin_rhsso):
+    """Returns RHSSO authentication object for HTTPX"""
+    return HttpxOidcClientAuth(admin_rhsso.get_token, "authorization")
+
+
+@pytest.fixture(scope="module")
+def terms_and_conditions(request, mockserver, module_label):
+    """Creates Mockserver Expectation that returns whether terms are required and returns its endpoint"""
+
+    def _terms_and_conditions(value):
+        return mockserver.create_expectation(f"{module_label}-terms", f"/{module_label}/terms-and-conditions",
+                                             {"terms_required": value}, ContentType.APPLICATION_JSON)
+
+    request.addfinalizer(lambda: mockserver.clear_expectation(f"{module_label}-terms"))
+    return _terms_and_conditions
+
+
+@pytest.fixture(scope="module")
+def cluster_info(request, mockserver, module_label):
+    """Creates Mockserver Expectation that returns client ID and returns its endpoint"""
+
+    def _cluster_info(value):
+        return mockserver.create_expectation(f"{module_label}-cluster", f"/{module_label}/cluster-info",
+                                             {"client_id": value}, ContentType.APPLICATION_JSON)
+
+    request.addfinalizer(lambda: mockserver.clear_expectation(f"{module_label}-cluster"))
+    return _cluster_info
+
+
+@pytest.fixture(scope="module")
+def resource_info(request, mockserver, module_label):
+    """Creates Mockserver Expectation that returns info about resource and returns its endpoint"""
+
+    def _resource_info(org_id, owner):
+        return mockserver.create_expectation(f"{module_label}-resource", f"/{module_label}/resource-info",
+                                             {"org_id": org_id, "owner": owner},
+                                             ContentType.APPLICATION_JSON)
+
+    request.addfinalizer(lambda: mockserver.clear_expectation(f"{module_label}-resource"))
+    return _resource_info
+
+
+@pytest.fixture()
+def commit():
+    """Ensure no default resources are created"""
+
+
+@pytest.fixture(scope="module")
+def authorization(openshift, blame, envoy, module_label, rhsso, terms_and_conditions, cluster_info, admin_rhsso,
+                  resource_info, request):
+    """Creates AuthConfig object from template"""
+    with resources.path("testsuite.resources", "dinosaur_config.yaml") as path:
+        auth = openshift.new_app(path, {
+            "NAME": blame("ac"),
+            "NAMESPACE": openshift.project,
+            "LABEL": module_label,
+            "HOST": envoy.hostname,
+            "RHSSO_ISSUER": rhsso.well_known['issuer'],
+            "ADMIN_ISSUER": admin_rhsso.well_known["issuer"],
+            "TERMS_AND_CONDITIONS": terms_and_conditions("false"),
+            "CLUSTER_INFO": cluster_info(rhsso.client_name),
+            "RESOURCE_INFO": resource_info("123", rhsso.client_name)
+        })
+
+        def _delete():
+            auth.delete()
+
+        request.addfinalizer(_delete)
+        return auth
+
+
+@pytest.fixture(scope="module")
+def user_with_valid_org_id(rhsso, blame):
+    """
+    Creates new user with valid middle name.
+    Middle name is mapped to org ID in auth config.
+    """
+    user = rhsso.realm.create_user(blame("someuser"), blame("password"))
+    user.assign_attribute({"middleName": "123"})
+    return HttpxOidcClientAuth.from_user(rhsso.get_token, user=user)
+
+
+@pytest.fixture(scope="module", params=["321", None])
+def user_with_invalid_org_id(rhsso, blame, request):
+    """
+    Creates new user with valid middle name.
+    Middle name is mapped to org ID in auth config.
+    """
+    user = rhsso.realm.create_user(blame("someuser"), blame("password"))
+    user.assign_attribute({"middleName": request.param})
+    return HttpxOidcClientAuth.from_user(rhsso.get_token, user=user)
+
+
+@pytest.fixture(scope="module")
+def user_with_invalid_email(rhsso, blame):
+    """Creates new user with invalid email"""
+    user = rhsso.realm.create_user(blame("someuser"), blame("password"), email="denied-test-user1@example.com")
+    user.assign_attribute({"middleName": "123"})
+    return HttpxOidcClientAuth.from_user(rhsso.get_token, user=user)
+
+
+@pytest.fixture(scope="module")
+def user_with_full_role(admin_rhsso, blame):
+    """Creates new user and adds him into realm_role"""
+    user = admin_rhsso.realm.create_user(blame("someuser"), blame("password"))
+    user.assign_realm_role(admin_rhsso.realm.create_realm_role("admin-full"))
+    return HttpxOidcClientAuth.from_user(admin_rhsso.get_token, user=user)
+
+
+@pytest.fixture(scope="module")
+def user_with_read_role(admin_rhsso, blame):
+    """Creates new user and adds him into realm_role"""
+    user = admin_rhsso.realm.create_user(blame("someuser"), blame("password"))
+    user.assign_realm_role(admin_rhsso.realm.create_realm_role("admin-read"))
+    return HttpxOidcClientAuth.from_user(admin_rhsso.get_token, user=user)
+
+
+@pytest.fixture(scope="module")
+def user_with_write_role(admin_rhsso, blame):
+    """Creates new user and adds him into realm_role"""
+    user = admin_rhsso.realm.create_user(blame("someuser"), blame("password"))
+    user.assign_realm_role(admin_rhsso.realm.create_realm_role("admin-write"))
+    return HttpxOidcClientAuth.from_user(admin_rhsso.get_token, user=user)

--- a/testsuite/tests/kuadrant/authorino/dinosaur/test_auth_config.py
+++ b/testsuite/tests/kuadrant/authorino/dinosaur/test_auth_config.py
@@ -1,0 +1,276 @@
+"""
+Test for complex AuthConfig
+"""
+
+import pytest
+
+ERROR_MESSAGE = {'kind': 'Error', 'id': '403', 'href': '/api/dinosaurs_mgmt/v1/errors/403',
+                 'code': 'DINOSAURS-MGMT-403',
+                 'reason': 'Forbidden'}
+
+
+def test_deny_email(client, user_with_invalid_email):
+    """
+    Test:
+        - send request using user with invalid email
+        - assert that response status code is 403
+    """
+    response = client.get("/anything/dinosaurs_mgmt/v1/dinosaurs", auth=user_with_invalid_email)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+
+def test_allow_org_id(client, user_with_valid_org_id):
+    """
+    Test:
+        - send request using user with valid middle name
+        - assert that response status code is 200
+    """
+    response = client.get("/anything/dinosaurs_mgmt/v1/dinosaurs", auth=user_with_valid_org_id)
+    assert response.status_code == 200
+
+
+def test_deny_invalid_org_id(client, user_with_invalid_org_id):
+    """
+    Test:
+        - send request using user with invalid middle name
+        - assert that response status code is 200
+    """
+    response = client.get("/anything/dinosaurs_mgmt/v1/dinosaurs", auth=user_with_invalid_org_id)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+
+@pytest.mark.parametrize("user", ["user_with_full_role", "user_with_read_role",
+                                  "user_with_write_role"])
+def test_admin_sso_get(client, user_with_valid_org_id, user, request):
+    """
+    Test:
+        - send request using user without role
+        - assert that response status code is 403
+        - send request using user with specific role
+        - assert that response status code is 200
+    """
+    auth = request.getfixturevalue(user)
+    response = client.get("/anything/dinosaurs_mgmt/v1/admin", auth=user_with_valid_org_id)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+    response = client.get("/anything/dinosaurs_mgmt/v1/admin", auth=auth)
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize("user", ["user_with_full_role", "user_with_write_role"])
+def test_admin_sso_patch(client, user_with_valid_org_id, user, request):
+    """
+    Test:
+        - send request using user without role
+        - assert that response status code is 403
+        - send request using user with specific role
+        - assert that response status code is 200
+    """
+    auth = request.getfixturevalue(user)
+    response = client.patch("/anything/dinosaurs_mgmt/v1/admin", auth=user_with_valid_org_id)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+    response = client.patch("/anything/dinosaurs_mgmt/v1/admin", auth=auth)
+    assert response.status_code == 200
+
+
+def test_admin_sso_patch_deny(client, user_with_read_role):
+    """
+    Test:
+        - send request using user with unsupported role
+        - assert that response status code is 403
+    """
+    response = client.patch("/anything/dinosaurs_mgmt/v1/admin", auth=user_with_read_role)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+
+def test_admin_sso_delete(client, user_with_valid_org_id, user_with_full_role):
+    """
+    Test:
+        - send request using user without role
+        - assert that response status code is 403
+        - send request using user with specific role
+        - assert that response status code is 200
+    """
+    response = client.delete("/anything/dinosaurs_mgmt/v1/admin", auth=user_with_valid_org_id)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+    response = client.delete("/anything/dinosaurs_mgmt/v1/admin", auth=user_with_full_role)
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize("user", ["user_with_read_role", "user_with_write_role"])
+def test_admin_sso_delete_deny(client, user, request):
+    """
+    Test:
+        - send request using user with unsupported role
+        - assert that response status code is 403
+    """
+    auth = request.getfixturevalue(user)
+    response = client.delete("/anything/dinosaurs_mgmt/v1/admin", auth=auth)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+
+def test_authz(client, user_with_valid_org_id):
+    """
+    Test:
+        - send request to internal authz-metadata endpoint
+        - assert that response status code is 403
+    """
+    response = client.get("/anything/dinosaurs_mgmt/v1/authz-metadata", auth=user_with_valid_org_id)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+
+def test_create(client, user_with_valid_org_id, terms_and_conditions):
+    """
+    Test:
+        - send request to dinosaurs endpoint that doesn't request terms and conditions
+        - assert that response status code is 200
+        - send request to dinosaurs endpoint that does request terms and conditions
+        - assert that response status code is 403
+    """
+    terms_and_conditions("false")
+    response = client.post("/anything/dinosaurs_mgmt/v1/dinosaurs", auth=user_with_valid_org_id)
+    assert response.status_code == 200
+
+    terms_and_conditions("true")
+    response = client.post("/anything/dinosaurs_mgmt/v1/dinosaurs", auth=user_with_valid_org_id)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+
+def test_metrics_federate(client, user_with_valid_org_id, user_with_invalid_org_id):
+    """
+    Test:
+        - send request to metrics endpoint using user with valid middle name
+        - assert that response status code is 200
+        - send request to metrics endpoint using user with invalid middle name
+        - assert that response status code is 403
+    """
+    response = client.get("/anything/dinosaurs_mgmt/v1/dinosaurs/metrics/federate", auth=user_with_valid_org_id)
+    assert response.status_code == 200
+
+    response = client.get("/anything/dinosaurs_mgmt/v1/dinosaurs/metrics/federate", auth=user_with_invalid_org_id)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+
+def test_service_accounts(client, user_with_valid_org_id, user_with_invalid_org_id):
+    """
+    Test:
+        - send request to service accounts endpoint using user with valid middle name
+        - assert that response status code is 200
+        - send request to service accounts endpoint using user with invalid middle name
+        - assert that response status code is 403
+    """
+    response = client.get("/anything/dinosaurs_mgmt/v1/service_accounts", auth=user_with_valid_org_id)
+    assert response.status_code == 200
+
+    response = client.get("/anything/dinosaurs_mgmt/v1/service_accounts", auth=user_with_invalid_org_id)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+
+def test_instance_types(client, user_with_valid_org_id, user_with_invalid_org_id):
+    """
+    Test:
+        - send request to instance types endpoint using user with valid middle name
+        - assert that response status code is 200
+        - send request to instance types endpoint using user with invalid middle name
+        - assert that response status code is 403
+    """
+    response = client.get("/anything/dinosaurs_mgmt/v1/instance_types", auth=user_with_valid_org_id)
+    assert response.status_code == 200
+
+    response = client.get("/anything/dinosaurs_mgmt/v1/instance_types", auth=user_with_invalid_org_id)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+
+def test_agent_clusters(client, user_with_valid_org_id, rhsso, cluster_info):
+    """
+    Test:
+        - send request to agent clusters endpoint with valid cluster info
+        - assert that response status code is 200
+        - send request to agent clusters endpoint with invalid cluster info
+        - assert that response status code is 403
+    """
+    cluster_info(rhsso.client_name)
+    response = client.get("/anything/dinosaurs_mgmt/v1/agent-clusters", auth=user_with_valid_org_id)
+    assert response.status_code == 200
+
+    cluster_info("invalid")
+    response = client.get("/anything/dinosaurs_mgmt/v1/agent-clusters", auth=user_with_valid_org_id)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+
+def test_resource_is_owner(client, user_with_valid_org_id, resource_info, rhsso):
+    """
+    Test:
+        - set resource info to valid middle name
+        - send requests (GET, DELETE and POST) to dinosaur resource using user with valid midlle name
+        - assert that response status code is 200
+    """
+    resource_info("123", rhsso.client_name)
+
+    response = client.get("/anything/dinosaurs_mgmt/v1/dinosaurs/123", auth=user_with_valid_org_id)
+    assert response.status_code == 200
+
+    response = client.delete("/anything/dinosaurs_mgmt/v1/dinosaurs/123", auth=user_with_valid_org_id)
+    assert response.status_code == 200
+
+    response = client.patch("/anything/dinosaurs_mgmt/v1/dinosaurs/123", auth=user_with_valid_org_id)
+    assert response.status_code == 200
+
+
+def test_resource_is_not_owner_client_denied(client, user_with_invalid_email, resource_info, rhsso):
+    """
+    Test:
+        - set resource info to valid middle name
+        - send requests (GET, DELETE and POST) to dinosaur resource using user with invalid midlle name
+        - assert that response status code is 403
+    """
+    resource_info("123", rhsso.client_name)
+
+    response = client.get("/anything/dinosaurs_mgmt/v1/dinosaurs/123", auth=user_with_invalid_email)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+    response = client.delete("/anything/dinosaurs_mgmt/v1/dinosaurs/123", auth=user_with_invalid_email)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+    response = client.patch("/anything/dinosaurs_mgmt/v1/dinosaurs/123", auth=user_with_invalid_email)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+
+def test_resource_is_not_owner_resource_denied(client, user_with_valid_org_id, resource_info, rhsso):
+    """
+    Test:
+        - set resource info to invalid middle name
+        - send requests (GET, DELETE and POST) to dinosaur resource using user with valid midlle name
+        - assert that response status code is 403
+    """
+    resource_info("321", rhsso.client_name)
+
+    response = client.get("/anything/dinosaurs_mgmt/v1/dinosaurs/123", auth=user_with_valid_org_id)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+    response = client.delete("/anything/dinosaurs_mgmt/v1/dinosaurs/123", auth=user_with_valid_org_id)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE
+
+    response = client.patch("/anything/dinosaurs_mgmt/v1/dinosaurs/123", auth=user_with_valid_org_id)
+    assert response.status_code == 403
+    assert response.json() == ERROR_MESSAGE


### PR DESCRIPTION
This PR adds tests for complex AuthConfig based on https://github.com/guicassolato/kas-fleet-manager-authorino/blob/main/kas-fleet-manager-authconfig.yaml
#153 needs to be merged first
Resolves #152 