### PR TITLE
Refactor settings structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ The results and reports will be saved in `/test-run-results` in the container.
 ```bash
 podman run \
 	-v $HOME/.kube/config:/run/kubeconfig:z \
-	-e KUADRANT_OPENSHIFT__project=authorino \
-	-e KUADRANT_OPENSHIFT2__project=authorino2 \
+	-e KUADRANT_SERVICE_PROTECTION__PROJECT=authorino \
+	-e KUADRANT_SERVICE_PROTECTION__PROJECT2=authorino2 \
 	-e KUADRANT_AUTH0__url="AUTH0_URL" \
 	-e KUADRANT_AUTH0__client_id="AUTH0_CLIENT_ID" \
 	-e KUADRANT_AUTH0__client_secret="AUTH0_CLIENT_SECRET" \	
@@ -90,8 +90,8 @@ podman run \
 ```bash
 podman run \
 	-v $HOME/.kube/config:/run/kubeconfig:z \
-	-e KUADRANT_OPENSHIFT__project=authorino \
-	-e KUADRANT_OPENSHIFT2__project=authorino2 \
+	-e KUADRANT_SERVICE_PROTECTION__PROJECT=authorino \
+	-e KUADRANT_SERVICE_PROTECTION__PROJECT2=authorino2 \
 	-e KUADRANT_RHSSO__url="https://my-sso.net" \
 	-e KUADRANT_RHSSO__password="ADMIN_PASSWORD" \
 	-e KUADRANT_RHSSO__username="ADMIN_USERNAME" \

--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -1,12 +1,11 @@
 #default:
 #  skip_cleanup: false
-#  openshift:
-#    project: "kuadrant"                       # Optional: namespace for tests to run, if None uses current project
+#  gateway_api: true                           # True, if Testsuite should test with Gateway API enabled (e.g. Full Kuadrant) or individual components (e.g. Authorino)
+#  cluster:                                    # Workload cluster where tests should run, will get overriden if run on Multicluster
+#    project: "kuadrant"                       # Optional: Default namespace for this cluster
 #    api_url: "https://api.openshift.com"      # Optional: OpenShift API URL, if None it will OpenShift that you are logged in
 #    token: "KUADRANT_RULEZ"                   # Optional: OpenShift Token, if None it will OpenShift that you are logged in
 #    kubeconfig_path: "~/.kube/config"         # Optional: Kubeconfig to use, if None the default one is used
-#  openshift2:
-#    project: "kuadrant2"                      # Required: Secondary OpenShift project, for running tests across projects
 #  tools:
 #    project: "tools"                          # Optional: OpenShift project, where external tools are located
 #  rhsso:
@@ -27,22 +26,28 @@
 #    url: "HYPERFOIL_URL"
 #    generate_reports: True                      # True, if each test should generate a report
 #    report_dir: "reports"                       # Directory, to which the reports should be saved
-#  authorino:
-#    image: "quay.io/kuadrant/authorino:latest"  # If specified will override the authorino image
-#    deploy: false                               # If false, the testsuite will use already deployed authorino for testing
-#    auth_url: ""                                # authorization URL for already deployed Authorino
-#    oidc_url: ""                                # oidc URL for already deployed Authorino
-#    metrics_service_name: ""                    # controller metrics service name for already deployer Authorino
-#  envoy:
-#    image: "docker.io/envoyproxy/envoy:v1.23-latest"  # Envoy image, the testsuite should use, only for Authorino tests now
-#  kuadrant:
-#    enabled: true                               # True, if Testsuite should test Kuadrant instead of individual operators
-#    namespace: "kuadrant"                       # Namespaces where Kuadrant resides
-#    gateway:                                    # Reference to Gateway that should be used
+#  service_protection:
+#    system_project: "kuadrant-system"           # Namespace where Kuadrant resource resides
+#    project: "kuadrant"                         # Namespace where tests will run
+#    project2: "kuadrant2"                       # Second namespace for tests, that run across multiple namespaces
+#    envoy:
+#      image: "docker.io/envoyproxy/envoy:v1.23-latest"  # Envoy image, the testsuite should use, only for Authorino tests
+#    gateway:                                      # Optional: Reference to Gateway that should be used, if empty testsuite will create its own
 #       namespace: "istio-system"
 #       name: "istio-ingressgateway"
