### PR TITLE
Authpolicy v1beta2 reformat

### DIFF
--- a/testsuite/objects/__init__.py
+++ b/testsuite/objects/__init__.py
@@ -73,12 +73,14 @@ class Selector:
 class Credentials:
     """Dataclass for Credentials structure"""
 
-    in_location: str
+    in_location: Literal["authorizationHeader", "customHeader", "queryString", "cookie"]
     keySelector: str
 
     def asdict(self):
-        """Custom asdict, because I cannot use 'in' as a name"""
-        return {"in": self.in_location, "keySelector": self.keySelector}
+        """Custom asdict because of needing to put location as parent dict key for inner dict"""
+        if self.in_location == "authorizationHeader":
+            return {self.in_location: {"prefix": self.keySelector}}
+        return {self.in_location: {"name": self.keySelector}}
 
 
 @dataclass
@@ -116,39 +118,7 @@ class Value(ABCValue):
 class ValueFrom(ABCValue):
     """Dataclass for dynamic Value. It contains reference path to existing value in AuthJson."""
 
-    authJSON: str
-
-    def asdict(self):
-        """Override `asdict` function"""
-        return {"valueFrom": {"authJSON": self.authJSON}}
-
-
-@dataclass
-class Property:
-    """Dataclass for static and dynamic values. Property is a Value with name."""
-
-    name: str
-    value: ABCValue
-
-    def asdict(self):
-        """Override `asdict` function"""
-        return {"name": self.name, **asdict(self.value)}
-
-
-@dataclass
-class ExtendedProperty(Property):
-    """
-    Dataclass extending Property class adding optional `overwrite` feature
-    used in extended_properties functionality in Identity section.
-    """
-
-    overwrite: Optional[bool] = None
-
-    def asdict(self):
-        """Extend inherited `asdict` function to include new attributes."""
-        if self.overwrite is not None:
-            return {**super().asdict(), "overwrite": self.overwrite}
-        return super().asdict()
+    selector: str
 
 
 @dataclass

--- a/testsuite/openshift/objects/auth_config/__init__.py
+++ b/testsuite/openshift/objects/auth_config/__init__.py
@@ -25,7 +25,7 @@ class AuthConfig(OpenShiftObject):
     @cached_property
     def identity(self) -> IdentitySection:
         """Gives access to identity settings"""
-        return IdentitySection(self, "identity")
+        return IdentitySection(self, "authentication")
 
     @cached_property
     def metadata(self) -> MetadataSection:
