### PR TITLE
Unify gateways

### DIFF
--- a/testsuite/openshift/objects/gateway_api/gateway.py
+++ b/testsuite/openshift/objects/gateway_api/gateway.py
@@ -8,8 +8,6 @@ from testsuite.openshift.client import OpenShiftClient
 from testsuite.openshift.objects import OpenShiftObject
 from testsuite.openshift.objects.proxy import Proxy
 from testsuite.openshift.objects.route import Route
-from testsuite.utils import randomize
-
 from . import Referencable
 from .route import HTTPRoute, HostnameWrapper
 
@@ -17,56 +15,7 @@ if typing.TYPE_CHECKING:
     from testsuite.openshift.httpbin import Httpbin
 
 
-# pylint: disable=too-many-instance-attributes
-class Gateway(Referencable, Proxy):
-    """Gateway object already present on the server"""
-
-    def __init__(self, openshift: OpenShiftClient, name, namespace, label, backend: "Httpbin") -> None:
-        super().__init__()
-        self.openshift = openshift
-        self.system_openshift = openshift.change_project(namespace)
-        self.name = name
-        self.label = label
-        self.namespace = namespace
-        self.backend = backend
-
-        self.route: HTTPRoute = None  # type: ignore
-        self.selector: Selector = None  # type: ignore
-
-    def _expose_route(self, name, service):
-        return self.system_openshift.routes.expose(name, service, port=8080)
-
-    def expose_hostname(self, name) -> Route:
-        route = self._expose_route(name, self.name)
-        if self.route is None:
-            self.route = HTTPRoute.create_instance(
-                self.openshift,
-                randomize(self.name),
-                self,
-                route.model.spec.host,
-                self.backend,
-                labels={"app": self.label},
-            )
-            self.selector = self.route.self_selector()
-            self.route.commit()
-        else:
-            self.route.add_hostname(route.model.spec.host)
-        self.selector = self.selector.union(route.self_selector())
-        return HostnameWrapper(self.route, route.model.spec.host)
-
-    def commit(self):
-        pass
-
-    def delete(self):
-        with self.openshift.context:
-            self.selector.delete()
-
-    @property
-    def reference(self):
-        return {"group": "gateway.networking.k8s.io", "kind": "Gateway", "name": self.name, "namespace": self.namespace}
-
-
-class MGCGateway(OpenShiftObject, Referencable):
+class Gateway(OpenShiftObject, Referencable):
     """Gateway object for purposes of MGC"""
 
     @classmethod
@@ -74,26 +23,23 @@ class MGCGateway(OpenShiftObject, Referencable):
         cls,
         openshift: OpenShiftClient,
         name: str,
-        gateway_class_name: str,
+        gateway_class: str,
         hostname: str,
-        placement: typing.Optional[str] = None,
+        labels: dict[str, str] = None,
     ):
         """Creates new instance of Gateway"""
