### PR TITLE
Fix authconfig instance parameters

### DIFF
--- a/testsuite/openshift/objects/auth_config/__init__.py
+++ b/testsuite/openshift/objects/auth_config/__init__.py
@@ -1,6 +1,6 @@
 """AuthConfig CR object"""
 from functools import cached_property
-from typing import Dict
+from typing import Dict, List
 
 from testsuite.objects import Authorization, Responses, Metadata, Identities, Authorizations
 from testsuite.openshift.client import OpenShiftClient
@@ -40,7 +40,7 @@ class AuthConfig(OpenShiftObject, Authorization):
 
     @classmethod
     def create_instance(cls, openshift: OpenShiftClient, name, route: Route,
-                        labels: Dict[str, str] = None, hostnames=None):
+                        labels: Dict[str, str] = None, hostnames: List[str] = None):
         """Creates base instance"""
         model: Dict = {
             "apiVersion": "authorino.kuadrant.io/v1beta1",

--- a/testsuite/openshift/objects/auth_config/auth_policy.py
+++ b/testsuite/openshift/objects/auth_config/auth_policy.py
@@ -1,5 +1,5 @@
 """Module containing classes related to Auth Policy"""
-from typing import Dict
+from typing import Dict, List
 
 from testsuite.openshift.client import OpenShiftClient
 from testsuite.openshift.objects.auth_config import AuthConfig
@@ -21,7 +21,7 @@ class AuthPolicy(AuthConfig):
         name,
         route: Referencable,
         labels: Dict[str, str] = None,
-        hostnames=None,
+        hostnames: List[str] = None,
     ):
         """Creates base instance"""
         model: Dict = {

--- a/testsuite/tests/kuadrant/authorino/operator/clusterwide/test_wildcard_collision.py
+++ b/testsuite/tests/kuadrant/authorino/operator/clusterwide/test_wildcard_collision.py
@@ -11,7 +11,9 @@ from testsuite.openshift.objects.auth_config import AuthConfig
 @pytest.fixture(scope="module")
 def authorization(authorino, blame, openshift, module_label, envoy, wildcard_domain):
     """In case of Authorino, AuthConfig used for authorization"""
-    auth = AuthConfig.create_instance(openshift, blame("ac"), wildcard_domain, labels={"testRun": module_label})
+    auth = AuthConfig.create_instance(
+        openshift, blame("ac"), None, hostnames=[wildcard_domain], labels={"testRun": module_label}
+    )
     auth.responses.add({"name": "header", "json": {"properties": [{"name": "anything", "value": "one"}]}})
     return auth
 
@@ -20,7 +22,9 @@ def authorization(authorino, blame, openshift, module_label, envoy, wildcard_dom
 @pytest.fixture(scope="module")
 def authorization2(authorino, blame, openshift2, module_label, envoy, wildcard_domain):
     """In case of Authorino, AuthConfig used for authorization"""
-    auth = AuthConfig.create_instance(openshift2, blame("ac"), wildcard_domain, labels={"testRun": module_label})
+    auth = AuthConfig.create_instance(
+        openshift2, blame("ac"), None, hostnames=[wildcard_domain], labels={"testRun": module_label}
+    )
     auth.responses.add({"name": "header", "json": {"properties": [{"name": "anything", "value": "two"}]}})
     return auth
 

--- a/testsuite/tests/kuadrant/authorino/operator/test_wildcard.py
+++ b/testsuite/tests/kuadrant/authorino/operator/test_wildcard.py
@@ -10,7 +10,9 @@ from testsuite.openshift.objects.auth_config import AuthConfig
 @pytest.fixture(scope="module")
 def authorization(authorino, blame, openshift, module_label, wildcard_domain):
     """In case of Authorino, AuthConfig used for authorization"""
-    return AuthConfig.create_instance(openshift, blame("ac"), wildcard_domain, labels={"testRun": module_label})
+    return AuthConfig.create_instance(
+        openshift, blame("ac"), None, hostnames=[wildcard_domain], labels={"testRun": module_label}
+    )
 
 
 def test_wildcard(client):


### PR DESCRIPTION
Fix to the https://github.com/Kuadrant/testsuite/pull/158. In the AuthConfig instance creation, there was still parsed string instead of the route object or list with hostnames.