### PR TITLE
Add ResponseProperties object and example refactor

### DIFF
--- a/testsuite/openshift/objects/auth_config/sections.py
+++ b/testsuite/openshift/objects/auth_config/sections.py
@@ -59,6 +59,23 @@ class Section:
 class Identities(Section):
     """Section which contains identity configuration"""
 
+    def add_item(
+        self,
+        name,
+        value,
+        priority: int = None,
+        when: Iterable[Rule] = None,
+        metrics: bool = None,
+        cache: Cache = None,
+        extended_properties: list[ABCValue] = None,
+    ):
+        """
+        Adds optional extendedProperties feature specific to IdentitySection and then calls parent add_idem() method
+        """
+        if extended_properties:
+            value["extendedProperties"] = [asdict(i) for i in extended_properties]
+        super().add_item(name, value, priority, when, metrics, cache)
+
     @modify
     def mtls(self, name: str, selector_key: str, selector_value: str, **common_features):
         """Adds mTLS identity
@@ -135,7 +152,7 @@ class Identities(Section):
     @modify
     def plain(self, name, auth_json, **common_features):
         """Adds plain identity"""
-        self.add_item(name, {"plain": {"authJSON": auth_json}, **common_features})
+        self.add_item(name, {"plain": {"authJSON": auth_json}}, **common_features)
 
     @modify
     def remove_all(self):

--- a/testsuite/openshift/objects/auth_config/sections.py
+++ b/testsuite/openshift/objects/auth_config/sections.py
@@ -7,6 +7,8 @@ from testsuite.objects import (
     Rule,
     Cache,
     ABCValue,
+    ValueFrom,
+    ResponseProperties,
 )
 from testsuite.openshift.objects import modify
 
@@ -193,18 +195,13 @@ class Responses(Section):
     """Section which contains response configuration"""
 
     def add_simple(self, auth_json, name="simple", key="data", **common_features):
-        """Adds simple response to AuthConfig"""
-        self.add(
-            {
-                "name": name,
-                "json": {"properties": [{"name": key, "valueFrom": {"authJSON": auth_json}}]},
-                **common_features,
-            }
-        )
+        self.add(asdict(ResponseProperties(name=name, json=[ValueFrom(auth_json, name=key)])), **common_features)
 
     @modify
     def add(self, response, **common_features):
         """Adds response section to AuthConfig."""
+        if isinstance(response, ResponseProperties):
+            response = asdict(response)
         self.add_item(response.pop("name"), response, **common_features)
 
 

--- a/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_extended_properties.py
+++ b/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_extended_properties.py
@@ -1,0 +1,49 @@
+"""Basic tests for extended properties"""
+import pytest
+
+from testsuite.objects import Value, ValueFrom
+from testsuite.utils import extract_response
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization, rhsso):
+    """
+    Add new identity with list of extended properties. This list contains:
+        - Static `value` and dynamic `jsonPath` properties
+        - Dynamic chaining properties which point to another extended property location before its created
+    Add simple response to inspect 'auth.identity' part of authJson where the properties will be created.
+    """
+    authorization.identity.oidc(
+        "rhsso",
+        rhsso.well_known["issuer"],
+        extended_properties=[
+            Value("static", name="property_static"),
+            # ValueFrom points to the request uri
+            ValueFrom("context.request.http.path", name="property_dynamic"),
+            ValueFrom("auth.identity.property_static", name="property_chain_static"),
+            ValueFrom("auth.identity.property_dynamic", name="property_chain_dynamic"),
+            ValueFrom("auth.identity.property_chain_self", name="property_chain_self", overwrite=True),
+        ],
+    )
+    authorization.responses.add_simple("auth.identity")
+    return authorization
+
+
+def test_basic(client, auth):
+    """
+    This test checks if static and dynamic extended properties are created and have the right value.
+    """
+    response = client.get("/anything/abc", auth=auth)
+    assert extract_response(response)["property_static"] % "MISSING" == "static"
+    assert extract_response(response)["property_dynamic"] % "MISSING" == "/anything/abc"
+
+
+def test_chain(client, auth):
+    """
+    This test checks if chaining extended properties have value None as chaining is not supported.
+    This behavior is undocumented but confirmed to be correct with dev team.
+    """
+    response = client.get("/anything/abc", auth=auth)
+    assert extract_response(response)["property_chain_static"] % "MISSING" is None
+    assert extract_response(response)["property_chain_dynamic"] % "MISSING" is None
+    assert extract_response(response)["property_chain_self"] % "MISSING" is None

--- a/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_overwriting.py
+++ b/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_overwriting.py
@@ -1,0 +1,36 @@
+"""https://github.com/Kuadrant/authorino/pull/399"""
+import pytest
+
+from testsuite.objects import Value
+from testsuite.utils import extract_response
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization):
+    """
+    Add plain authentication with three extended properties:
+    explicit False, explicit True and missing which should be default False.
+    Add simple response to expose `auth.identity` part of AuthJson
+    """
+    authorization.identity.plain(
+        "plain",
+        "context.request.http.headers.x-user|@fromstr",
+        extended_properties=[
+            Value("bar", name="name", overwrite=False),
+            Value(35, name="age", overwrite=True),
+            Value("admin", name="group"),
+        ],
+    )
+    authorization.responses.add_simple("auth.identity")
+
+    return authorization
+
+
+def test_overwrite(client):
+    """
+    Test the ExtendedProperty overwrite functionality overwriting the value in headers when True.
+    """
+    response = client.get("/get", headers={"x-user": '{"name":"foo","age":30,"group":"guest"}'})
+    assert extract_response(response)["name"] % "MISSING" == "foo"
+    assert extract_response(response)["age"] % 0 == 35
+    assert extract_response(response)["group"] % "MISSING" == "guest"

