### PR TITLE
Add has_dns_error() and has_tls_error() assert to mgc tests

### DIFF
--- a/testsuite/openshift/objects/gateway_api/route.py
+++ b/testsuite/openshift/objects/gateway_api/route.py
@@ -6,7 +6,7 @@ from functools import cached_property
 
 from httpx import Client
 
-from testsuite.httpx import HttpxBackoffClient
+from testsuite.httpx import KuadrantClient
 from testsuite.openshift.client import OpenShiftClient
 from testsuite.openshift.objects import modify, OpenShiftObject
 from testsuite.openshift.objects.route import Route
@@ -23,7 +23,7 @@ class HTTPRoute(OpenShiftObject, Referencable):
 
     def client(self, **kwargs) -> Client:
         """Returns HTTPX client"""
-        return HttpxBackoffClient(base_url=f"http://{self.hostnames[0]}", **kwargs)
+        return KuadrantClient(base_url=f"http://{self.hostnames[0]}", **kwargs)
 
     @classmethod
     def create_instance(
@@ -106,7 +106,7 @@ class HostnameWrapper(Route, Referencable):
         return self._hostname
 
     def client(self, **kwargs) -> Client:
-        return HttpxBackoffClient(base_url=f"http://{self.hostname}", **kwargs)
+        return KuadrantClient(base_url=f"http://{self.hostname}", **kwargs)
 
     @property
     def reference(self) -> dict[str, str]:

--- a/testsuite/openshift/objects/route.py
+++ b/testsuite/openshift/objects/route.py
@@ -4,7 +4,7 @@ from functools import cached_property
 
 from httpx import Client
 
-from testsuite.httpx import HttpxBackoffClient
+from testsuite.httpx import KuadrantClient
 from testsuite.openshift.objects import OpenShiftObject
 
 
@@ -53,7 +53,7 @@ class OpenshiftRoute(OpenShiftObject, Route):
         protocol = "http"
         if "tls" in self.model.spec:
             protocol = "https"
-        return HttpxBackoffClient(base_url=f"{protocol}://{self.hostname}", **kwargs)
+        return KuadrantClient(base_url=f"{protocol}://{self.hostname}", **kwargs)
 
     @cached_property
     def hostname(self):

--- a/testsuite/tests/kuadrant/authorino/operator/http/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/http/conftest.py
@@ -2,7 +2,7 @@
 import pytest
 
 from testsuite.objects import Value, JsonResponse
-from testsuite.httpx import HttpxBackoffClient
+from testsuite.httpx import KuadrantClient
 from testsuite.openshift.objects.auth_config import AuthConfig
 from testsuite.openshift.objects.route import OpenshiftRoute
 
@@ -20,7 +20,7 @@ def authorization(authorization, wildcard_domain, openshift, module_label) -> Au
 @pytest.fixture(scope="module")
 def client(authorization, authorino_route):
     """Returns httpx client to be used for requests, it also commits AuthConfig"""
-    client = HttpxBackoffClient(base_url=f"http://{authorino_route.model.spec.host}", verify=False)
+    client = KuadrantClient(base_url=f"http://{authorino_route.model.spec.host}", verify=False)
     yield client
     client.close()
 

--- a/testsuite/tests/mgc/test_basic.py
+++ b/testsuite/tests/mgc/test_basic.py
@@ -15,7 +15,7 @@ Notes:
 """
 import pytest
 
-from testsuite.httpx import HttpxBackoffClient
+from testsuite.httpx import KuadrantClient
 
 pytestmark = [pytest.mark.mgc]
 
@@ -34,7 +34,9 @@ def test_smoke(route, upstream_gateway):
     tls_cert = upstream_gateway.get_tls_cert()
 
     # assert that tls_cert is used by the server
-    backend_client = HttpxBackoffClient(base_url=f"https://{route.hostnames[0]}", verify=tls_cert)
+    backend_client = KuadrantClient(base_url=f"https://{route.hostnames[0]}", verify=tls_cert)
 
-    response = backend_client.get("get")
-    assert response.status_code == 200
+    result = backend_client.get("get")
+    assert not result.has_dns_error()
+    assert not result.has_tls_error()
+    assert result.status_code == 200


### PR DESCRIPTION
* Add two new asserts to MGC tests, which ensure that in case of incorrect configuration or a bug, tests will Fail instead throwing and Exception
* Rename our HttpX client to `KuadrantClient`