### PR TITLE
Add tests for extended_properties feature

### DIFF
--- a/testsuite/objects/__init__.py
+++ b/testsuite/objects/__init__.py
@@ -2,9 +2,9 @@
 import abc
 from dataclasses import dataclass, is_dataclass, fields, field
 from copy import deepcopy
-from typing import Literal, Union, Optional
+from typing import Literal, Optional
 
-JSONValues = Union[None, str, int, bool, list["JSONValues"], dict[str, "JSONValues"]]
+JSONValues = None | str | int | bool | list["JSONValues"] | dict[str, "JSONValues"]
 
 # pylint: disable=invalid-name
 
@@ -13,7 +13,7 @@ def asdict(obj) -> dict[str, JSONValues]:
     """
     This function converts dataclass object to dictionary.
     While it works similar to `dataclasses.asdict` a notable change is usage of
-    overriding `to_dict()` function if dataclass contains it.
+    overriding `asdict()` function if dataclass contains it.
     This function works recursively in lists, tuples and dicts. All other values are passed to copy.deepcopy function.
     """
     if not is_dataclass(obj):
@@ -133,6 +133,22 @@ class Property:
     def asdict(self):
         """Override `asdict` function"""
         return {"name": self.name, **asdict(self.value)}
+
+
+@dataclass
+class ExtendedProperty(Property):
+    """
+    Dataclass extending Property class adding optional `overwrite` feature
+    used in extended_properties functionality in Identity section.
+    """
+
+    overwrite: Optional[bool] = None
+
+    def asdict(self):
+        """Extend inherited `asdict` function to include new attributes."""
+        if self.overwrite is not None:
+            return {**super().asdict(), "overwrite": self.overwrite}
+        return super().asdict()
 
 
 @dataclass

--- a/testsuite/openshift/objects/auth_config/sections.py
+++ b/testsuite/openshift/objects/auth_config/sections.py
@@ -10,6 +10,7 @@ from testsuite.objects import (
     Credentials,
     ValueFrom,
     Property,
+    ExtendedProperty,
 )
 from testsuite.openshift.objects import modify
 
@@ -44,7 +45,14 @@ class Section:
         return self.obj.auth_section.setdefault(self.section_name, [])
 
     def add_item(
-        self, name, value, priority: int = None, when: Iterable[Rule] = None, metrics: bool = None, cache: Cache = None
+        self,
+        name,
+        value,
+        *,
+        priority: int = None,
+        when: Iterable[Rule] = None,
+        metrics: bool = None,
+        cache: Cache = None
     ):
         """Adds item to the section"""
         item = {"name": name, **value}
@@ -66,6 +74,14 @@ class Section:
 
 class IdentitySection(Section):
     """Section which contains identity configuration"""
+
+    def add_item(self, name, value, *, extended_properties: list[ExtendedProperty] = None, **common_features):
+        """
+        Adds optional extendedProperties feature specific to IdentitySection and then calls parent add_item() method
+        """
+        if extended_properties:
+            value["extendedProperties"] = [asdict(i) for i in extended_properties]
+        super().add_item(name, value, **common_features)
 
     @modify
     def add_mtls(self, name: str, selector: Selector, **common_features):
@@ -129,7 +145,7 @@ class IdentitySection(Section):
     @modify
     def add_plain(self, name, auth_json, **common_features):
         """Adds plain identity"""
-        self.add_item(name, {"plain": {"authJSON": auth_json}, **common_features})
+        self.add_item(name, {"plain": {"authJSON": auth_json}}, **common_features)
 
 
 class MetadataSection(Section):

--- a/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_extended_properties.py
+++ b/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_extended_properties.py
@@ -1,0 +1,49 @@
+"""Basic tests for extended properties"""
+import pytest
+
+from testsuite.objects import Value, ValueFrom, ExtendedProperty
+from testsuite.utils import extract_response
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization, rhsso):
+    """
+    Add new identity with list of extended properties. This list contains:
+        - Static `value` and dynamic `jsonPath` properties
+        - Dynamic chaining properties which point to another extended property location before its created
+    Add simple response to inspect 'auth.identity' part of authJson where the properties will be created.
+    """
+    authorization.identity.add_oidc(
+        "rhsso",
+        rhsso.well_known["issuer"],
+        extended_properties=[
+            ExtendedProperty("property_static", Value("static")),
+            # ValueFrom points to the request uri
+            ExtendedProperty("property_dynamic", ValueFrom("context.request.http.path")),
+            ExtendedProperty("property_chain_static", ValueFrom("auth.identity.property_static")),
+            ExtendedProperty("property_chain_dynamic", ValueFrom("auth.identity.property_dynamic")),
+            ExtendedProperty("property_chain_self", ValueFrom("auth.identity.property_chain_self"), overwrite=True),
+        ],
+    )
+    authorization.responses.add_simple("auth.identity")
+    return authorization
+
+
+def test_basic(client, auth):
+    """
+    This test checks if static and dynamic extended properties are created and have the right value.
+    """
+    response = client.get("/anything/abc", auth=auth)
+    assert extract_response(response)["property_static"] % "MISSING" == "static"
+    assert extract_response(response)["property_dynamic"] % "MISSING" == "/anything/abc"
+
+
+def test_chain(client, auth):
+    """
+    This test checks if chaining extended properties have value None as chaining is not supported.
+    This behavior is undocumented but confirmed to be correct with dev team.
+    """
+    response = client.get("/anything/abc", auth=auth)
+    assert extract_response(response)["property_chain_static"] % "MISSING" is None
+    assert extract_response(response)["property_chain_dynamic"] % "MISSING" is None
+    assert extract_response(response)["property_chain_self"] % "MISSING" is None