--- a/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_token_normalization.py
+++ b/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_token_normalization.py
@@ -1,0 +1,59 @@
+"""https://github.com/Kuadrant/authorino/blob/main/docs/user-guides/token-normalization.md"""
+import pytest
+from testsuite.objects import Value, ValueFrom, Rule
+from testsuite.httpx.auth import HeaderApiKeyAuth, HttpxOidcClientAuth
+
+
+@pytest.fixture(scope="module")
+def auth_api_key(create_api_key, module_label):
+    """Creates API key Secret and returns auth for it."""
+    api_key = create_api_key("api-key", module_label, "api_key_value")
+    return HeaderApiKeyAuth(api_key)
+
+
+@pytest.fixture(scope="module")
+def auth_oidc_admin(rhsso, blame):
+    """Creates new user with new 'admin' role and return auth for it."""
+    realm_role = rhsso.realm.create_realm_role("admin")
+    user = rhsso.realm.create_user(blame("someuser"), blame("password"))
+    user.assign_realm_role(realm_role)
+    return HttpxOidcClientAuth.from_user(rhsso.get_token, user, "authorization")
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization, rhsso, module_label):
+    """
+    Add rhsso identity provider with extended property "roles" which is dynamically mapped to
+    list of granted realm roles 'auth.identity.realm_access.roles'
+    Add api_key identity with extended property "roles" which is static list of one role 'admin'.
+
+    Add authorization rule allowing DELETE method only to users with role 'admin' in 'auth.identity.roles'
+    """
+    authorization.identity.oidc(
+        "rhsso",
+        rhsso.well_known["issuer"],
+        extended_properties=[ValueFrom("auth.identity.realm_access.roles", name="roles")],
+    )
+    authorization.identity.api_key(
+        "api_key", match_label=module_label, extended_properties=[Value(["admin"], name="roles")]
+    )
+
+    rule = Rule(selector="auth.identity.roles", operator="incl", value="admin")
+    when = Rule(selector="context.request.http.method", operator="eq", value="DELETE")
+    authorization.authorization.auth_rule("only-admins-can-delete", rule=rule, when=[when])
+    return authorization
+
+
+def test_token_normalization(client, auth, auth_oidc_admin, auth_api_key):
+    """
+    Tests token normalization scenario where three users with different types of authentication have "roles" value
+    normalized via extended_properties. Only user with an 'admin' role can use method DELETE.
+    - auth: oidc user without 'admin' role
+    - auth_oidc_admin: oidc user with 'admin' role
+    - auth_api_key: api key user which has static 'admin' role
+    """
+
+    assert client.get("/get", auth=auth).status_code == 200
+    assert client.delete("/delete", auth=auth).status_code == 403
+    assert client.delete("/delete", auth=auth_oidc_admin).status_code == 200
+    assert client.delete("/delete", auth=auth_api_key).status_code == 200

