### PR TITLE
Add secrets tests back to Kuadrant

### DIFF
--- a/testsuite/tests/kuadrant/authorino/identity/api_key/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/identity/api_key/conftest.py
@@ -5,12 +5,6 @@ from testsuite.httpx.auth import HeaderApiKeyAuth
 
 
 @pytest.fixture(scope="module")
-def run_on_kuadrant():
-    """Secrets are not correctly reconciled https://github.com/Kuadrant/kuadrant-operator/issues/127"""
-    return False
-
-
-@pytest.fixture(scope="module")
 def api_key(create_api_key, module_label):
     """Creates API key Secret"""
     api_key = "api_key_value"

--- a/testsuite/tests/kuadrant/authorino/metadata/test_uma.py
+++ b/testsuite/tests/kuadrant/authorino/metadata/test_uma.py
@@ -27,12 +27,6 @@ allow {
 """
 
 
-@pytest.fixture(scope="module")
-def run_on_kuadrant():
-    """Secrets are not correctly reconciled https://github.com/Kuadrant/kuadrant-operator/issues/127"""
-    return False
-
-
 @pytest.fixture(scope="module", autouse=True)
 def client_secret(create_client_secret, rhsso):
     """Creates a required secret, used by Authorino to start the authentication with the UMA registry."""


### PR DESCRIPTION
https://github.com/Kuadrant/kuadrant-operator/issues/127 Is fixed, so we can enable those tests again