### PR TITLE
Dataclasses refactor and add new to_dict function

### DIFF
--- a/testsuite/objects/sections.py
+++ b/testsuite/objects/sections.py
@@ -4,7 +4,7 @@ import abc
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from testsuite.objects import Rule, Value
+    from testsuite.objects import Rule, ABCValue
 
 
 class Authorizations(abc.ABC):
@@ -27,7 +27,7 @@ class Authorizations(abc.ABC):
         """Adds JSON pattern-matching authorization rule (authorization.json)"""
 
     @abc.abstractmethod
-    def kubernetes(self, name: str, user: "Value", kube_attrs: dict, **common_features):
+    def kubernetes(self, name: str, user: "ABCValue", kube_attrs: dict, **common_features):
         """Adds kubernetes authorization rule."""
 
 

--- a/testsuite/openshift/objects/auth_config/sections.py
+++ b/testsuite/openshift/objects/auth_config/sections.py
@@ -1,8 +1,17 @@
 """AuthConfig CR object"""
-from dataclasses import asdict
 from typing import Dict, Literal, Iterable, TYPE_CHECKING
 
-from testsuite.objects import Identities, Metadata, Responses, MatchExpression, Authorizations, Rule, Cache, Value
+from testsuite.objects import (
+    asdict,
+    Identities,
+    Metadata,
+    Responses,
+    MatchExpression,
+    Authorizations,
+    Rule,
+    Cache,
+    ABCValue,
+)
 from testsuite.openshift.objects import modify
 
 if TYPE_CHECKING:
@@ -45,7 +54,7 @@ class Section:
         if metrics:
             item["metrics"] = metrics
         if cache:
-            item["cache"] = cache.to_dict()
+            item["cache"] = asdict(cache)
         if priority:
             item["priority"] = priority
         self.section.append(item)
@@ -215,7 +224,7 @@ class AuthorizationsSection(Section, Authorizations):
         self.add_item(name, {"opa": {"externalRegistry": {"endpoint": endpoint, "ttl": ttl}}}, **common_features)
 
     @modify
-    def kubernetes(self, name: str, user: Value, kube_attrs: dict, **common_features):
+    def kubernetes(self, name: str, user: ABCValue, kube_attrs: dict, **common_features):
         """Adds Kubernetes authorization
 
         :param name: name of kubernetes authorization
@@ -226,7 +235,7 @@ class AuthorizationsSection(Section, Authorizations):
         self.add_item(
             name,
             {
-                "kubernetes": {"user": user.to_dict(), "resourceAttributes": kube_attrs},
+                "kubernetes": {"user": asdict(user), "resourceAttributes": kube_attrs},
             },
             **common_features
         )

--- a/testsuite/tests/kuadrant/authorino/caching/metadata/test_caching.py
+++ b/testsuite/tests/kuadrant/authorino/caching/metadata/test_caching.py
@@ -3,7 +3,7 @@ from time import sleep
 
 import pytest
 
-from testsuite.objects import Cache, Value
+from testsuite.objects import Cache, ValueFrom
 from testsuite.utils import extract_response
 
 
@@ -16,7 +16,7 @@ def cache_ttl():
 @pytest.fixture(scope="module")
 def authorization(authorization, module_label, expectation_path, cache_ttl):
     """Adds Cached Metadata to the AuthConfig"""
-    meta_cache = Cache(cache_ttl, Value(jsonPath="context.request.http.path"))
+    meta_cache = Cache(cache_ttl, ValueFrom("context.request.http.path"))
     authorization.metadata.http_metadata(module_label, expectation_path, "GET", cache=meta_cache)
     return authorization
 

--- a/testsuite/tests/kuadrant/authorino/operator/tls/test_webhook.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/test_webhook.py
@@ -8,7 +8,7 @@ import pytest
 import openshift as oc
 from openshift import OpenShiftPythonException
 
-from testsuite.objects import Authorization, Rule, Value
+from testsuite.objects import Authorization, Rule, ValueFrom
 from testsuite.certificates import CertInfo
 from testsuite.utils import cert_builder
 from testsuite.openshift.objects.ingress import Ingress
@@ -78,7 +78,7 @@ def authorization(authorization, openshift, module_label, authorino_domain) -> A
 
     # add OPA policy to process admission webhook request
     authorization.authorization.opa_policy("features", OPA_POLICY)
-    user_value = Value(jsonPath="auth.identity.username")
+    user_value = ValueFrom("auth.identity.username")
 
     when = [
         Rule("auth.authorization.features.allow", "eq", "true"),


### PR DESCRIPTION
This PR includes:
 - Refactor of Value class to three dataclasses removing redundant test of exclusivity.
 - Replacing usage of `dataclasses.asdict()` and direct `object.to_dict()` method calls in favor of new `to_dict()` function