### PR TITLE
Add tests for Common feature - Metrics

### DIFF
--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -34,6 +34,7 @@
 #    deploy: false                               # If false, the testsuite will use already deployed authorino for testing
 #    auth_url: ""                                # authorization URL for already deployed Authorino
 #    oidc_url: ""                                # oidc URL for already deployed Authorino
+#    metrics_service_name: ""                    # controller metrics service name for already deployer Authorino
 #  envoy:
 #    image: "docker.io/envoyproxy/envoy:v1.23-latest"  # Envoy image, the testsuite should use, only for Authorino tests now
 #  kuadrant:

--- a/testsuite/objects/__init__.py
+++ b/testsuite/objects/__init__.py
@@ -135,6 +135,11 @@ class Authorino(LifecycleObject):
 
     @property
     @abc.abstractmethod
+    def metrics_service(self):
+        """Authorino metrics service name"""
+
+    @property
+    @abc.abstractmethod
     def authorization_url(self):
         """Authorization URL that can be plugged into envoy"""
 
@@ -147,13 +152,18 @@ class Authorino(LifecycleObject):
 class PreexistingAuthorino(Authorino):
     """Authorino which is already deployed prior to the testrun"""
 
-    def __init__(self, authorization_url, oidc_url) -> None:
+    def __init__(self, authorization_url, oidc_url, metrics_service) -> None:
         super().__init__()
         self._authorization_url = authorization_url
         self._oidc_url = oidc_url
+        self._metrics_service = metrics_service
 
     def wait_for_ready(self):
         return True
+
+    @property
+    def metrics_service(self):
+        return self._metrics_service
 
     @property
     def authorization_url(self):

--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -32,12 +32,12 @@ class OpenShiftClient:
     def __init__(self, project: str, api_url: str = None, token: str = None, kubeconfig_path: str = None):
         self._project = project
         self._api_url = api_url
-        self.token = token
+        self._token = token
         self._kubeconfig_path = kubeconfig_path
 
     def change_project(self, project) -> "OpenShiftClient":
         """Return new OpenShiftClient with a different project"""
-        return OpenShiftClient(project, self._api_url, self.token, self._kubeconfig_path)
+        return OpenShiftClient(project, self._api_url, self._token, self._kubeconfig_path)
 
     @cached_property
     def context(self):
@@ -46,7 +46,7 @@ class OpenShiftClient:
 
         context.project_name = self._project
         context.api_url = self._api_url
-        context.token = self.token
+        context.token = self._token
         context.kubeconfig_path = self._kubeconfig_path
 
         return context
@@ -56,6 +56,12 @@ class OpenShiftClient:
         """Returns real API url"""
         with self.context:
             return oc.whoami("--show-server=true")
+
+    @property
+    def token(self):
+        """Returns real OpenShift token"""
+        with self.context:
+            return oc.whoami("-t")
 
     @cached_property
     def apps_url(self):

--- a/testsuite/openshift/objects/authorino.py
+++ b/testsuite/openshift/objects/authorino.py
@@ -64,6 +64,12 @@ class AuthorinoCR(OpenShiftObject, Authorino):
             return selector(f"deployment/{self.name()}").object()
 
     @property
+    def metrics_service(self):
+        """Returns Authorino metrics service APIObject"""
+        with self.context:
+            return selector(f"service/{self.name()}-controller-metrics").object()
+
+    @property
     def authorization_url(self):
         """Return service endpoint for authorization"""
         return f"{self.name()}-authorino-authorization.{self.namespace()}.svc.cluster.local"

--- a/testsuite/openshift/objects/metrics/__init__.py
+++ b/testsuite/openshift/objects/metrics/__init__.py
@@ -1,0 +1,5 @@
+"""Package implements objects to work with metrics from Prometheus client for OpenShift"""
+from .prometheus import Prometheus, Metrics
+from .service_monitor import ServiceMonitor, MetricsEndpoint
+
+__all__ = ["Prometheus", "Metrics", "ServiceMonitor", "MetricsEndpoint"]

