### PR TITLE
Fix wrong credentials param test_auth_credentials.py

### DIFF
--- a/testsuite/tests/kuadrant/authorino/identity/rhsso/test_auth_credentials.py
+++ b/testsuite/tests/kuadrant/authorino/identity/rhsso/test_auth_credentials.py
@@ -21,7 +21,7 @@ def authorization(authorization, rhsso, credentials):
 def test_custom_selector(client, auth, credentials):
     """Test if auth credentials are stored in right place"""
     response = client.get("/get", headers={"authorization": "Token " + auth.token.access_token})
-    if credentials == "authorization_header":
+    if credentials == "authorizationHeader":
         assert response.status_code == 200
     else:
         assert response.status_code == 401
@@ -30,7 +30,7 @@ def test_custom_selector(client, auth, credentials):
 def test_custom_header(client, auth, credentials):
     """Test if auth credentials are stored in right place"""
     response = client.get("/get", headers={"Token": auth.token.access_token})
-    if credentials == "custom_header":
+    if credentials == "customHeader":
         assert response.status_code == 200
     else:
         assert response.status_code == 401
@@ -39,7 +39,7 @@ def test_custom_header(client, auth, credentials):
 def test_query(client, auth, credentials):
     """Test if auth credentials are stored in right place"""
     response = client.get("/get", params={"Token": auth.token.access_token})
-    if credentials == "query":
+    if credentials == "queryString":
         assert response.status_code == 200
     else:
         assert response.status_code == 401


### PR DESCRIPTION
Fix wrong credentials parameters that were missed in #248 
It is interesting that it was not caught in automated commit test via `mypy` tool because the variables are behind `pytest` parametrize feature.