-#  mgc:
-#    spokes:
+#    authorino:
+#      image: "quay.io/kuadrant/authorino:latest"  # If specified will override the authorino image
+#      deploy: false                               # If false, the testsuite will use already deployed authorino for testing
+#      auth_url: ""                                # authorization URL for already deployed Authorino
+#      oidc_url: ""                                # oidc URL for already deployed Authorino
+#      metrics_service_name: ""                    # controller metrics service name for already deployer Authorino
+#  control_plane:
+#    hub:                                          # Hub cluster
+#      project: "multi-cluster-gateways"         # Optional: namespace where MGC resources are created and where the hub gateway will be created
+#      api_url: "https://api.openshift.com"      # Optional: OpenShift API URL, if None it will OpenShift that you are logged in
+#      token: "KUADRANT_RULEZ"                   # Optional: OpenShift Token, if None it will OpenShift that you are logged in
+#      kubeconfig_path: "~/.kube/config"         # Optional: Kubeconfig to use, if None the default one is used
+#    spokes:                                       # List of all spokes in the multi-cluster
 #      local-cluster:
 #        project: "kuadrant"                       # Optional: namespace for tests to run, if None uses current project
 #        api_url: "https://api.openshift.com"      # Optional: OpenShift API URL, if None it will OpenShift that you are logged in

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,6 +1,8 @@
 default:
   skip_cleanup: false
   dynaconf_merge: true
+  gateway_api: true
+  cluster: {}
   tools:
     project: "tools"
   cfssl: "cfssl"
@@ -9,17 +11,18 @@ default:
     test_user:
       username: "testUser"
       password: "testPassword"
-  authorino:
-    deploy: true
-    log_level: "debug"
-  envoy:
-    image: "docker.io/envoyproxy/envoy:v1.23-latest"
-  kuadrant:
-    enabled: true
+  service_protection:
+    system_project: "kuadrant-system"
     project: "kuadrant"
+    project2: "kuadrant2"
+    envoy:
+      image: "docker.io/envoyproxy/envoy:v1.23-latest"
     gateway:
        project: "istio-system"
        name: "istio-ingressgateway"
+    authorino:
+      deploy: true
+      log_level: "debug"
   hyperfoil:
     generate_reports: True
     reports_dir: "reports"