--- a/testsuite/openshift/objects/metrics/prometheus.py
+++ b/testsuite/openshift/objects/metrics/prometheus.py
@@ -1,0 +1,91 @@
+"""Simple client for the OpenShift metrics"""
+from typing import Callable
+from datetime import datetime
+
+import httpx
+import backoff
+from apyproxy import ApyProxy
+
+
+def _params(key: str = "", labels: dict[str, str] = None) -> dict[str, str]:
+    """Generate metrics query parameters based on key and labels"""
+    if not labels:
+        return {"query": key}
+    # pylint: disable=consider-using-f-string
+    return {"query": "%s{%s}" % (key, ",".join(f"{k}='{v}'" for k, v in labels.items()))}
+
+
+class Metrics:
+    """Interface to the returned OpenShift metrics"""
+
+    def __init__(self, metrics):
+        self.metrics = metrics
+
+    def filter(self, func: Callable[[dict], bool]) -> "Metrics":
+        """Filter method accept function `func` as a single argument.
+        Given function will be used as a filter on metrics structure.
+        E.g. func = lambda x: x["metric"]["evaluator_name"] == 'json'
+        After the filtering, new Metrics object will be returned."""
+        return Metrics([m for m in self.metrics if func(m)])
+
+    @property
+    def names(self) -> list[str]:
+        """Return list of metrics names"""
+        return [m["metric"]["__name__"] for m in self.metrics]
+
+    @property
+    def values(self) -> list[float]:
+        """Return list of metrics values as floats"""
+        return [float(m["value"][1]) for m in self.metrics]
+
+
+class Prometheus:
+    """Interface to the OpenShift Prometheus client"""
+
+    def __init__(self, url: str, token: str, namespace: str = None):
+        self.token = token
+        self.headers = {"Authorization": f"Bearer {self.token}"}
+        self.namespace = namespace
+
+        self._client = httpx.Client(headers=self.headers, verify=False)
+        self.client = ApyProxy(url, self._client).api.v1
+
+    def get_targets(self) -> dict:
+        """Get active metric targets information"""
+        params = {"state": "active"}
+        response = self.client.targets.get(params=params)
+
+        return response.json()["data"]["activeTargets"]
+
+    def get_metrics(self, key: str = "", labels: dict[str, str] = None) -> Metrics:
+        """Get metrics by key or labels"""
+        if self.namespace:
+            labels = labels or {}
+            labels.setdefault("namespace", self.namespace)
+
+        params = _params(key, labels)
+        response = self.client.query.get(params=params)
+
+        return Metrics(response.json()["data"]["result"])
+
+    def wait_for_scrape(self, target_service: str, metrics_path: str = "/metrics"):
+        """Wait before next metrics scrape on service is finished"""
+        call_time = datetime.utcnow()
+
+        @backoff.on_predicate(backoff.constant, interval=10, jitter=None, max_tries=10)
+        def _wait_for_scrape():
+            """Wait for new scrape after the function call time"""
+            for target in self.get_targets():
+                if (
+                    "service" in target["labels"].keys()
+                    and target["labels"]["service"] == target_service
+                    and target["discoveredLabels"]["__metrics_path__"] == metrics_path
+                ):
+                    return call_time < datetime.fromisoformat(target["lastScrape"][:26])
+            return False
+
+        _wait_for_scrape()
+
+    def close(self):
+        """Close httpx client connection"""
+        self._client.close()

