### PR TITLE
Add support for Kuadrants AuthPolicy

### DIFF
--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -33,3 +33,9 @@
 #    url: ""                                     # URL for already deployed Authorino
 #  envoy:
 #    image: "docker.io/envoyproxy/envoy:v1.23-latest"  # Envoy image, the testsuite should use, only for Authorino tests now
+#  kuadrant:
+#    enabled: true                               # True, if Testsuite should test Kuadrant instead of individual operators
+#    namespace: "kuadrant"                       # Namespaces where Kuadrant resides
+#    gateway:                                    # Reference to Gateway that should be used
+#       namespace: "istio-system"
+#       name: "istio-ingressgateway"

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -14,3 +14,9 @@ default:
     log_level: "debug"
   envoy:
     image: "docker.io/envoyproxy/envoy:v1.23-latest"
+  kuadrant:
+    enabled: true
+    project: "kuadrant"
+    gateway:
+       project: "istio-system"
+       name: "istio-ingressgateway"

--- a/testsuite/config/__init__.py
+++ b/testsuite/config/__init__.py
@@ -32,7 +32,8 @@ settings = Dynaconf(
         DefaultValueValidator("rhsso.url", default=fetch_route("no-ssl-sso")),
         DefaultValueValidator("rhsso.password", default=fetch_secret("credential-sso", "ADMIN_PASSWORD")),
         DefaultValueValidator("mockserver.url", default=fetch_route("mockserver", force_http=True)),
+        Validator("kuadrant.enable", must_exist=False, eq=False) | Validator("kuadrant.gateway.name", must_exist=True),
     ],
-    validate_only=["authorino"],
+    validate_only=["authorino", "kuadrant"],
     loaders=["dynaconf.loaders.env_loader", "testsuite.config.openshift_loader"]
 )

--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -4,6 +4,7 @@ import enum
 import os
 from functools import cached_property
 from typing import Dict, Optional
+from urllib.parse import urlparse
 
 import openshift as oc
 from openshift import Context, Selector, OpenShiftPythonException
@@ -34,7 +35,7 @@ class OpenShiftClient:
         self.token = token
         self._kubeconfig_path = kubeconfig_path
 
-    def change_project(self, project):
+    def change_project(self, project) -> "OpenShiftClient":
         """Return new OpenShiftClient with a different project"""
         return OpenShiftClient(project, self._api_url, self.token, self._kubeconfig_path)
 
@@ -55,6 +56,12 @@ class OpenShiftClient:
         """Returns real API url"""
         with self.context:
             return oc.whoami("--show-server=true")
+
+    @cached_property
+    def apps_url(self):
+        """Return URL under which all routes are routed"""
+        hostname = urlparse(self.api_url).hostname
+        return "apps." + hostname.split(".", 1)[1]
 
     @property
     def project(self):

--- a/testsuite/openshift/envoy.py
+++ b/testsuite/openshift/envoy.py
@@ -32,12 +32,12 @@ class Envoy(Proxy):
                 .narrow(lambda route: route.model.metadata.name == self.name)\
                 .object(cls=OpenshiftRoute)
 
-    def add_hostname(self, name) -> tuple[Route, str]:
+    def add_hostname(self, name) -> str:
         """Add another hostname that points to this Envoy"""
         route = OpenshiftRoute(dict_to_model=self.openshift.routes.expose(name, self.name).as_dict())
         with self.openshift.context:
             self.envoy_objects = self.envoy_objects.union(route.self_selector())
-        return route, route.hostnames[0]
+        return route.hostnames[0]
 
     @cached_property
     def hostname(self):

--- a/testsuite/openshift/httpbin.py
+++ b/testsuite/openshift/httpbin.py
@@ -4,9 +4,10 @@ from importlib import resources
 
 from testsuite.objects import LifecycleObject
 from testsuite.openshift.client import OpenShiftClient
