### PR TITLE
Add kuadrant namespace annotation to gateway

### DIFF
--- a/testsuite/openshift/objects/gateway_api/gateway.py
+++ b/testsuite/openshift/objects/gateway_api/gateway.py
@@ -25,6 +25,7 @@ class Gateway(OpenShiftObject, Referencable):
         name: str,
         gateway_class: str,
         hostname: str,
+        kuadrant_namespace: str,
         labels: dict[str, str] = None,
     ):
         """Creates new instance of Gateway"""
@@ -32,7 +33,11 @@ class Gateway(OpenShiftObject, Referencable):
         model = {
             "apiVersion": "gateway.networking.k8s.io/v1beta1",
             "kind": "Gateway",
-            "metadata": {"name": name, "labels": labels},
+            "metadata": {
+                "name": name,
+                "labels": labels,
+                "annotations": {"kuadrant.io/namespace": kuadrant_namespace},
+            },
             "spec": {
                 "gatewayClassName": gateway_class,
                 "listeners": [
@@ -83,6 +88,7 @@ class MGCGateway(Gateway):
         name: str,
         gateway_class: str,
         hostname: str,
+        kuadrant_namespace: str,
         labels: dict[str, str] = None,
         placement: typing.Optional[str] = None,
     ):
@@ -93,7 +99,9 @@ class MGCGateway(Gateway):
         if placement is not None:
             labels["cluster.open-cluster-management.io/placement"] = placement
 
-        return super(MGCGateway, cls).create_instance(openshift, name, gateway_class, hostname, labels)
+        return super(MGCGateway, cls).create_instance(
+            openshift, name, gateway_class, hostname, kuadrant_namespace, labels
+        )
 
     def get_spoke_gateway(self, spokes: dict[str, OpenShiftClient]) -> "MGCGateway":
         """

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -242,9 +242,11 @@ def backend(request, openshift, blame, label):
 
 
 @pytest.fixture(scope="module")
-def gateway(request, openshift, blame, wildcard_domain, module_label) -> Gateway:
+def gateway(request, openshift, blame, wildcard_domain, module_label, testconfig) -> Gateway:
     """Gateway object to use when working with Gateway API"""
-    gateway = Gateway.create_instance(openshift, blame("gw"), "istio", wildcard_domain, {"app": module_label})
+    gateway = Gateway.create_instance(
+        openshift, blame("gw"), "istio", wildcard_domain, testconfig["kuadrant"]["project"], {"app": module_label}
+    )
     request.addfinalizer(gateway.delete)
     gateway.commit()
     gateway.wait_for_ready()

--- a/testsuite/tests/mgc/conftest.py
+++ b/testsuite/tests/mgc/conftest.py
@@ -29,7 +29,7 @@ def spokes(testconfig):
 
 
 @pytest.fixture(scope="module")
-def upstream_gateway(request, openshift, blame, hostname, module_label):
+def upstream_gateway(request, openshift, blame, hostname, module_label, testconfig):
     """Creates and returns configured and ready upstream Gateway"""
     upstream_gateway = MGCGateway.create_instance(
         openshift=openshift,
@@ -37,6 +37,7 @@ def upstream_gateway(request, openshift, blame, hostname, module_label):
         gateway_class="kuadrant-multi-cluster-gateway-instance-per-cluster",
         hostname=f"*.{hostname}",
         placement="http-gateway",
+        kuadrant_namespace=testconfig["kuadrant"]["project"],
         labels={"app": module_label},
     )
     request.addfinalizer(upstream_gateway.delete)


### PR DESCRIPTION
This will fix the Reconciliation error of RateLimitPolicy in Limitador tests but the tests themselves are still failing and need more investigation to fix.
Related issue: https://github.com/Kuadrant/kuadrant-operator/issues/259