--- a/testsuite/openshift/objects/metrics/service_monitor.py
+++ b/testsuite/openshift/objects/metrics/service_monitor.py
@@ -1,0 +1,46 @@
+"""Module implements Service Monitor CR for OpenShift"""
+from dataclasses import dataclass
+
+from testsuite.objects import asdict
+from testsuite.openshift.client import OpenShiftClient
+from testsuite.openshift.objects import OpenShiftObject
+
+
+@dataclass
+class MetricsEndpoint:
+    """Dataclass for endpoint definition in Service Monitor OpenShift object.
+    It contains endpoint path and port to the exported metrics."""
+
+    path: str = "/metrics"
+    port: str = "http"
+
+
+class ServiceMonitor(OpenShiftObject):
+    """Represents Service Monitor object for OpenShift"""
+
+    @classmethod
+    def create_instance(
+        cls,
+        openshift: OpenShiftClient,
+        name: str,
+        endpoints: list[MetricsEndpoint],
+        match_labels: dict[str, str],
+        labels: dict[str, str] = None,
+    ):
+        """Creates new instance of ServiceMonitor"""
+        model = {
+            "apiVersion": "monitoring.coreos.com/v1",
+            "kind": "ServiceMonitor",
+            "metadata": {
+                "name": name,
+                "labels": labels,
+            },
+            "spec": {
+                "endpoints": [asdict(e) for e in endpoints],
+                "selector": {
+                    "matchLabels": match_labels,
+                },
+            },
+        }
+
+        return cls(model, context=openshift.context)

--- a/testsuite/openshift/types/__init__.py
+++ b/testsuite/openshift/types/__init__.py
@@ -22,8 +22,15 @@ class RemoteMapping:
 
     def __iter__(self):
         """Return iterator for requested resource"""
-        data = self._client.do_action("get", self._resource_name, parse_output=True)
-        return iter(data["items"])
+        data = self._client.do_action(
+            "get",
+            self._resource_name,
+            "-o",
+            "json",
+            "--ignore-not-found=true",
+            parse_output=True,
+        )
+        return iter(data.as_dict()["items"])
 
     def __getitem__(self, name):
         """Return requested resource as APIObject"""

--- a/testsuite/openshift/types/routes.py
+++ b/testsuite/openshift/types/routes.py
@@ -20,3 +20,7 @@ class Routes(RemoteMapping):
         return self._client.do_action(
             "expose", "service", f"--name={name}", "-o", "json", service, *extra_args, parse_output=True
         )
+
+    def for_service(self, service_name: str) -> list:
+        """Return routes for specific service"""
+        return [r for r in self if r["spec"]["to"]["name"] == service_name]