+from testsuite.openshift.objects.gateway_api import Referencable
 
 
-class Httpbin(LifecycleObject):
+class Httpbin(LifecycleObject, Referencable):
     """Httpbin deployed in OpenShift through template"""
     def __init__(self, openshift: OpenShiftClient, name, label) -> None:
         super().__init__()
@@ -19,6 +20,9 @@ class Httpbin(LifecycleObject):
     @property
     def reference(self):
         return {
+            "group": "",
+            "kind": "Service",
+            "port": 8080,
             "name": self.name,
             "namespace": self.openshift.project
         }

--- a/testsuite/openshift/httpbin.py
+++ b/testsuite/openshift/httpbin.py
@@ -17,6 +17,13 @@ class Httpbin(LifecycleObject):
         self.httpbin_objects = None
 
     @property
+    def reference(self):
+        return {
+            "name": self.name,
+            "namespace": self.openshift.project
+        }
+
+    @property
     def url(self):
         """URL for the httpbin service"""
         return f"{self.name}.{self.openshift.project}.svc.cluster.local"

--- a/testsuite/openshift/objects/auth_config/__init__.py
+++ b/testsuite/openshift/objects/auth_config/__init__.py
@@ -7,6 +7,7 @@ from testsuite.openshift.client import OpenShiftClient
 from testsuite.openshift.objects import OpenShiftObject, modify
 from .sections import AuthorizationsSection, IdentitySection, MetadataSection, \
     ResponsesSection
+from ..route import Route
 
 
 class AuthConfig(OpenShiftObject, Authorization):
@@ -33,7 +34,7 @@ class AuthConfig(OpenShiftObject, Authorization):
         return ResponsesSection(self, "response")
 
     @classmethod
-    def create_instance(cls, openshift: OpenShiftClient, name, host, labels: Dict[str, str] = None):
+    def create_instance(cls, openshift: OpenShiftClient, name, route: Route, labels: Dict[str, str] = None):
         """Creates base instance"""
         model: Dict = {
             "apiVersion": "authorino.kuadrant.io/v1beta1",
@@ -43,7 +44,7 @@ class AuthConfig(OpenShiftObject, Authorization):
                 "namespace": openshift.project
             },
             "spec": {
-                "hosts": [host]
+                "hosts": route.hostnames
             }
         }
 

--- a/testsuite/openshift/objects/auth_config/auth_policy.py
+++ b/testsuite/openshift/objects/auth_config/auth_policy.py
@@ -1,0 +1,42 @@
+"""Module containing classes related to Auth Policy"""
+from typing import Dict
+
+from testsuite.openshift.client import OpenShiftClient
+from testsuite.openshift.objects.auth_config import AuthConfig
+from testsuite.openshift.objects.gateway_api import Referencable
+
+
+class AuthPolicy(AuthConfig):
+    """AuthPolicy object, it serves as Kuadrants AuthConfig"""
+
+    @property
+    def auth_section(self):
+        return self.model.spec.setdefault("authScheme", {})
+
+    # pylint: disable=unused-argument
+    @classmethod
+    def create_instance(  # type: ignore
+        cls,
+        openshift: OpenShiftClient,
+        name,
+        route: Referencable,
+        labels: Dict[str, str] = None,
+        hostnames=None,
+    ):
+        """Creates base instance"""
+        model: Dict = {
+            "apiVersion": "kuadrant.io/v1beta1",
+            "kind": "AuthPolicy",
+            "metadata": {
+                "name": name,
+                "namespace": openshift.project,
+            },
+            "spec": {
+                "targetRef": route.reference,
+            },
+        }
+
+        if labels is not None:
+            model["metadata"]["labels"] = labels
+
+        return cls(model, context=openshift.context)

--- a/testsuite/openshift/objects/auth_config/sections.py
+++ b/testsuite/openshift/objects/auth_config/sections.py
@@ -1,14 +1,17 @@
 """AuthConfig CR object"""
 from dataclasses import asdict
-from typing import Dict, Literal, Iterable
+from typing import Dict, Literal, Iterable, TYPE_CHECKING
 
 from testsuite.objects import Identities, Metadata, Responses, MatchExpression, Authorizations, Rule, Cache, Value