-        labels = {}
-        if placement is not None:
-            labels = {"cluster.open-cluster-management.io/placement": placement}
 
         model = {
             "apiVersion": "gateway.networking.k8s.io/v1beta1",
             "kind": "Gateway",
-            "metadata": {"name": name, "namespace": openshift.project, "labels": labels},
+            "metadata": {"name": name, "labels": labels},
             "spec": {
-                "gatewayClassName": gateway_class_name,
+                "gatewayClassName": gateway_class,
                 "listeners": [
                     {
                         "name": "api",
-                        "port": 443,
-                        "protocol": "HTTPS",
+                        "port": 8080,
+                        "protocol": "HTTP",
                         "hostname": hostname,
                         "allowedRoutes": {"namespaces": {"from": "All"}},
                     }
@@ -102,6 +48,47 @@ class MGCGateway(OpenShiftObject, Referencable):
         }
 
         return cls(model, context=openshift.context)
+
+    def wait_for_ready(self) -> bool:
+        """Waits for the gateway to be ready"""
+        return True
+
+    @property
+    def hostname(self):
+        """Hostname of the first listener"""
+        return self.model.spec.listeners[0].hostname
+
+    @property
+    def reference(self):
+        return {
+            "group": "gateway.networking.k8s.io",
+            "kind": "Gateway",
+            "name": self.name(),
+            "namespace": self.namespace(),
+        }
+
+
+class MGCGateway(Gateway):
+    """Gateway object for purposes of MGC"""
+
+    @classmethod
+    def create_instance(
+        cls,
+        openshift: OpenShiftClient,
+        name: str,
+        gateway_class: str,
+        hostname: str,
+        labels: dict[str, str] = None,
+        placement: typing.Optional[str] = None,
+    ):
+        """Creates new instance of Gateway"""
+        if labels is None:
+            labels = {}
+
+        if placement is not None:
+            labels["cluster.open-cluster-management.io/placement"] = placement
+
+        return Gateway.create_instance(openshift, name, gateway_class, hostname, labels)
 
     def is_ready(self):
         """Checks whether the gateway got its IP address assigned thus is ready"""
@@ -121,16 +108,44 @@ class MGCGateway(OpenShiftObject, Referencable):
             assert success, "Gateway didn't get ready in time"
             self.refresh()
 
-    @property
-    def hostname(self):
-        """Hostname of the first listener"""
-        return self.model["spec"]["listeners"][0]["hostname"]
 
-    @property
-    def reference(self):
-        return {
-            "group": "gateway.networking.k8s.io",
-            "kind": "Gateway",
-            "name": self.name(),
-            "namespace": self.namespace(),
-        }
+class GatewayProxy(Proxy):
+    """Wrapper for Gateway object to make it a Proxy implementation e.g. exposing hostnames outside of the cluster"""
+
+    def __init__(self, openshift: OpenShiftClient, gateway: Gateway, label, backend: "Httpbin") -> None:
+        super().__init__()
+        self.openshift = openshift
+        self.gateway = gateway
+        self.name = gateway.name()
+        self.label = label
+        self.backend = backend
+
+        self.route: HTTPRoute = None  # type: ignore
+        self.selector: Selector = None  # type: ignore
+
+    def _expose_route(self, name, service):
+        return self.openshift.routes.expose(name, service, port="api")
+
+    def expose_hostname(self, name) -> Route:
+        route = self._expose_route(name, self.name)
+        if self.route is None:
+            self.route = HTTPRoute.create_instance(
+                self.openshift,
+                self.name,
+                self.gateway,
+                route.model.spec.host,
+                self.backend,
+                labels={"app": self.label},
+            )
+            self.selector = self.route.self_selector()
+            self.route.commit()
+        else:
+            self.route.add_hostname(route.model.spec.host)
+        self.selector.union(route.self_selector())
+        return HostnameWrapper(self.route, route.model.spec.host)
+
+    def commit(self):
+        pass
+
+    def delete(self):
+        self.selector.delete()

--- a/testsuite/tests/mgc/test_basic.py
+++ b/testsuite/tests/mgc/test_basic.py
@@ -14,11 +14,10 @@ Notes:
 * dnspolicies leak at this moment
 """
 from time import sleep
-import httpx
+
 import pytest
-from testsuite.openshift.httpbin import Httpbin
+
 from testsuite.openshift.objects.gateway_api.gateway import MGCGateway
-from testsuite.openshift.objects.gateway_api.route import HTTPRoute
 
 pytestmark = [pytest.mark.mgc]
 
@@ -37,60 +36,26 @@ def hostname(blame, base_domain):
 
 
 @pytest.fixture(scope="module")
-def gateway(request, openshift, blame, hostname):
+def gateway(request, openshift, blame, hostname, module_label):
     """Creates and returns configured and ready upstream Gateway"""
     upstream_gateway = MGCGateway.create_instance(
         openshift=openshift,
         name=blame("mgc-gateway"),
-        gateway_class_name="kuadrant-multi-cluster-gateway-instance-per-cluster",
+        gateway_class="kuadrant-multi-cluster-gateway-instance-per-cluster",
         hostname=hostname,
         placement="local-gateway",
+        labels={"app": module_label},
     )
-    upstream_gateway.commit()
     request.addfinalizer(upstream_gateway.delete)
+    upstream_gateway.commit()
     upstream_gateway.wait_for_ready()
 
-    return upstream_gateway
-
-
-def _downstream_gateway_of_gateway(gateway, openshift):
-    """
-    Upon upstream Gateway creation MGC creates downstream Gateways on spoke clusters according to the Placement decision
-    HTTPRoutes must be created on the spoke clusters binding to the corresponding downstream Gateway
-    """
-    # in future this function may be a method of MGCGateway if done properly
-    openshift = openshift.change_project(f"kuadrant-{gateway.namespace()}")
-    downstream_gateway = openshift.do_action("get", ["gateway", gateway.name(), "-o", "yaml"], parse_output=False)
-    downstream_gateway = MGCGateway(string_to_model=downstream_gateway.out(), context=openshift.context)
-    # should be deleted automatically by the mgc operator upon mgc gateway deletion
-    return downstream_gateway
-
-
-@pytest.fixture(scope="module")
-def backend(request, openshift2, blame, label):
-    """Deploys Httpbin backend"""
-    httpbin = Httpbin(openshift2, blame("httpbin"), label)
-    request.addfinalizer(httpbin.delete)
-    httpbin.commit()
-    return httpbin
-
-
-@pytest.fixture(scope="module")
-def http_route(gateway, backend, blame, openshift2):
-    """Creates and returns HTTPRoute bound to the backend and the downstream Gateway"""
-    downstream_gateway = _downstream_gateway_of_gateway(gateway, openshift2)
-
-    route = HTTPRoute.create_instance(
-        openshift2,
-        blame("route"),
-        parent=downstream_gateway,
-        hostname=downstream_gateway.hostname,
-        backend=backend,
+    openshift = openshift.change_project(f"kuadrant-{upstream_gateway.namespace()}")
+    downstream_gateway = openshift.do_action(
+        "get", ["gateway", upstream_gateway.name(), "-o", "yaml"], parse_output=False
     )
-
-    route.commit()
-    yield route
-    route.delete()
+    downstream_gateway = MGCGateway(string_to_model=downstream_gateway.out(), context=openshift.context)
+    return downstream_gateway
 
 
 def test_gateway_readiness(gateway):
@@ -98,15 +63,14 @@ def test_gateway_readiness(gateway):
     assert gateway.is_ready()
 
 
-def test_smoke(http_route):
+def test_smoke(route):
     """
     Tests whether the backend, exposed using the HTTPRoute and Gateway, was exposed correctly,
     having a tls secured endpoint with a hostname managed by MGC
     """
-    backend_hostname = http_route.hostname[0]
-    backend_client = httpx.Client(verify=False)  # self-signed certificate; TBD
+    backend_client = route.client(verify=False)  # self-signed certificate; TBD
 
     sleep(30)  # wait for DNS record to propagate correctly; TBD
 
-    response = backend_client.get(f"https://{backend_hostname}/get")
+    response = backend_client.get("get")
     assert response.status_code == 200


### PR DESCRIPTION
Depends on #231. Unifies both `Gateway` and `MGCGateway` into one workflow, where the gateway object is interchangeable and introduces `GatewayProxy` wrapper, which serves as a Proxy implementation.