--- a/testsuite/tests/kuadrant/authorino/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/conftest.py
@@ -25,7 +25,11 @@ def authorino(authorino, openshift, blame, request, testconfig, module_label, au
     if not testconfig["authorino"]["deploy"]:
         if len(authorino_parameters) > 0:
             return pytest.skip("Can't change parameters of already deployed Authorino")
-        return PreexistingAuthorino(testconfig["authorino"]["auth_url"], testconfig["authorino"]["oidc_url"])
+        return PreexistingAuthorino(
+            testconfig["authorino"]["auth_url"],
+            testconfig["authorino"]["oidc_url"],
+            testconfig["authorino"]["metrics_service_name"],
+        )
 
     labels = authorino_parameters.setdefault("label_selectors", [])
     labels.append(f"testRun={module_label}")

--- a/testsuite/tests/kuadrant/authorino/metrics/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/metrics/conftest.py
@@ -1,0 +1,56 @@
+"""Conftest for the Authorino metrics tests"""
+import pytest
+
+from testsuite.openshift.objects.metrics import ServiceMonitor, MetricsEndpoint, Prometheus
+
+
+@pytest.fixture(scope="module")
+def run_on_kuadrant():
+    """Kuadrant doesn't allow customization of Authorino parameters"""
+    return False
+
+
+@pytest.fixture(scope="session")
+def prometheus(request, openshift):
+    """
+    Return an instance of OpenShift metrics client
+    Skip tests if query route is not properly configured
+    """
+    # find thanos-querier route in the openshift-monitoring project
+    # this route allows to query metrics
+    openshift_monitoring = openshift.change_project("openshift-monitoring")
+    routes = openshift_monitoring.routes.for_service("thanos-querier")
+    if len(routes) > 0:
+        url = ("https://" if "tls" in routes[0]["spec"] else "http://") + routes[0]["spec"]["host"]
+        prometheus = Prometheus(url, openshift.token, openshift.project)
+        request.addfinalizer(prometheus.close)
+        return prometheus
+
+    return pytest.skip("Skipping metrics tests as query route is not properly configured")
+
+
+@pytest.fixture(scope="module")
+def label_metrics_service(authorino, module_label):
+    """Label Authorino controller-metrics service for the proper discovery"""
+    authorino.metrics_service.label({"app": module_label})
+
+
+# pylint: disable=unused-argument
+@pytest.fixture(scope="module", autouse=True)
+def create_service_monitor(openshift, blame, module_label, label_metrics_service):
+    """Create ServiceMonitor object to follow Authorino /metrics and /server-metrics endpoints"""
+    endpoints = [MetricsEndpoint("/metrics", "http"), MetricsEndpoint("/server-metrics", "http")]
+    service_monitor = ServiceMonitor.create_instance(
+        openshift, blame("sm"), endpoints, match_labels={"app": module_label}
+    )
+
+    service_monitor.commit()
+    yield service_monitor
+    service_monitor.delete()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def send_request(client, auth):
+    """Send a simple get request so that a few metrics can appear"""
+    response = client.get("/get", auth=auth)
+    assert response.status_code == 200

--- a/testsuite/tests/kuadrant/authorino/metrics/test_deep_metrics.py
+++ b/testsuite/tests/kuadrant/authorino/metrics/test_deep_metrics.py
@@ -1,0 +1,65 @@
+"""Tests for the functionality of the deep-evaluator metric samples"""
+import pytest
+
+
+@pytest.fixture(scope="module")
+def mockserver_expectation(request, mockserver, module_label):
+    """Creates Mockserver Expectation which returns non-empty response on hit"""
+    request.addfinalizer(lambda: mockserver.clear_expectation(module_label))
+    return mockserver.create_expectation(module_label, "response")
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization, mockserver_expectation):
+    """
+    Create AuthConfig with one of each type of evaluators. Allow metrics collection in every section.
+
+    Add to the AuthConfig:
+        - anonymous identity
+        - always allowed opa policy authorization
+        - http metadata from the mockserver
+        - non-empty response
+    """
+    authorization.identity.anonymous("anonymous", metrics=True)
+    authorization.authorization.opa_policy("opa", "allow { true }", metrics=True)
+    authorization.metadata.http_metadata("http", mockserver_expectation, "GET", metrics=True)
+    authorization.responses.add(
+        {
+            "name": "json",
+            "json": {
+                "properties": [
+                    {"name": "auth", "value": "response"},
+                ]
+            },
+        },
+        metrics=True,
+    )
+
+    return authorization
+
+
+@pytest.fixture(scope="module")
+def deep_metrics(authorino, prometheus):
+    """Return all evaluator(deep) metrics"""
+    prometheus.wait_for_scrape(authorino.metrics_service.name(), "/server-metrics")
+
+    return prometheus.get_metrics("auth_server_evaluator_total", labels={"service": authorino.metrics_service.name()})
+
+
+@pytest.mark.parametrize(
+    "metric_name, metric_type",
+    [
+        ("opa", "AUTHORIZATION_OPA"),
+        ("anonymous", "IDENTITY_NOOP"),
+        ("http", "METADATA_GENERIC_HTTP"),
+        ("json", "RESPONSE_JSON"),
+    ],
+)
+def test_deep_metrics(metric_name, metric_type, deep_metrics):
+    """Test if each set evaluator metric is collected and correctly responds to the request sent"""
+    metrics = deep_metrics.filter(
+        lambda x: x["metric"]["evaluator_name"] == metric_name and x["metric"]["evaluator_type"] == metric_type
+    )
+
+    assert metrics
+    assert metrics.values[0] == 1