-from testsuite.openshift.objects import OpenShiftObject, modify
+from testsuite.openshift.objects import modify
+
+if TYPE_CHECKING:
+    from testsuite.openshift.objects.auth_config import AuthConfig
 
 
 class Section:
     """Common class for all Sections"""
-    def __init__(self, obj: OpenShiftObject, section_name) -> None:
+    def __init__(self, obj: "AuthConfig", section_name) -> None:
         super().__init__()
         self.obj = obj
         self.section_name = section_name
@@ -27,7 +30,7 @@ class Section:
     @property
     def section(self):
         """The actual dict section which will be edited"""
-        return self.obj.model.spec.setdefault(self.section_name, [])
+        return self.obj.auth_section.setdefault(self.section_name, [])
 
     def add_item(self, name, value, priority: int = None, when: Iterable[Rule] = None,
                  metrics: bool = None, cache: Cache = None):

--- a/testsuite/openshift/objects/gateway_api/__init__.py
+++ b/testsuite/openshift/objects/gateway_api/__init__.py
@@ -1,0 +1,129 @@
+"""Module containing all Gateway API related classes"""
+import typing
+from abc import ABC, abstractmethod
+from functools import cached_property
+
+from openshift import Selector
+
+from testsuite.httpx import HttpxBackoffClient
+from testsuite.openshift.client import OpenShiftClient
+from testsuite.openshift.objects import OpenShiftObject, modify
+from testsuite.openshift.objects.proxy import Proxy
+from testsuite.openshift.objects.route import Route
+from testsuite.utils import randomize
+
+if typing.TYPE_CHECKING:
+    from testsuite.openshift.httpbin import Httpbin
+
+
+class Referencable(ABC):
+    """Object that can be referenced in Gateway API style"""
+
+    @property
+    @abstractmethod
+    def reference(self) -> dict[str, str]:
+        """
+        Returns dict, which can be used as reference in Gateway API Objects.
+        https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.ParentReference
+        """
+
+
+class HTTPRoute(OpenShiftObject, Referencable, Route):
+    """HTTPRoute object, serves as replacement for Routes and Ingresses"""
+
+    @cached_property
+    def hostnames(self):
+        return self.model.spec.hostnames
+
+    @classmethod
+    def create_instance(
+        cls,
+        openshift: OpenShiftClient,
+        name,
+        parent: Referencable,
+        hostname,
+        backend: "Httpbin",
+        labels: dict[str, str] = None,
+    ):
+        """Creates new instance of HTTPRoute"""
+        model = {
+            "apiVersion": "gateway.networking.k8s.io/v1alpha2",
+            "kind": "HTTPRoute",
+            "metadata": {"name": name, "namespace": openshift.project},
+            "spec": {
+                "parentRefs": [parent.reference],
+                "hostnames": [hostname],
+                "rules": [{"backendRefs": [backend.reference]}],
+            },
+        }
+
+        if labels is not None:
+            model["metadata"]["labels"] = labels  # type: ignore
+
+        return cls(model, context=openshift.context)
+
+    @property
+    def reference(self):
+        return {
+            "group": "gateway.networking.k8s.io",
+            "kind": "HTTPRoute",
+            "name": self.name(),
+            "namespace": self.namespace(),
+        }
+
+    @modify
+    def add_hostname(self, hostname):
+        """Adds hostname to the Route"""
+        self.model.spec.hostnames.append(hostname)
+
+
+# pylint: disable=too-many-instance-attributes
+class Gateway(Referencable, Proxy):
+    """Gateway object already present on the server"""
+
+    def __init__(self, openshift: OpenShiftClient, name, namespace, label, httpbin: "Httpbin") -> None:
+        super().__init__()
+        self.openshift = openshift
+        self.system_openshift = openshift.change_project(namespace)
+        self.name = name
+        self.label = label
+        self.namespace = namespace
+        self.httpbin = httpbin
+
+        self._route: HTTPRoute = None  # type: ignore
+        self._selector: Selector = None  # type: ignore
+
+    def _expose_route(self, name, service):
+        return self.system_openshift.routes.expose(name, service, port=8080)
+
+    @cached_property
+    def route(self) -> HTTPRoute:
+        return self._route
+
+    def add_hostname(self, name) -> str:
+        route = self._expose_route(name, self.name)
+        self._selector.union(route.self_selector())
+        self.route.add_hostname(route.model.spec.host)
+        return route.model.spec.host
+
+    def client(self, **kwargs):
+        """Return Httpx client for the requests to this backend"""
+        return HttpxBackoffClient(base_url=f"http://{self.route.hostnames[0]}", **kwargs)
+
+    def commit(self):
+        name = randomize(self.name)
+        route = self._expose_route(name, self.name)
+        self._selector = route.self_selector()
+
+        self._route = HTTPRoute.create_instance(
+            self.openshift, name, self, route.model.spec.host, self.httpbin, {"app": self.label}
+        )
+        self._route.commit()
+
+    def delete(self):
+        self._route.delete()
+        self._selector.delete()
+
+    @property
+    def reference(self):
+        return {"group": "gateway.networking.k8s.io", "kind": "Gateway", "name": self.name, "namespace": self.namespace}

