### PR TITLE
Simplify Mockserver expectation

### DIFF
--- a/testsuite/mockserver.py
+++ b/testsuite/mockserver.py
@@ -8,30 +8,63 @@ from testsuite.utils import ContentType
 
 
 class Mockserver:
-    """Mockserver deployed in Openshift (located in Tools or self-managed)"""
+    """
+    Mockserver deployed in Openshift (located in Tools or self-managed)
+    All existing expectations are stored in `self.expectations: dict[expectation_id, expectation_path]`
+    """
 
     def __init__(self, url):
         self.url = url
+        self.expectations = {}
 
-    def create_expectation(self, expectation_id, path, body,
-                           content_type: Union[ContentType, str] = ContentType.PLAIN_TEXT):
-        """Creates an Expectation - response with given body"""
+    def _expectation(self, expectation_id, response_data):
+        """
+        Creates an Expectation with given response_data.
+        Expectation is accessible on the `mockserver.url/expectation_id` url.
+        """
+        json_data = {
+            "id": expectation_id,
+            "httpRequest": {
+                "path": f"/{expectation_id}"
+            }
+        }
+        json_data.update(response_data)
+
         response = httpx.put(
-            urljoin(self.url, "/mockserver/expectation"), verify=False, timeout=5, json={
-                    "id": expectation_id,
-                    "httpRequest": {
-                        "path": path
-                    },
-                    "httpResponse": {
-                        "headers": {
-                            "Content-Type": [str(content_type)]
-                        },
-                        "body": body
-                    }
-                }
-            )
+            urljoin(self.url, "/mockserver/expectation"), verify=False, timeout=5, json=json_data)
         response.raise_for_status()
-        return self.url + path
+        self.expectations[expectation_id] = f"{self.url}/{expectation_id}"
+        return self.expectations[expectation_id]
+
+    def create_expectation(
+            self,
+            expectation_id,
+            body,
+            content_type: Union[ContentType, str] = ContentType.PLAIN_TEXT,
+    ):
+        """Creates an Expectation - response with given body"""
+        json_data = {
+            "httpResponse": {
+                "headers": {
+                    "Content-Type": [str(content_type)]
+                },
+                "body": body
+            }
+        }
+        return self._expectation(expectation_id, json_data)
+
+    def create_template_expectation(self, expectation_id, template):
+        """
+        Creates template expectation in Mustache format.
+        https://www.mock-server.com/mock_server/response_templates.html
+        """
+        json_data = {
+            "httpResponseTemplate": {
+                "templateType": "MUSTACHE",
+                "template": template
+            }
+        }
+        return self._expectation(expectation_id, json_data)
 
     def clear_expectation(self, expectation_id):
         """Clears Expectation with specific ID"""
@@ -40,3 +73,16 @@ class Mockserver:
                     "id": expectation_id
                 }
             ).raise_for_status()
+        del self.expectations[expectation_id]
+
+    def verify_expectation(self, path):
+        """Verify a request has been received a specific number of times for specific expectation"""
+        return httpx.put(
+            urljoin(self.url, "/mockserver/retrieve"), params="type=REQUESTS&format=JSON",
+            verify=False, timeout=5, json={
+               "path": path
+            })
+
+    def get_expectation_endpoint(self, expectation_id):
+        """Returns endpoint for expectation"""
+        return f"{self.url}/{expectation_id}"

--- a/testsuite/tests/kuadrant/authorino/authorization/opa/external_registry/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/authorization/opa/external_registry/conftest.py
@@ -14,7 +14,7 @@ def header():
 def opa_policy_expectation(request, mockserver, module_label, header):
     """Creates Mockserver Expectation that returns Rego query and returns its endpoint"""
     request.addfinalizer(lambda: mockserver.clear_expectation(module_label))