--- a/testsuite/tests/kuadrant/authorino/response/test_auth_json.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_auth_json.py
@@ -3,6 +3,7 @@
 import json
 
 import pytest
+from testsuite.objects import ResponseProperties, Value
 
 
 @pytest.fixture(scope="module")
@@ -27,7 +28,7 @@ def path_and_value(request):
 def responses(path_and_value):
     """Returns response to be added to the AuthConfig"""
     path, _ = path_and_value
-    return [{"name": "header", "json": {"properties": [{"name": "anything", "valueFrom": {"authJSON": path}}]}}]
+    return [ResponseProperties("header", json=[Value(path, name="anything")])]
 
 
 def test_auth_json_path(auth, client, path_and_value):

--- a/testsuite/tests/kuadrant/authorino/response/test_multiple_responses.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_multiple_responses.py
@@ -2,14 +2,15 @@
 import json
 
 import pytest
+from testsuite.objects import ResponseProperties, Value
 
 
 @pytest.fixture(scope="module")
 def responses():
     """Returns response to be added to the AuthConfig"""
     return [
-        {"name": "Header", "json": {"properties": [{"name": "anything", "value": "one"}]}},
-        {"name": "X-Test", "json": {"properties": [{"name": "anything", "value": "two"}]}},
+        ResponseProperties("Header", json=[Value("one", name="anything")]),
+        ResponseProperties("X-Test", json=[Value("two", name="anything")]),
     ]
 
 

--- a/testsuite/tests/kuadrant/authorino/response/test_simple_response.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_simple_response.py
@@ -2,12 +2,13 @@
 import json
 
 import pytest
+from testsuite.objects import ResponseProperties, Value
 
 
 @pytest.fixture(scope="module")
 def responses():
     """Returns response to be added to the AuthConfig"""
-    return [{"name": "header", "json": {"properties": [{"name": "anything", "value": "one"}]}}]
+    return [ResponseProperties(name="header", json=[Value("one", name="anything")])]
 
 
 def test_simple_response_with(auth, client):

--- a/testsuite/tests/kuadrant/authorino/response/test_wrapper_key.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_wrapper_key.py
@@ -2,6 +2,7 @@
 import json
 
 import pytest
+from testsuite.objects import ResponseProperties, Value
 
 
 @pytest.fixture(scope="module", params=["123456789", "standardCharacters", "specialcharacters+*-."])
@@ -14,7 +15,11 @@ def header_name(request):
 def responses(header_name):
     """Returns response to be added to the AuthConfig"""
     return [
-        {"name": "header", "wrapperKey": header_name, "json": {"properties": [{"name": "anything", "value": "one"}]}}
+        ResponseProperties(
+            name="header",
+            wrapperKey=header_name,
+            json=[Value(value="one", name="anything")],
+        )
     ]
 
 


### PR DESCRIPTION
Based on commit b042b30f63e8c1040de7138bc13469217fa0493d in #212 

Usage of dynamic response function is quite common in tests to expose and check Authorino internal variables. I propose creating new object for easier definition of this function without the need to construct complicated dictionaries in tests.

**Contains fix of Value class to dataclass.**

This PR also contains example refactor of https://github.com/Kuadrant/testsuite/tree/main/testsuite/tests/kuadrant/authorino/response tests.