--- a/testsuite/openshift/objects/proxy.py
+++ b/testsuite/openshift/objects/proxy.py
@@ -17,7 +17,7 @@ class Proxy(LifecycleObject):
         """Returns default route for the proxy"""
 
     @abstractmethod
-    def add_hostname(self, name) -> tuple[Route, str]:
+    def add_hostname(self, name) -> str:
         """Add another hostname that points to this Proxy"""
 
     @abstractmethod

--- a/testsuite/openshift/objects/proxy.py
+++ b/testsuite/openshift/objects/proxy.py
@@ -1,0 +1,25 @@
+"""Module containing Proxy related stuff"""
+from abc import abstractmethod
+from functools import cached_property
+
+from httpx import Client
+
+from testsuite.objects import LifecycleObject
+from testsuite.openshift.objects.route import Route
+
+
+class Proxy(LifecycleObject):
+    """Abstraction layer for a Proxy sitting between end-user and Authorino/Limitador"""
+
+    @cached_property
+    @abstractmethod
+    def route(self) -> Route:
+        """Returns default route for the proxy"""
+
+    @abstractmethod
+    def add_hostname(self, name) -> tuple[Route, str]:
+        """Add another hostname that points to this Proxy"""
+
+    @abstractmethod
+    def client(self, **kwargs) -> Client:
+        """Return Httpx client for the requests to this backend"""

--- a/testsuite/openshift/objects/route.py
+++ b/testsuite/openshift/objects/route.py
@@ -10,12 +10,12 @@ class Route(ABC):
 
     @cached_property
     @abstractmethod
-    def hostname(self):
-        """Returns Route hostname"""
+    def hostnames(self) -> list[str]:
+        """Returns all Route hostnames"""
 
 
 class OpenshiftRoute(OpenShiftObject, Route):
     """Openshift Route object"""
     @cached_property
-    def hostname(self):
-        return self.model.spec.host
+    def hostnames(self):
+        return [self.model.spec.host]

--- a/testsuite/openshift/objects/route.py
+++ b/testsuite/openshift/objects/route.py
@@ -1,0 +1,21 @@
+"""Module containing Route related stuff"""
+from abc import ABC, abstractmethod
+from functools import cached_property
+
+from testsuite.openshift.objects import OpenShiftObject
+
+
+class Route(ABC):
+    """Abstraction layer for Route/Ingress/HTTPRoute"""
+
+    @cached_property
+    @abstractmethod
+    def hostname(self):
+        """Returns Route hostname"""
+
+
+class OpenshiftRoute(OpenShiftObject, Route):
+    """Openshift Route object"""
+    @cached_property
+    def hostname(self):
+        return self.model.spec.host

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -202,7 +202,7 @@ def backend(request, openshift, blame, label):
 @pytest.fixture(scope="module")
 def envoy(request, authorino, openshift, blame, backend, module_label, testconfig):
     """Deploys Envoy that wire up the Backend behind the reverse-proxy and Authorino instance"""
