### PR TITLE
Replaces deprecated files() API

### DIFF
--- a/testsuite/openshift/envoy.py
+++ b/testsuite/openshift/envoy.py
@@ -102,20 +102,19 @@ class TLSEnvoy(Envoy):
         return HttpxBackoffClient(base_url=f"https://{self.hostname}", **kwargs)
 
     def commit(self):
-        with resources.path("testsuite.resources.tls", "envoy.yaml") as path:
-            self.envoy_objects = self.openshift.new_app(
-                path,
-                {
-                    "NAME": self.name,
-                    "LABEL": self.label,
-                    "AUTHORINO_URL": self.authorino.authorization_url,
-                    "UPSTREAM_URL": self.httpbin_hostname,
-                    "AUTHORINO_CA_SECRET": self.authorino_ca_secret,
-                    "ENVOY_CA_SECRET": self.backend_ca_secret,
-                    "ENVOY_CERT_SECRET": self.envoy_cert_secret,
-                    "ENVOY_IMAGE": self.image,
-                },
-            )
+        self.envoy_objects = self.openshift.new_app(
+            resources.files("testsuite.resources.tls").joinpath("envoy.yaml"),
+            {
+                "NAME": self.name,
+                "LABEL": self.label,
+                "AUTHORINO_URL": self.authorino.authorization_url,
+                "UPSTREAM_URL": self.httpbin_hostname,
+                "AUTHORINO_CA_SECRET": self.authorino_ca_secret,
+                "ENVOY_CA_SECRET": self.backend_ca_secret,
+                "ENVOY_CERT_SECRET": self.envoy_cert_secret,
+                "ENVOY_IMAGE": self.image,
+            },
+        )
 
         with self.openshift.context:
             assert self.openshift.is_ready(self.envoy_objects.narrow("deployment")), "Envoy wasn't ready in time"

--- a/testsuite/openshift/httpbin.py
+++ b/testsuite/openshift/httpbin.py
@@ -29,10 +29,10 @@ class Httpbin(LifecycleObject, Referencable):
         return f"{self.name}.{self.openshift.project}.svc.cluster.local"
 
     def commit(self):
-        with resources.path("testsuite.resources", "httpbin.yaml") as path:
-            self.httpbin_objects = self.openshift.new_app(
-                path, {"NAME": self.name, "LABEL": self.label, "REPLICAS": self.replicas}
-            )
+        self.httpbin_objects = self.openshift.new_app(
+            resources.files("testsuite.resources").joinpath("httpbin.yaml"),
+            {"NAME": self.name, "LABEL": self.label, "REPLICAS": self.replicas},
+        )
 
         with self.openshift.context:
             assert self.openshift.is_ready(self.httpbin_objects.narrow("deployment")), "Httpbin wasn't ready in time"

--- a/testsuite/tests/kuadrant/authorino/dinosaur/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/dinosaur/conftest.py
@@ -104,27 +104,23 @@ def authorization(
     request,
 ):
     """Creates AuthConfig object from template"""
-    with resources.path("testsuite.resources", "dinosaur_config.yaml") as path:
-        auth = openshift.new_app(
-            path,
-            {
-                "NAME": blame("ac"),
-                "NAMESPACE": openshift.project,
-                "LABEL": module_label,
-                "HOST": envoy.hostname,
-                "RHSSO_ISSUER": rhsso.well_known["issuer"],
-                "ADMIN_ISSUER": admin_rhsso.well_known["issuer"],
-                "TERMS_AND_CONDITIONS": terms_and_conditions("false"),
-                "CLUSTER_INFO": cluster_info(rhsso.client_name),
-                "RESOURCE_INFO": resource_info("123", rhsso.client_name),
-            },
-        )
+    auth = openshift.new_app(
+        resources.files("testsuite.resources").joinpath("dinosaur_config.yaml"),
+        {
+            "NAME": blame("ac"),
+            "NAMESPACE": openshift.project,
+            "LABEL": module_label,
+            "HOST": envoy.hostname,
+            "RHSSO_ISSUER": rhsso.well_known["issuer"],
+            "ADMIN_ISSUER": admin_rhsso.well_known["issuer"],
+            "TERMS_AND_CONDITIONS": terms_and_conditions("false"),
+            "CLUSTER_INFO": cluster_info(rhsso.client_name),
+            "RESOURCE_INFO": resource_info("123", rhsso.client_name),
+        },
+    )
 
-        def _delete():
-            auth.delete()
-
-        request.addfinalizer(_delete)
-        return auth
+    request.addfinalizer(auth.delete)
+    return auth
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
`importlib.resources.path` deprecated since Python 3.11 in favor of `importlib.resources.files`