### PR TITLE
Enable response tests on Kuadrant

### DIFF
--- a/testsuite/tests/kuadrant/authorino/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/conftest.py
@@ -44,12 +44,13 @@ def authorino(authorino, openshift, blame, request, testconfig, module_label, au
 
 # pylint: disable=unused-argument
 @pytest.fixture(scope="module")
-def authorization(authorization, oidc_provider, authorino, envoy, blame, openshift, module_label) -> Authorization:
+def authorization(authorization, oidc_provider, authorino, envoy,
+                  authorization_name, openshift, module_label) -> Authorization:
     """In case of Authorino, AuthConfig used for authorization"""
     if authorization is None:
-        authorization = AuthConfig.create_instance(openshift, blame("ac"),
+        authorization = AuthConfig.create_instance(openshift, authorization_name,
                                                    envoy.route, labels={"testRun": module_label})
-        authorization.identity.oidc("rhsso", oidc_provider.well_known["issuer"])
+    authorization.identity.oidc("rhsso", oidc_provider.well_known["issuer"])
     return authorization
 
 

--- a/testsuite/tests/kuadrant/authorino/identity/auth/test_auth_identity.py
+++ b/testsuite/tests/kuadrant/authorino/identity/auth/test_auth_identity.py
@@ -19,6 +19,13 @@ def oidc_provider(request) -> OIDCProvider:
     return request.getfixturevalue(request.param)
 
 
+# pylint: disable=unused-argument
+@pytest.fixture(scope="module")
+def authorization_name(blame, oidc_provider):
+    """Ensure for every oidc_provider we have a unique authorization"""
+    return blame("authz")
+
+
 @pytest.fixture(scope="module")
 def wrong_auth(oidc_provider, auth0, rhsso):
     """Different (but valid) auth than was configured"""

--- a/testsuite/tests/kuadrant/authorino/response/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/response/conftest.py
@@ -1,14 +1,6 @@
 """Conftest for custom Response tests"""
 import pytest
 
-from testsuite.openshift.objects.auth_config import AuthConfig
-
-
-@pytest.fixture(scope="module")
-def run_on_kuadrant():
-    """Tests needs to be rewritten to not create special AuthConfig"""
-    return False
-
 
 @pytest.fixture(scope="module")
 def responses():
@@ -16,12 +8,16 @@ def responses():
     return []
 
 
+# pylint: disable=unused-argument
 @pytest.fixture(scope="module")
-def authorization(openshift, blame, envoy, oidc_provider, responses, module_label):
+def authorization_name(blame, responses):
+    """Ensure for every response we have a unique authorization"""
+    return blame("authz")
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization, responses):
     """Add response to Authorization"""
-    authorization = AuthConfig.create_instance(openshift, blame("ac"),
-                                               envoy.route, labels={"testRun": module_label})
-    authorization.identity.oidc("rhsso", oidc_provider.well_known["issuer"])
     for response in responses:
         authorization.responses.add(response)
     return authorization

--- a/testsuite/tests/kuadrant/conftest.py
+++ b/testsuite/tests/kuadrant/conftest.py
@@ -28,14 +28,18 @@ def authorino(kuadrant, skip_no_kuadrant):
     return None
 
 
-# pylint: disable=unused-argument
 @pytest.fixture(scope="module")
-def authorization(authorino, kuadrant, oidc_provider, envoy, blame, openshift, module_label):
+def authorization_name(blame):
+    """Name of the Authorization resource, can be overriden to include more dependencies"""
+    return blame("authz")
+
+
+@pytest.fixture(scope="module")
+def authorization(authorino, kuadrant, envoy, authorization_name, openshift, module_label):
     """Authorization object (In case of Kuadrant AuthPolicy)"""
     if kuadrant:
-        policy = AuthPolicy.create_instance(openshift,
-                                            blame("policy"), envoy.route, labels={"testRun": module_label})
-        policy.identity.oidc("rhsso", oidc_provider.well_known["issuer"])
+        policy = AuthPolicy.create_instance(openshift, authorization_name,
+                                            envoy.route, labels={"testRun": module_label})
         return policy
     return None
 


### PR DESCRIPTION
Requires #158. Adds `authorization_name` fixture, which enables parametrization of `Authorization` without recreating it.