--- a/testsuite/tests/kuadrant/authorino/metrics/test_metrics.py
+++ b/testsuite/tests/kuadrant/authorino/metrics/test_metrics.py
@@ -1,0 +1,71 @@
+"""Tests for integrity of the metrics endpoints"""
+import pytest
+
+
+METRICS = [
+    "controller_runtime_reconcile_total",
+    "controller_runtime_reconcile_errors_total",
+    "controller_runtime_max_concurrent_reconciles",
+    "workqueue_adds_total",
+    "workqueue_depth",
+    "workqueue_longest_running_processor_seconds",
+    "workqueue_retries_total",
+    "workqueue_unfinished_work_seconds",
+    "rest_client_requests_total",
+]
+
+METRICS_HISTOGRAM = [
+    "controller_runtime_reconcile_time_seconds",
+    "workqueue_queue_duration_seconds",
+    "workqueue_work_duration_seconds",
+]
+
+SERVER_METRICS = [
+    "auth_server_authconfig_total",
+    "auth_server_authconfig_response_status",
+    "auth_server_response_status",
+    "grpc_server_handled_total",
+    "grpc_server_msg_received_total",
+    "grpc_server_msg_sent_total",
+    "grpc_server_started_total",
+]
+
+SERVER_METRICS_HISTOGRAM = [
+    "auth_server_authconfig_duration_seconds",
+    "grpc_server_handling_seconds",
+]
+
+
+@pytest.fixture(scope="module")
+def metrics_keys(authorino, prometheus):
+    """Return all metrics defined for the Authorino metrics service"""
+    prometheus.wait_for_scrape(authorino.metrics_service.name(), "/metrics")
+    prometheus.wait_for_scrape(authorino.metrics_service.name(), "/server-metrics")
+
+    return prometheus.get_metrics(labels={"service": authorino.metrics_service.name()}).names
+
+
+@pytest.mark.parametrize("metric", METRICS)
+def test_metrics(metric, metrics_keys):
+    """Test for metrics that Authorino export at the /metrics endpoint"""
+    assert metric in metrics_keys
+
+
+@pytest.mark.parametrize("metric", METRICS_HISTOGRAM)
+def test_metrics_histogram(metric, metrics_keys):
+    """Test for histogram metrics that Authorino export at the /metrics endpoint"""
+    for suffix in ["_bucket", "_sum", "_count"]:
+        assert metric + suffix in metrics_keys
+
+
+@pytest.mark.parametrize("metric", SERVER_METRICS)
+def test_server_metrics(metric, metrics_keys):
+    """Test for metrics that Authorino export at the /server-metrics endpoint"""
+    assert metric in metrics_keys
+
+
+@pytest.mark.parametrize("metric", SERVER_METRICS_HISTOGRAM)
+def test_server_metrics_histogram(metric, metrics_keys):
+    """Test for histogram metrics that Authorino export at the /server-metrics endpoint"""
+    for suffix in ["_bucket", "_sum", "_count"]:
+        assert metric + suffix in metrics_keys


### PR DESCRIPTION
Fix routes iteration method (**\_\_iter\_\_**).
Add real Openshift token acquiring possibility.
Add Authorino metrics endpoint getter (Preexisting and new Authorino).
Add Prometheus and Metrics clients for easier metrics fetching.
Add Authorino metrics and server-metrics tests.

Test cases:
- [X] Tests for integrity of /metrics endpoint
- [X] Tests for integrity of /server-metrics endpoint
- [X] Test for deep metrics:
    - [X] Identity evaluator metrics
    - [X] Authorization evaluator metrics
    - [X] Metadata evaluator metrics
    - [X] Response evaluator metrics


Closes #106