-    envoy = Envoy(openshift, authorino, blame("envoy"), module_label, backend.url, testconfig["envoy"]["image"])
+    envoy = Envoy(openshift, authorino, blame("envoy"), module_label, backend, testconfig["envoy"]["image"])
     request.addfinalizer(envoy.delete)
     envoy.commit()
     return envoy

--- a/testsuite/tests/kuadrant/authorino/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/conftest.py
@@ -48,7 +48,7 @@ def authorization(authorization, oidc_provider, authorino, envoy, blame, openshi
     """In case of Authorino, AuthConfig used for authorization"""
     if authorization is None:
         authorization = AuthConfig.create_instance(openshift, blame("ac"),
-                                                   envoy.hostname, labels={"testRun": module_label})
+                                                   envoy.route, labels={"testRun": module_label})
     authorization.identity.oidc("rhsso", oidc_provider.well_known["issuer"])
     return authorization
 

--- a/testsuite/tests/kuadrant/authorino/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/conftest.py
@@ -49,7 +49,7 @@ def authorization(authorization, oidc_provider, authorino, envoy, blame, openshi
     if authorization is None:
         authorization = AuthConfig.create_instance(openshift, blame("ac"),
                                                    envoy.route, labels={"testRun": module_label})
-    authorization.identity.oidc("rhsso", oidc_provider.well_known["issuer"])
+        authorization.identity.oidc("rhsso", oidc_provider.well_known["issuer"])
     return authorization
 
 

--- a/testsuite/tests/kuadrant/authorino/identity/anonymous/test_anonymous_context.py
+++ b/testsuite/tests/kuadrant/authorino/identity/anonymous/test_anonymous_context.py
@@ -20,5 +20,5 @@ def test_anonymous_context(client):
         - Assert that response has the right information in context
     """
     response = client.get("/get")
-    assert json.loads(response.json()["headers"]["Auth-Json"])["auth"]
     assert response.status_code == 200
+    assert json.loads(response.json()["headers"]["Auth-Json"])["auth"]

--- a/testsuite/tests/kuadrant/authorino/identity/api_key/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/identity/api_key/conftest.py
@@ -5,6 +5,12 @@ from testsuite.httpx.auth import HeaderApiKeyAuth
 
 
 @pytest.fixture(scope="module")
+def run_on_kuadrant():
+    """Secrets are not correctly reconciled https://github.com/Kuadrant/kuadrant-operator/issues/127"""
+    return False
+
+
+@pytest.fixture(scope="module")
 def api_key(create_api_key, module_label):
     """Creates API key Secret"""
     api_key = "api_key_value"

--- a/testsuite/tests/kuadrant/authorino/identity/api_key/test_auth_credentials.py
+++ b/testsuite/tests/kuadrant/authorino/identity/api_key/test_auth_credentials.py
@@ -19,7 +19,7 @@ def credentials(request):
 def authorization(openshift, blame, envoy, module_label, credentials):
     """Add API key identity to AuthConfig"""
     authorization = AuthConfig.create_instance(openshift, blame("ac"),
-                                               envoy.hostname, labels={"testRun": module_label})
+                                               envoy.route, labels={"testRun": module_label})
     authorization.identity.api_key("api_key", match_label=module_label, credentials=credentials,
                                    selector="API_KEY")
     return authorization

--- a/testsuite/tests/kuadrant/authorino/identity/rhsso/test_auth_credentials.py
+++ b/testsuite/tests/kuadrant/authorino/identity/rhsso/test_auth_credentials.py
@@ -19,7 +19,7 @@ def credentials(request):
 def authorization(rhsso, openshift, blame, envoy, module_label, credentials):
     """Add RHSSO identity to AuthConfig"""
     authorization = AuthConfig.create_instance(openshift, blame("ac"),
-                                               envoy.hostname, labels={"testRun": module_label})
+                                               envoy.route, labels={"testRun": module_label})
     authorization.identity.oidc("rhsso", rhsso.well_known["issuer"], credentials, "Token")
     return authorization
 

