### PR TITLE
Enable multiple_host test on Kuadrant

### DIFF
--- a/testsuite/openshift/objects/gateway_api/__init__.py
+++ b/testsuite/openshift/objects/gateway_api/__init__.py
@@ -74,7 +74,18 @@ class HTTPRoute(OpenShiftObject, Referencable, Route):
     @modify
     def add_hostname(self, hostname):
         """Adds hostname to the Route"""
-        self.model.spec.hostnames.append(hostname)
+        if hostname not in self.model.spec.hostnames:
+            self.model.spec.hostnames.append(hostname)
+
+    @modify
+    def remove_hostname(self, hostname):
+        """Adds hostname to the Route"""
+        self.model.spec.hostnames.remove(hostname)
+
+    @modify
+    def remove_all_hostnames(self):
+        """Adds hostname to the Route"""
+        self.model.spec.hostnames = []
 
 
 # pylint: disable=too-many-instance-attributes

--- a/testsuite/tests/kuadrant/authorino/multiple_hosts/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/multiple_hosts/conftest.py
@@ -5,12 +5,6 @@ from testsuite.httpx import HttpxBackoffClient
 
 
 @pytest.fixture(scope="module")
-def run_on_kuadrant():
-    """Handling of hosts needs to be rewritten"""
-    return False
-
-
-@pytest.fixture(scope="module")
 def hostname(envoy):
     """Original hostname"""
     return envoy.hostname


### PR DESCRIPTION
Requires #158. Adds host manipulation to AuthPolicy in a not-ideal way. 