-    return mockserver.create_expectation(module_label, f"/{module_label}/opa", rego_allow_header(*header))
+    return mockserver.create_expectation(module_label, rego_allow_header(*header))
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/kuadrant/authorino/authorization/opa/external_registry/test_auto_refresh_policy.py
+++ b/testsuite/tests/kuadrant/authorino/authorization/opa/external_registry/test_auto_refresh_policy.py
@@ -18,7 +18,7 @@ def updated_header():
 @pytest.fixture(scope="module", autouse=True)
 def update_external_opa(mockserver, module_label, updated_header):
     """Updates Expectation with updated header"""
-    mockserver.create_expectation(module_label, f"/{module_label}/opa", rego_allow_header(*updated_header))
+    mockserver.create_expectation(module_label, rego_allow_header(*updated_header))
     # Sleeps for 1 second to compensate auto-refresh cycle `authorization.opa.externalRegistry.ttl = 1`
     time.sleep(1)
 

--- a/testsuite/tests/kuadrant/authorino/dinosaur/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/dinosaur/conftest.py
@@ -34,8 +34,11 @@ def terms_and_conditions(request, mockserver, module_label):
     """Creates Mockserver Expectation that returns whether terms are required and returns its endpoint"""
 
     def _terms_and_conditions(value):
-        return mockserver.create_expectation(f"{module_label}-terms", f"/{module_label}/terms-and-conditions",
-                                             {"terms_required": value}, ContentType.APPLICATION_JSON)
+        return mockserver.create_expectation(
+            f"{module_label}-terms",
+            {"terms_required": value},
+            ContentType.APPLICATION_JSON,
+        )
 
     request.addfinalizer(lambda: mockserver.clear_expectation(f"{module_label}-terms"))
     return _terms_and_conditions
@@ -46,8 +49,11 @@ def cluster_info(request, mockserver, module_label):
     """Creates Mockserver Expectation that returns client ID and returns its endpoint"""
 
     def _cluster_info(value):
-        return mockserver.create_expectation(f"{module_label}-cluster", f"/{module_label}/cluster-info",
-                                             {"client_id": value}, ContentType.APPLICATION_JSON)
+        return mockserver.create_expectation(
+            f"{module_label}-cluster",
+            {"client_id": value},
+            ContentType.APPLICATION_JSON
+        )
 
     request.addfinalizer(lambda: mockserver.clear_expectation(f"{module_label}-cluster"))
     return _cluster_info
@@ -58,9 +64,11 @@ def resource_info(request, mockserver, module_label):
     """Creates Mockserver Expectation that returns info about resource and returns its endpoint"""
 
     def _resource_info(org_id, owner):
-        return mockserver.create_expectation(f"{module_label}-resource", f"/{module_label}/resource-info",
-                                             {"org_id": org_id, "owner": owner},
-                                             ContentType.APPLICATION_JSON)
+        return mockserver.create_expectation(
+            f"{module_label}-resource",
+            {"org_id": org_id, "owner": owner},
+            ContentType.APPLICATION_JSON,
+        )
 
     request.addfinalizer(lambda: mockserver.clear_expectation(f"{module_label}-resource"))
     return _resource_info

--- a/testsuite/tests/kuadrant/authorino/metadata/test_http.py
+++ b/testsuite/tests/kuadrant/authorino/metadata/test_http.py
@@ -22,8 +22,7 @@ country_code == object.get(input.auth.metadata.mock, "countryCode", "")}
 def country_mock_expectation(request, mockserver, module_label):
     """Creates Mockserver Expectation which returns simple JSON that contains `allowed_countries`"""
     request.addfinalizer(lambda: mockserver.clear_expectation(module_label))
-    return mockserver.create_expectation(
-        module_label, f"/{module_label}/opa", ALLOWED_COUNTRY, ContentType.APPLICATION_JSON)
+    return mockserver.create_expectation(module_label, ALLOWED_COUNTRY, ContentType.APPLICATION_JSON)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This PR adds some functionality and simplifies Mockserver
- removes the unnecessary `path` argument for the `create_expectation` method. The `expectation_id` is used to create a path for expectation. It is possible to create expectations with scope function.
- adds a new method that creates an expectation for templated responses: https://www.mock-server.com/mock_server/response_templates.html
- an instance of mockserver now stores live expectations