--- a/testsuite/tests/kuadrant/authorino/metadata/test_uma.py
+++ b/testsuite/tests/kuadrant/authorino/metadata/test_uma.py
@@ -27,6 +27,12 @@ allow {
 """
 
 
+@pytest.fixture(scope="module")
+def run_on_kuadrant():
+    """Secrets are not correctly reconciled https://github.com/Kuadrant/kuadrant-operator/issues/127"""
+    return False
+
+
 @pytest.fixture(scope="module", autouse=True)
 def client_secret(create_client_secret, rhsso):
     """Creates a required secret, used by Authorino to start the authentication with the UMA registry."""

--- a/testsuite/tests/kuadrant/authorino/multiple_hosts/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/multiple_hosts/conftest.py
@@ -13,7 +13,8 @@ def hostname(envoy):
 @pytest.fixture(scope="module")
 def second_hostname(envoy, blame):
     """Second valid hostname"""
-    return envoy.create_route(blame('second')).model.spec.host
+    _, hostname = envoy.add_hostname(blame('second'))
+    return hostname
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/kuadrant/authorino/multiple_hosts/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/multiple_hosts/conftest.py
@@ -5,6 +5,12 @@ from testsuite.httpx import HttpxBackoffClient
 
 
 @pytest.fixture(scope="module")
+def run_on_kuadrant():
+    """Handling of hosts needs to be rewritten"""
+    return False
+
+
+@pytest.fixture(scope="module")
 def hostname(envoy):
     """Original hostname"""
     return envoy.hostname
@@ -13,8 +19,7 @@ def hostname(envoy):
 @pytest.fixture(scope="module")
 def second_hostname(envoy, blame):
     """Second valid hostname"""
-    _, hostname = envoy.add_hostname(blame('second'))
-    return hostname
+    return envoy.add_hostname(blame('second'))
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/kuadrant/authorino/operator/clusterwide/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/clusterwide/conftest.py
@@ -13,14 +13,14 @@ def authorino_parameters():
 @pytest.fixture(scope="module")
 def hostname2(envoy, blame):
     """Second route for the envoy"""
-    _, hostname = envoy.add_hostname(blame("route"))
-    return hostname
+    return envoy.add_hostname(blame("route"))
 
 
 @pytest.fixture(scope="module")
 def authorization2(hostname2, blame, openshift2, module_label, oidc_provider):
     """Second valid hostname"""
-    auth = AuthConfig.create_instance(openshift2, blame("ac"), hostname2, labels={"testRun": module_label})
+    route, _ = hostname2
+    auth = AuthConfig.create_instance(openshift2, blame("ac"), route, labels={"testRun": module_label})
     auth.identity.oidc("rhsso", oidc_provider.well_known["issuer"])
     return auth
 
@@ -28,8 +28,9 @@ def authorization2(hostname2, blame, openshift2, module_label, oidc_provider):
 @pytest.fixture(scope="module")
 def client2(hostname2, envoy):
     """Client for second AuthConfig"""
+    _, hostname = hostname2
     client = envoy.client()
-    client.base_url = f"http://{hostname2}"
+    client.base_url = f"http://{hostname}"
     yield client
     client.close()
 

--- a/testsuite/tests/kuadrant/authorino/operator/clusterwide/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/clusterwide/conftest.py
@@ -13,7 +13,8 @@ def authorino_parameters():
 @pytest.fixture(scope="module")
 def hostname2(envoy, blame):
     """Second route for the envoy"""
-    return envoy.create_route(blame("route")).model.spec.host
+    _, hostname = envoy.add_hostname(blame("route"))
+    return hostname
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/kuadrant/authorino/operator/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/conftest.py
@@ -1,0 +1,8 @@
+"""Module containing common features of all Operator tests"""
+import pytest
+
+
+@pytest.fixture(scope="module")
+def run_on_kuadrant():
+    """Kuadrant doesn't allow customization of Authorino parameters"""
+    return False

--- a/testsuite/tests/kuadrant/authorino/operator/sharding/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/sharding/conftest.py
@@ -24,7 +24,7 @@ def authorization(request, authorino, blame, openshift, module_label):
     """In case of Authorino, AuthConfig used for authorization"""
 
     def _authorization(hostname=None, sharding_label=None):
-        auth = AuthConfig.create_instance(openshift, blame("ac"), hostname,
+        auth = AuthConfig.create_instance(openshift, blame("ac"), None, hostnames=[hostname],
                                           labels={"testRun": module_label, "sharding": sharding_label})
         auth.responses.add({"name": "header", "json": {"properties": [{"name": "anything", "value": sharding_label}]}})
         request.addfinalizer(auth.delete)

--- a/testsuite/tests/kuadrant/authorino/operator/sharding/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/sharding/conftest.py
@@ -10,7 +10,7 @@ def envoy(request, authorino, openshift, blame, backend, testconfig):
     """Envoy"""
 
     def _envoy(auth=authorino):
-        envoy = Envoy(openshift, auth, blame("envoy"), blame("label"), backend.url, testconfig["envoy"]["image"])
+        envoy = Envoy(openshift, auth, blame("envoy"), blame("label"), backend, testconfig["envoy"]["image"])
         request.addfinalizer(envoy.delete)
         envoy.commit()
         return envoy

--- a/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
@@ -145,7 +145,7 @@ def envoy(request, authorino, openshift, create_secret, blame, label, backend,
     envoy_ca_secret = create_secret(envoy_authority, "backendca", labels=authorino_labels)
     envoy_secret = create_secret(envoy_cert, "envoycert")
 
-    envoy = TLSEnvoy(openshift, authorino, blame("backend"), label, backend.url, testconfig["envoy"]["image"],
+    envoy = TLSEnvoy(openshift, authorino, blame("backend"), label, backend, testconfig["envoy"]["image"],
                      authorino_secret, envoy_ca_secret, envoy_secret)
     request.addfinalizer(envoy.delete)
     envoy.commit()

--- a/testsuite/tests/kuadrant/authorino/response/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/response/conftest.py
@@ -14,7 +14,7 @@ def responses():
 def authorization(openshift, blame, envoy, oidc_provider, responses, module_label):
     """Add response to Authorization"""
     authorization = AuthConfig.create_instance(openshift, blame("ac"),
-                                               envoy.hostname, labels={"testRun": module_label})
+                                               envoy.route, labels={"testRun": module_label})
     authorization.identity.oidc("rhsso", oidc_provider.well_known["issuer"])
     for response in responses:
         authorization.responses.add(response)

--- a/testsuite/tests/kuadrant/authorino/response/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/response/conftest.py
@@ -5,6 +5,12 @@ from testsuite.openshift.objects.auth_config import AuthConfig
 
 
 @pytest.fixture(scope="module")
+def run_on_kuadrant():
+    """Tests needs to be rewritten to not create special AuthConfig"""
+    return False
+
+
+@pytest.fixture(scope="module")
 def responses():
     """Returns responses to be added to the AuthConfig"""
     return []


### PR DESCRIPTION
# Overview

This PR adds the ability to run (most of) the authoring tests on Kuadrant. The actual tests are mostly unchanged, but everything else had to change in some mostly minor ways. Currently, around 43 out of 106 tests run on Kuadrant, and many need code changes that will come in subsequent PRs.

# Notable changes
* Add `Route` and `Proxy` interfaces
   * Kuadrant uses a different route and differently configured envoy than we do, so I added these interfaces to ensure compatibility with new Kuadrant classes.
   * Change some parameter types in said classes to ensure compatibility with the new ones.
* Add `run_on_kuadrant` fixture, which indicates that the test or module doesn't run on Kuadrant
* Add configuration options for Kuadrant deployment
  * It expects that Kuadrant and Gateway are already deployed.   