@@ -48,7 +48,7 @@ class AuthConfig(OpenShiftObject):
     ):
         """Creates base instance"""
         model: Dict = {
-            "apiVersion": "authorino.kuadrant.io/v1beta1",
+            "apiVersion": "authorino.kuadrant.io/v1beta2",
             "kind": "AuthConfig",
             "metadata": {"name": name, "namespace": openshift.project, "labels": labels},
             "spec": {"hosts": hostnames or [route.hostname]},  # type: ignore
@@ -70,13 +70,6 @@ class AuthConfig(OpenShiftObject):
     def remove_all_hosts(self):
         """Remove all hosts"""
         self.model.spec.hosts = []
-
-    @modify
-    def set_deny_with(self, code, value):
-        """Set denyWith"""
-        self.auth_section["denyWith"] = {
-            "unauthenticated": {"code": code, "headers": [{"name": "Location", "valueFrom": {"authJSON": value}}]}
-        }
 
     @modify
     def add_rule(self, when: list[Rule]):

--- a/testsuite/openshift/objects/auth_config/__init__.py
+++ b/testsuite/openshift/objects/auth_config/__init__.py
@@ -2,7 +2,7 @@
 from functools import cached_property
 from typing import Dict, List, Optional
 
-from testsuite.objects import Rule
+from testsuite.objects import Rule, asdict
 from testsuite.openshift.client import OpenShiftClient
 from testsuite.openshift.objects import OpenShiftObject, modify
 from .sections import IdentitySection, MetadataSection, ResponseSection, AuthorizationSection
@@ -75,4 +75,4 @@ class AuthConfig(OpenShiftObject):
     def add_rule(self, when: list[Rule]):
         """Add rule for the skip of entire AuthConfig"""
         self.auth_section.setdefault("when", [])
-        self.auth_section["when"].extend([vars(x) for x in when])
+        self.auth_section["when"].extend([asdict(x) for x in when])

--- a/testsuite/openshift/objects/auth_config/auth_policy.py
+++ b/testsuite/openshift/objects/auth_config/auth_policy.py
@@ -1,7 +1,10 @@
 """Module containing classes related to Auth Policy"""
 from typing import Dict, List
 
+from testsuite.objects import Rule, asdict
+
 from testsuite.openshift.client import OpenShiftClient
+from testsuite.openshift.objects import modify
 from testsuite.openshift.objects.auth_config import AuthConfig
 from testsuite.openshift.objects.gateway_api.route import HTTPRoute
 
@@ -55,3 +58,9 @@ class AuthPolicy(AuthConfig):
 
     def remove_all_hosts(self):
         return self.route.remove_all_hostnames()
+
+    @modify
+    def add_rule(self, when: list[Rule]):
+        """Add rule for the skip of entire AuthPolicy"""
+        self.model.spec.setdefault("when", [])
+        self.model.spec["when"].extend([asdict(x) for x in when])

--- a/testsuite/openshift/objects/auth_config/auth_policy.py
+++ b/testsuite/openshift/objects/auth_config/auth_policy.py
@@ -23,7 +23,7 @@ class AuthPolicy(AuthConfig):
 
     @property
     def auth_section(self):
-        return self.model.spec.setdefault("authScheme", {})
+        return self.model.spec.setdefault("rules", {})
 
     # pylint: disable=unused-argument
     @classmethod
@@ -37,7 +37,7 @@ class AuthPolicy(AuthConfig):
     ):
         """Creates base instance"""
         model: Dict = {
-            "apiVersion": "kuadrant.io/v1beta1",
+            "apiVersion": "kuadrant.io/v1beta2",
             "kind": "AuthPolicy",
             "metadata": {"name": name, "namespace": openshift.project, "labels": labels},
             "spec": {

--- a/testsuite/tests/kuadrant/authorino/conditions/section_conditions/test_response_condition.py
+++ b/testsuite/tests/kuadrant/authorino/conditions/section_conditions/test_response_condition.py
@@ -1,7 +1,7 @@
 """Test condition to skip the response section of AuthConfig"""
 import pytest
 
-from testsuite.objects import Property, Rule, Value
+from testsuite.objects import Rule, Value
 from testsuite.utils import extract_response
 
 
@@ -9,7 +9,7 @@ from testsuite.utils import extract_response
 def authorization(authorization):
     """Add to the AuthConfig response, which will only trigger on POST requests"""
     authorization.responses.add_json(
-        "simple", [Property("data", Value("response"))], when=[Rule("context.request.http.method", "eq", "POST")]
+        "simple", {"data": Value("response")}, when=[Rule("context.request.http.method", "eq", "POST")]
     )
     return authorization
 

--- a/testsuite/tests/kuadrant/authorino/identity/api_key/test_auth_credentials.py
+++ b/testsuite/tests/kuadrant/authorino/identity/api_key/test_auth_credentials.py
@@ -4,7 +4,7 @@ import pytest
 from testsuite.objects import Credentials
 
 
-@pytest.fixture(scope="module", params=["authorization_header", "custom_header", "query", "cookie"])
+@pytest.fixture(scope="module", params=["authorizationHeader", "customHeader", "queryString", "cookie"])
 def credentials(request):
     """Location where are auth credentials passed"""
     return Credentials(request.param, "APIKEY")

--- a/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_extended_properties.py
+++ b/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_extended_properties.py
@@ -1,7 +1,7 @@
 """Basic tests for extended properties"""
 import pytest
 
-from testsuite.objects import Value, ValueFrom, ExtendedProperty
+from testsuite.objects import Value, ValueFrom
 from testsuite.utils import extract_response
 
 
@@ -16,14 +16,15 @@ def authorization(authorization, rhsso):
     authorization.identity.add_oidc(
         "rhsso",
         rhsso.well_known["issuer"],
-        extended_properties=[
-            ExtendedProperty("property_static", Value("static")),
-            # ValueFrom points to the request uri
-            ExtendedProperty("property_dynamic", ValueFrom("context.request.http.path")),
-            ExtendedProperty("property_chain_static", ValueFrom("auth.identity.property_static")),
-            ExtendedProperty("property_chain_dynamic", ValueFrom("auth.identity.property_dynamic")),
-            ExtendedProperty("property_chain_self", ValueFrom("auth.identity.property_chain_self"), overwrite=True),
-        ],
+        defaults_properties={
+            "property_static": Value("static"),
+            "property_dynamic": ValueFrom("context.request.http.path"),
+            "property_chain_static": ValueFrom("auth.identity.property_static"),
+            "property_chain_dynamic": ValueFrom("auth.identity.property_dynamic"),
+        },
+        overrides_properties={
+            "property_chain_self": ValueFrom("auth.identity.property_chain_self"),
+        },
     )
     authorization.responses.add_simple("auth.identity")
     return authorization

--- a/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_overwriting.py
+++ b/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_overwriting.py
@@ -1,25 +1,27 @@
 """https://github.com/Kuadrant/authorino/pull/399"""
 import pytest
 
-from testsuite.objects import ExtendedProperty, Value
+from testsuite.objects import Value
 from testsuite.utils import extract_response
 
 
 @pytest.fixture(scope="module")
 def authorization(authorization):
     """
-    Add plain authentication with three extended properties:
-    explicit False, explicit True and missing which should be default False.
+    Add plain authentication with defaults and overrides properties.
     Add simple response to expose `auth.identity` part of AuthJson
     """
     authorization.identity.add_plain(
         "plain",
         "context.request.http.headers.x-user|@fromstr",
-        extended_properties=[
-            ExtendedProperty("name", Value("bar"), overwrite=False),
-            ExtendedProperty("age", Value(35), overwrite=True),
-            ExtendedProperty("group", Value("admin")),
-        ],
+        defaults_properties={
+            "name": Value("bar"),
+            "group": Value("admin"),
+        },
+        overrides_properties={
+            "age": Value(35),
+            "expire": Value("1-12-1999"),
+        },
     )
     authorization.responses.add_simple("auth.identity")
 
@@ -28,9 +30,10 @@ def authorization(authorization):
 
 def test_overwrite(client):
     """
-    Test the ExtendedProperty overwrite functionality overwriting the value in headers when True.
+    Test overriding and defaults capability. Defaults must not override the value in header but Overrides must do so.
     """
-    response = client.get("/get", headers={"x-user": '{"name":"foo","age":30,"group":"guest"}'})
+    response = client.get("/get", headers={"x-user": '{"name":"foo","age":30}'})
     assert extract_response(response)["name"] % "MISSING" == "foo"
     assert extract_response(response)["age"] % "MISSING" == 35
-    assert extract_response(response)["group"] % "MISSING" == "guest"
+    assert extract_response(response)["group"] % "MISSING" == "admin"
+    assert extract_response(response)["expire"] % "MISSING" == "1-12-1999"

--- a/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_token_normalization.py
+++ b/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_token_normalization.py
@@ -1,6 +1,6 @@
 """https://github.com/Kuadrant/authorino/blob/main/docs/user-guides/token-normalization.md"""
 import pytest
-from testsuite.objects import Value, ValueFrom, ExtendedProperty, Rule
+from testsuite.objects import Value, ValueFrom, Rule
 from testsuite.httpx.auth import HeaderApiKeyAuth, HttpxOidcClientAuth
 
 
@@ -37,10 +37,12 @@ def authorization(authorization, rhsso, api_key):
     authorization.identity.add_oidc(
         "rhsso",
         rhsso.well_known["issuer"],
-        extended_properties=[ExtendedProperty("roles", ValueFrom("auth.identity.realm_access.roles"))],
+        overrides_properties={"roles": ValueFrom("auth.identity.realm_access.roles")},
     )
     authorization.identity.add_api_key(
-        "api_key", selector=api_key.selector, extended_properties=[ExtendedProperty("roles", Value(["admin"]))]
+        "api_key",
+        selector=api_key.selector,
+        defaults_properties={"roles": Value(["admin"])},
     )
 
     rule = Rule(selector="auth.identity.roles", operator="incl", value="admin")

--- a/testsuite/tests/kuadrant/authorino/identity/rhsso/test_auth_credentials.py
+++ b/testsuite/tests/kuadrant/authorino/identity/rhsso/test_auth_credentials.py
@@ -5,7 +5,7 @@ from testsuite.openshift.objects.auth_config import AuthConfig
 from testsuite.objects import Credentials
 
 
-@pytest.fixture(scope="module", params=["authorization_header", "custom_header", "query", "cookie"])
+@pytest.fixture(scope="module", params=["authorizationHeader", "customHeader", "queryString", "cookie"])
 def credentials(request):
     """Location where are auth credentials passed"""
     return request.param

--- a/testsuite/tests/kuadrant/authorino/identity/rhsso/test_rhsso_context.py
+++ b/testsuite/tests/kuadrant/authorino/identity/rhsso/test_rhsso_context.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from testsuite.objects import Property, ValueFrom
+from testsuite.objects import ValueFrom
 
 
 @pytest.fixture(scope="module")
@@ -12,10 +12,10 @@ def authorization(authorization):
     """Setup AuthConfig for test"""
     authorization.responses.add_json(
         "auth-json",
-        [
-            Property("auth", ValueFrom("auth.identity")),
-            Property("context", ValueFrom("context.request.http.headers.authorization")),
-        ],
+        {
+            "auth": ValueFrom("auth.identity"),
+            "context": ValueFrom("context.request.http.headers.authorization"),
+        },
     )
     return authorization
 

--- a/testsuite/tests/kuadrant/authorino/metrics/test_deep_metrics.py
+++ b/testsuite/tests/kuadrant/authorino/metrics/test_deep_metrics.py
@@ -1,7 +1,7 @@
 """Tests for the functionality of the deep-evaluator metric samples"""
 import pytest
 
-from testsuite.objects import Property, Value
+from testsuite.objects import Value
 
 
 @pytest.fixture(scope="module")
@@ -25,7 +25,7 @@ def authorization(authorization, mockserver_expectation):
     authorization.identity.add_anonymous("anonymous", metrics=True)
     authorization.authorization.add_opa_policy("opa", "allow { true }", metrics=True)
     authorization.metadata.add_http("http", mockserver_expectation, "GET", metrics=True)
-    authorization.responses.add_json("json", [Property("auth", Value("response"))], metrics=True)
+    authorization.responses.add_json("json", {"auth": Value("response")}, metrics=True)
 
     return authorization
 

--- a/testsuite/tests/kuadrant/authorino/operator/clusterwide/test_wildcard_collision.py
+++ b/testsuite/tests/kuadrant/authorino/operator/clusterwide/test_wildcard_collision.py
@@ -4,7 +4,7 @@ Test for wildcard collisions with clusterwide authorino
 
 import pytest
 
-from testsuite.objects import Property, Value
+from testsuite.objects import Value
 from testsuite.openshift.objects.auth_config import AuthConfig
 
 
@@ -15,7 +15,7 @@ def authorization(authorino, blame, openshift, module_label, proxy, wildcard_dom
     auth = AuthConfig.create_instance(
         openshift, blame("ac"), None, hostnames=[wildcard_domain], labels={"testRun": module_label}
     )
-    auth.responses.add_json("header", [Property("anything", Value("one"))])
+    auth.responses.add_json("header", {"anything": Value("one")})
     return auth
 
 
@@ -26,7 +26,7 @@ def authorization2(authorino, blame, openshift2, module_label, proxy, wildcard_d
     auth = AuthConfig.create_instance(
         openshift2, blame("ac"), None, hostnames=[wildcard_domain], labels={"testRun": module_label}
     )
-    auth.responses.add_json("header", [Property("anything", Value("two"))])
+    auth.responses.add_json("header", {"anything": Value("two")})
     return auth
 
 

--- a/testsuite/tests/kuadrant/authorino/operator/http/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/http/conftest.py
@@ -1,7 +1,7 @@
 """Conftest for all tests requiring custom deployment of Authorino"""
 import pytest
 
-from testsuite.objects import Property, Value
+from testsuite.objects import Value
 from testsuite.httpx import HttpxBackoffClient
 from testsuite.openshift.objects.auth_config import AuthConfig
 from testsuite.openshift.objects.route import OpenshiftRoute
@@ -13,9 +13,7 @@ def authorization(authorization, wildcard_domain, openshift, module_label) -> Au
     """In case of Authorino, AuthConfig used for authorization"""
     authorization.remove_all_hosts()
     authorization.add_host(wildcard_domain)
-    authorization.responses.add_json(
-        "another-json-returned-in-a-header", [Property("propX", Value("valueX"))], wrapper_key="x-ext-auth-other-json"
-    )
+    authorization.responses.add_json("x-ext-auth-other-json", {"propX": Value("valueX")})
     return authorization
 
 

--- a/testsuite/tests/kuadrant/authorino/operator/sharding/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/sharding/conftest.py
@@ -1,7 +1,7 @@
 """Conftest for authorino sharding tests"""
 import pytest
 
-from testsuite.objects import Property, Value
+from testsuite.objects import Value
 from testsuite.openshift.envoy import Envoy
 from testsuite.openshift.objects.auth_config import AuthConfig
 
@@ -34,7 +34,7 @@ def authorization(request, authorino, blame, openshift, module_label):
             hostnames=[hostname],
             labels={"testRun": module_label, "sharding": sharding_label},
         )
-        auth.responses.add_json("header", [Property("anything", Value(sharding_label))])
+        auth.responses.add_json("header", {"anything": Value(sharding_label)})
         request.addfinalizer(auth.delete)
         auth.commit()
         return auth

--- a/testsuite/tests/kuadrant/authorino/priority/test_sequence_api_key.py
+++ b/testsuite/tests/kuadrant/authorino/priority/test_sequence_api_key.py
@@ -35,11 +35,11 @@ def authorization(authorization, first_api_key, second_api_key):
     authorization.identity.add_api_key(
         "priority-zero",
         selector=first_api_key.selector,
-        credentials=Credentials("authorization_header", "APIKEY"),
+        credentials=Credentials("authorizationHeader", "APIKEY"),
         priority=0,
     )
     authorization.identity.add_api_key(
-        "priority-one", selector=second_api_key.selector, credentials=Credentials("query", "APIKEY"), priority=1
+        "priority-one", selector=second_api_key.selector, credentials=Credentials("queryString", "APIKEY"), priority=1
     )
 
     return authorization

--- a/testsuite/tests/kuadrant/authorino/response/test_auth_json.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_auth_json.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from testsuite.objects import Property, ValueFrom
+from testsuite.objects import ValueFrom
 
 
 @pytest.fixture(scope="module")
@@ -31,7 +31,7 @@ def authorization(authorization, path_and_value):
     path, _ = path_and_value
 
     authorization.responses.clear_all()  # delete previous responses due to the parametrization
-    authorization.responses.add_json("header", [Property("anything", ValueFrom(path))])
+    authorization.responses.add_json("header", {"anything": ValueFrom(path)})
     return authorization
 
 

--- a/testsuite/tests/kuadrant/authorino/response/test_base64.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_base64.py
@@ -6,14 +6,14 @@ from base64 import standard_b64encode
 
 import pytest
 
-from testsuite.objects import Property, ValueFrom
+from testsuite.objects import ValueFrom
 
 
 @pytest.fixture(scope="module")
 def authorization(authorization):
     """Add response to Authorization"""
     authorization.responses.add_json(
-        "header", [Property("anything", ValueFrom("context.request.http.headers.test|@base64:decode"))]
+        "header", {"anything": ValueFrom("context.request.http.headers.test|@base64:decode")}
     )
     return authorization
 

--- a/testsuite/tests/kuadrant/authorino/response/test_headers.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_headers.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 
-from testsuite.objects import Property, Value
+from testsuite.objects import Value
 
 
 @pytest.fixture(scope="module", params=["123456789", "standardCharacters", "specialcharacters+*-."])
@@ -16,11 +16,11 @@ def header_name(request):
 def authorization(authorization, header_name):
     """Add response to Authorization"""
     authorization.responses.clear_all()  # delete previous responses due to the parametrization
-    authorization.responses.add_json("header", [Property("anything", Value("one"))], wrapper_key=header_name)
+    authorization.responses.add_json(header_name, {"anything": Value("one")})
     return authorization
 
 
-def test_wrapper_key_with(auth, client, header_name):
+def test_headers(auth, client, header_name):
     """Tests that value in correct Header"""
     response = client.get("/get", auth=auth)
     assert response.status_code == 200

--- a/testsuite/tests/kuadrant/authorino/response/test_multiple_responses.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_multiple_responses.py
@@ -3,14 +3,14 @@ import json
 
 import pytest
 
-from testsuite.objects import Property, Value
+from testsuite.objects import Value
 
 
 @pytest.fixture(scope="module")
 def authorization(authorization):
     """Add response to Authorization"""
-    authorization.responses.add_json("header", [Property("anything", Value("one"))])
-    authorization.responses.add_json("X-Test", [Property("anything", Value("two"))])
+    authorization.responses.add_json("header", {"anything": Value("one")})
+    authorization.responses.add_json("X-Test", {"anything": Value("two")})
     return authorization
 
 

--- a/testsuite/tests/kuadrant/authorino/response/test_simple_response.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_simple_response.py
@@ -3,13 +3,13 @@ import json
 
 import pytest
 
-from testsuite.objects import Property, Value
+from testsuite.objects import Value
 
 
 @pytest.fixture(scope="module")
 def authorization(authorization):
     """Add response to Authorization"""
-    authorization.responses.add_json("header", [Property("anything", Value("one"))])
+    authorization.responses.add_json("header", {"anything": Value("one")})
     return authorization
 
 

--- a/testsuite/tests/kuadrant/authorino/test_redirect.py
+++ b/testsuite/tests/kuadrant/authorino/test_redirect.py
@@ -3,6 +3,8 @@ Test for authorino redirect
 """
 import pytest
 
+from testsuite.objects import ValueFrom
+
 STATUS_CODE = 302
 REDIRECT_URL = "http://anything.inavlid?redirect_to="
 
@@ -10,7 +12,11 @@ REDIRECT_URL = "http://anything.inavlid?redirect_to="
 @pytest.fixture(scope="module")
 def authorization(authorization):
     """In case of Authorino, AuthConfig used for authorization"""
-    authorization.set_deny_with(STATUS_CODE, REDIRECT_URL + "{context.request.http.path}")
+    authorization.responses.set_deny_with(
+        "unauthenticated",
+        code=STATUS_CODE,
+        headers={"Location": ValueFrom(REDIRECT_URL + "{context.request.http.path}")},
+    )
     return authorization
 
 

--- a/testsuite/tests/kuadrant/authorino/wristband/test_wristband.py
+++ b/testsuite/tests/kuadrant/authorino/wristband/test_wristband.py
@@ -1,5 +1,8 @@
 """Test api authentication with wristband-token that was acquired after authentication on the edge layer"""
+import pytest
 from jose import jwt
+
+pytest.skip("Envoy dynamic metadata not yet implemented due to v1beta2 AuthConfig change", allow_module_level=True)
 
 
 def test_wristband_token_claims(oidc_provider, auth, wristband_token, wristband_endpoint, certificates):


### PR DESCRIPTION
This PR makes this testsuite compatible with newest AuthConfig/AuthPolicy v1beta2

Few notes:
- Envoy Dynamic Metadata function needs to be added in Responses section when tests for it will be created
    - **Wristband tests are for now skipped!** 
- Test for Custom deny code/body/headers need to be created
- testsuite/tests/kuadrant/authorino/response/test_headers.py is maybe not needed as wrapperKey no longer exists or needs some rewrite