--- a/testsuite/config/__init__.py
+++ b/testsuite/config/__init__.py
@@ -33,12 +33,16 @@ settings = Dynaconf(
     envvar_prefix="KUADRANT",
     merge_enabled=True,
     validators=[
-        Validator("authorino.deploy", must_exist=True, eq=True)
-        | (Validator("authorino.auth_url", must_exist=True) & Validator("authorino.oidc_url", must_exist=True)),
+        Validator("service_protection.authorino.deploy", must_exist=True, eq=True)
+        | (
+            Validator("service_protection.authorino.auth_url", must_exist=True)
+            & Validator("service_protection.authorino.oidc_url", must_exist=True)
+        ),
         DefaultValueValidator("rhsso.url", default=fetch_route("no-ssl-sso")),
         DefaultValueValidator("rhsso.password", default=fetch_secret("credential-sso", "ADMIN_PASSWORD")),
         DefaultValueValidator("mockserver.url", default=fetch_route("mockserver", force_http=True)),
-        Validator("kuadrant.enable", must_exist=False, eq=False) | Validator("kuadrant.gateway.name", must_exist=True),
+        Validator("gateway_api", must_exist=False, eq=False)
+        | Validator("service_protection.gateway.name", must_exist=True),
     ],
     validate_only=["authorino", "kuadrant"],
     loaders=["dynaconf.loaders.env_loader", "testsuite.config.openshift_loader"],

--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -28,7 +28,7 @@ class OpenShiftClient:
 
     # pylint: disable=too-many-public-methods
 
-    def __init__(self, project: str, api_url: str = None, token: str = None, kubeconfig_path: str = None):
+    def __init__(self, project: str = None, api_url: str = None, token: str = None, kubeconfig_path: str = None):
         self._project = project
         self._api_url = api_url
         self._token = token

--- a/testsuite/tests/kuadrant/authorino/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/conftest.py
@@ -1,6 +1,5 @@
 """Conftest for Authorino tests"""
 import pytest
-from weakget import weakget
 
 from testsuite.httpx.auth import HttpxOidcClientAuth
 from testsuite.objects import Authorino, PreexistingAuthorino
@@ -22,13 +21,14 @@ def authorino(authorino, openshift, blame, request, testconfig, module_label, au
     if authorino:
         return authorino
 
-    if not testconfig["authorino"]["deploy"]:
+    authorino_config = testconfig["service_protection"]["authorino"]
+    if not authorino_config["deploy"]:
         if len(authorino_parameters) > 0:
             return pytest.skip("Can't change parameters of already deployed Authorino")
         return PreexistingAuthorino(
-            testconfig["authorino"]["auth_url"],
-            testconfig["authorino"]["oidc_url"],
-            testconfig["authorino"]["metrics_service_name"],
+            authorino_config["auth_url"],
+            authorino_config["oidc_url"],
+            authorino_config["metrics_service_name"],
         )
 
     labels = authorino_parameters.setdefault("label_selectors", [])
@@ -38,8 +38,8 @@ def authorino(authorino, openshift, blame, request, testconfig, module_label, au
 
     authorino = AuthorinoCR.create_instance(
         openshift,
-        image=weakget(testconfig)["authorino"]["image"] % None,
-        log_level=weakget(testconfig)["authorino"]["log_level"] % None,
+        image=authorino_config.get("image"),
+        log_level=authorino_config.get("log_level"),
         **authorino_parameters,
     )
     request.addfinalizer(lambda: authorino.delete(ignore_not_found=True))

--- a/testsuite/tests/kuadrant/authorino/identity/api_key/test_api_key_context.py
+++ b/testsuite/tests/kuadrant/authorino/identity/api_key/test_api_key_context.py
@@ -12,7 +12,7 @@ def authorization(authorization, api_key):
     return authorization
 
 
-def tests_api_key_context(client, auth, api_key, module_label, testconfig):
+def tests_api_key_context(client, auth, api_key, module_label, openshift):
     """
     Test:
         - Make request with API key authentication
@@ -22,5 +22,5 @@ def tests_api_key_context(client, auth, api_key, module_label, testconfig):
     assert response.status_code == 200
     identity = extract_response(response)
     assert identity["data"]["api_key"] % None == api_key.model.data.api_key
-    assert identity["metadata"]["namespace"] % None == testconfig["openshift"].project
+    assert identity["metadata"]["namespace"] % None == openshift.project
     assert identity["metadata"]["labels"]["group"] % None == module_label

--- a/testsuite/tests/kuadrant/authorino/metrics/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/metrics/conftest.py
@@ -14,7 +14,7 @@ def run_on_kuadrant():
     return False
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def prometheus(request, openshift):
     """
     Return an instance of OpenShift metrics client

--- a/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
@@ -34,7 +34,7 @@ def cert_attributes_other(cert_attributes) -> Dict[str, str]:
     }
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def certificates(cfssl, authorino_domain, wildcard_domain, cert_attributes, cert_attributes_other):
     """
     Certificate hierarchy used for the tests
@@ -72,7 +72,7 @@ def create_secret(blame, request, openshift):
     return _create_secret
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def authorino_domain(openshift):
     """
     Hostname of the upstream certificate sent to be validated by APIcast

--- a/testsuite/tests/kuadrant/authorino/operator/tls/mtls/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/mtls/conftest.py
@@ -17,7 +17,7 @@ def authorization(authorization, blame, selector, cert_attributes):
     return authorization
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def certificates(cfssl, authorino_domain, wildcard_domain, cert_attributes, cert_attributes_other):
     """Certificate hierarchy used for the mTLS tests"""
     chain = {

--- a/testsuite/tests/kuadrant/authorino/operator/tls/test_webhook.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/test_webhook.py
@@ -31,7 +31,7 @@ def specific_authorino_name(blame):
     return blame("authorino")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def authorino_domain(openshift, specific_authorino_name):
     """
     Hostname of the upstream certificate sent to be validated by APIcast
@@ -40,7 +40,7 @@ def authorino_domain(openshift, specific_authorino_name):
     return f"{specific_authorino_name}-authorino-authorization.{openshift.project}.svc"
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def certificates(cfssl, authorino_domain, wildcard_domain):
     """Certificate hierarchy used for the tests.
     Authorino certificate has *hosts* set to *authorino_domain* value.

--- a/testsuite/tests/kuadrant/authorino/wristband/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/wristband/conftest.py
@@ -35,7 +35,7 @@ def wristband_secret(blame, request, openshift, certificates) -> str:
     return wristband_secret_name
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def certificates(cfssl, wildcard_domain):
     """Certificate hierarchy used for the wristband tests"""
     chain = {

--- a/testsuite/tests/mgc/dnspolicy/conftest.py
+++ b/testsuite/tests/mgc/dnspolicy/conftest.py
@@ -5,10 +5,10 @@ from testsuite.openshift.objects.gateway_api.gateway import MGCGateway
 
 
 @pytest.fixture(scope="module")
-def upstream_gateway(request, openshift, blame, hostname, module_label):
+def upstream_gateway(request, hub_openshift, blame, hostname, module_label):
     """Creates and returns configured and ready upstream Gateway with disabled tls"""
     upstream_gateway = MGCGateway.create_instance(
-        openshift=openshift,
+        openshift=hub_openshift,
         name=blame("mgc-gateway"),
         gateway_class="kuadrant-multi-cluster-gateway-instance-per-cluster",
         hostname=f"*.{hostname}",

--- a/testsuite/tests/mgc/dnspolicy/health_check/conftest.py
+++ b/testsuite/tests/mgc/dnspolicy/health_check/conftest.py
@@ -6,13 +6,13 @@ from testsuite.openshift.objects.gateway_api.gateway import MGCGateway
 
 
 @pytest.fixture(scope="module")
-def upstream_gateway(request, openshift, blame, module_label, initial_host):
+def upstream_gateway(request, hub_openshift, blame, module_label, initial_host):
     """
     Creates and returns configured and ready upstream Gateway with FQDN hostname
     Health checks available only with Fully Qualified Domain Names in gateway (no wildcards are allowed)
     """
     upstream_gateway = MGCGateway.create_instance(
-        openshift=openshift,
+        openshift=hub_openshift,
         name=blame("mgc-gateway"),
         gateway_class="kuadrant-multi-cluster-gateway-instance-per-cluster",
         hostname=initial_host,


### PR DESCRIPTION
* Rename `kuadrant` to `service_protection`
  * Move `authorino` and `envoy` under `service_protection`
* Rename `mgc` to `control_plane`
* Move `kuadrant.enable` to `gateway_api`
* Change how OpenShift are configured:
   * Introduce `cluster` configuration, which represent the cluster info where everything should run
      * By default is completely empty, which means that whatever server user is logged in will be used
      * This would be overridden if ran with MGC as the workload will be automatically moved to a spoke
   * All settings in `service_protection` section are only a projects on the cluster, no other configuration is allowed
   * `control_plane.spokes` and `control_plane.hub` (new settings) require a full cluster configuration, same as `cluster`
* Change `openshift()` and `openshift2()` fixtures to a module scope
  * When running future tests with MGC, the actual client is dependant on the hub gateway and spoke
  * This change means that `backend` is now also `module` scope, meaning slower tests
  
## Current minimal configuration:
```
default:
  skip_cleanup: false
  dynaconf_merge: true
  gateway_api: true
  control_plane:
    hub:
      project: "multi-cluster-gateways"
    spokes:
      local-cluster: {}
```