### PR TITLE
Add automatic builds

### DIFF
--- a/.github/workflows/build_release_image.yml
+++ b/.github/workflows/build_release_image.yml
@@ -1,0 +1,54 @@
+name: Build and push image
+
+on:
+  push:
+    tags:
+      - v*
+
+env:
+  IMG_REGISTRY_HOST: quay.io
+  IMG_REGISTRY_ORG: kuadrant
+  IMG_NAME: testsuite
+
+jobs:
+  build:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Add tag name
+        id: tag-name
+        run: |
+          echo "IMG_TAGS=$(echo ${{ github.ref_name }} | sed -r 's/(v)(.*)/\2/')" >> $GITHUB_ENV
+      - name: Format version
+        id: format-version
+        run: |
+          echo "IMG_TAGS=${{ env.IMG_TAGS }} $(echo ${{ env.IMG_TAGS }} | sed -r 's/(.*)(\.[0-9]*)(.*)/\1/')" >> $GITHUB_ENV
+      - name: Add latest tag
+        if: ${{ !contains(github.ref_name, 'rc') }}
+        id: add-latest-tag
+        run: |
+          echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+      - name: Build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMG_NAME }}
+          tags: ${{ env.IMG_TAGS }}
+          layers: true
+          platforms: linux/amd64
+          containerfiles: |
+            ./Dockerfile
+      - name: Push Image
+        if: ${{ !env.ACT }}
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
+          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+      - name: Print Image URL
+        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/.github/workflows/build_unstable_image.yml
+++ b/.github/workflows/build_unstable_image.yml
@@ -2,12 +2,14 @@ name: Build and push image
 
 on:
   push:
-    tags:
-      - v*
+    branches:
+      - main
 
 env:
   IMG_REGISTRY_HOST: quay.io
   IMG_REGISTRY_ORG: kuadrant
+  IMG_NAME: testsuite
+  IMG_TAGS: unstable
 
 jobs:
   build:
@@ -16,24 +18,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      - name: Add tag name
-        id: tag-name
-        run: |
-          echo "IMG_TAGS=$(echo ${{ github.ref_name }} | sed -r 's/(v)(.*)/\2/')" >> $GITHUB_ENV
-      - name: Format version
-        id: format-version
-        run: |
-          echo "IMG_TAGS=${{ env.IMG_TAGS }} $(echo ${{ env.IMG_TAGS }} | sed -r 's/(.*)(\.[0-9]*)(.*)/\1/')" >> $GITHUB_ENV
-      - name: Add latest tag
-        if: ${{ !contains(github.ref_name, 'rc') }}
-        id: add-latest-tag
-        run: |
-          echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
-          image: testsuite
+          image: ${{ env.IMG_NAME }}
           tags: ${{ env.IMG_TAGS }}
           layers: true
           platforms: linux/amd64

--- a/.github/workflows/promote_to_latest.yml
+++ b/.github/workflows/promote_to_latest.yml
@@ -1,0 +1,29 @@
+name: Promotes unstable image to latest
+
+on:
+  workflow_dispatch:
+
+env:
+  IMG_REGISTRY_HOST: quay.io
+  IMG_REGISTRY_ORG: kuadrant
+  IMG_NAME: testsuite
+
+jobs:
+  build:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
+          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+      - name: Create repository name
+        run: |
+          echo "REPOSITORY=${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.IMG_NAME }}" >> $GITHUB_ENV
+      - name: Promotes to latest
+        run:
+          podman pull ${{ env.REPOSITORY }}:unstable
+          podman tag ${{ env.REPOSITORY }}:unstable ${{ env.REPOSITORY }}:latest
+          podman push ${{ env.REPOSITORY }}:latest


### PR DESCRIPTION
Currently, the image is only built with each release, which requires manual steps to do. This PR proposes automatic builds to the `unstable` tag with occasional promotes to `latest` without doing a full release to create more frequent builds.

In the future we need to revise how we do releases and this should suffice until we figure it out.