--- a/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_overwriting.py
+++ b/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_overwriting.py
@@ -1,0 +1,36 @@
+"""https://github.com/Kuadrant/authorino/pull/399"""
+import pytest
+
+from testsuite.objects import ExtendedProperty, Value
+from testsuite.utils import extract_response
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization):
+    """
+    Add plain authentication with three extended properties:
+    explicit False, explicit True and missing which should be default False.
+    Add simple response to expose `auth.identity` part of AuthJson
+    """
+    authorization.identity.add_plain(
+        "plain",
+        "context.request.http.headers.x-user|@fromstr",
+        extended_properties=[
+            ExtendedProperty("name", Value("bar"), overwrite=False),
+            ExtendedProperty("age", Value(35), overwrite=True),
+            ExtendedProperty("group", Value("admin")),
+        ],
+    )
+    authorization.responses.add_simple("auth.identity")
+
+    return authorization
+
+
+def test_overwrite(client):
+    """
+    Test the ExtendedProperty overwrite functionality overwriting the value in headers when True.
+    """
+    response = client.get("/get", headers={"x-user": '{"name":"foo","age":30,"group":"guest"}'})
+    assert extract_response(response)["name"] % "MISSING" == "foo"
+    assert extract_response(response)["age"] % "MISSING" == 35
+    assert extract_response(response)["group"] % "MISSING" == "guest"

--- a/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_token_normalization.py
+++ b/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_token_normalization.py
@@ -1,0 +1,64 @@
+"""https://github.com/Kuadrant/authorino/blob/main/docs/user-guides/token-normalization.md"""
+import pytest
+from testsuite.objects import Value, ValueFrom, ExtendedProperty, Rule
+from testsuite.httpx.auth import HeaderApiKeyAuth, HttpxOidcClientAuth
+
+
+@pytest.fixture(scope="module")
+def api_key(create_api_key, module_label):
+    """Creates API key Secret."""
+    return create_api_key("api-key", module_label, "api_key_value")
+
+
+@pytest.fixture(scope="module")
+def auth_api_key(api_key):
+    """Return Api key auth"""
+    return HeaderApiKeyAuth(api_key)
+
+
+@pytest.fixture(scope="module")
+def auth_oidc_admin(rhsso, blame):
+    """Creates new user with new 'admin' role and return auth for it."""
+    realm_role = rhsso.realm.create_realm_role("admin")
+    user = rhsso.realm.create_user(blame("someuser"), blame("password"))
+    user.assign_realm_role(realm_role)
+    return HttpxOidcClientAuth.from_user(rhsso.get_token, user, "authorization")
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization, rhsso, api_key):
+    """
+    Add rhsso identity provider with extended property "roles" which is dynamically mapped to
+    list of granted realm roles 'auth.identity.realm_access.roles'
+    Add api_key identity with extended property "roles" which is static list of one role 'admin'.
+
+    Add authorization rule allowing DELETE method only to users with role 'admin' in 'auth.identity.roles'
+    """
+    authorization.identity.add_oidc(
+        "rhsso",
+        rhsso.well_known["issuer"],
+        extended_properties=[ExtendedProperty("roles", ValueFrom("auth.identity.realm_access.roles"))],
+    )
+    authorization.identity.add_api_key(
+        "api_key", selector=api_key.selector, extended_properties=[ExtendedProperty("roles", Value(["admin"]))]
+    )
+
+    rule = Rule(selector="auth.identity.roles", operator="incl", value="admin")
+    when = Rule(selector="context.request.http.method", operator="eq", value="DELETE")
+    authorization.authorization.add_auth_rules("only-admins-can-delete", rules=[rule], when=[when])
+    return authorization
+
+
+def test_token_normalization(client, auth, auth_oidc_admin, auth_api_key):
+    """
+    Tests token normalization scenario where three users with different types of authentication have "roles" value
+    normalized via extended_properties. Only user with an 'admin' role can use method DELETE.
+    - auth: oidc user without 'admin' role
+    - auth_oidc_admin: oidc user with 'admin' role
+    - auth_api_key: api key user which has static 'admin' role
+    """
+
+    assert client.get("/get", auth=auth).status_code == 200
+    assert client.delete("/delete", auth=auth).status_code == 403
+    assert client.delete("/delete", auth=auth_oidc_admin).status_code == 200
+    assert client.delete("/delete", auth=auth_api_key).status_code == 200


### PR DESCRIPTION
- [x] `extended_properties` functionality implementation (contains fix of `Value` class)
- [x] Test cases:
    - [x] Token normalization
    - [x] Other extended_properties tests
    - [x] Overwrite tests
 
Contains also:

-  bugfix of "Add plain identity" function https://github.com/Kuadrant/testsuite/pull/212#discussion_r1272674382
- Replace Union with more native type marking https://github.com/Kuadrant/testsuite/pull/212#discussion_r1281998698
- ~Replace custom `asdict()` in `ValueFrom` with dict transformation https://github.com/Kuadrant/testsuite/pull/212#discussion_r1282710508~ 
- Fix typo in docstring for `asdict()` https://github.com/Kuadrant/testsuite/pull/212#discussion_r1285922191
- Change `add_item` function to force keyword-only common_features arguments https://github.com/Kuadrant/testsuite/pull/212#discussion_r1305881457

Closes #108 