### PR TITLE
Blame email for RHSSO users

### DIFF
--- a/testsuite/tests/kuadrant/authorino/metadata/test_user_info.py
+++ b/testsuite/tests/kuadrant/authorino/metadata/test_user_info.py
@@ -9,9 +9,9 @@ from testsuite.objects import Rule
 
 
 @pytest.fixture(scope="module")
-def user2(rhsso):
+def user2(rhsso, blame):
     """Second User which has incorrect email"""
-    return rhsso.realm.create_user("user2", "password", email="test@test.com")
+    return rhsso.realm.create_user("user2", "password", email=f"{blame('test')}@test.com")
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/kuadrant/test_rate_limit_authz.py
+++ b/testsuite/tests/kuadrant/test_rate_limit_authz.py
@@ -32,10 +32,10 @@ def auth(oidc_provider):
 
 
 @pytest.fixture(scope="module")
-def auth2(rhsso):
+def auth2(rhsso, blame):
     """Creates new RHSSO user and returns its authentication object for HTTPX"""
     name = rhsso.user.username + "-test2"
-    user = rhsso.realm.create_user(name, "password", email="test@test.com")
+    user = rhsso.realm.create_user(name, "password", email=f"{blame('test')}@test.com")
     return HttpxOidcClientAuth.from_user(rhsso.get_token, user=user)
 
 


### PR DESCRIPTION
Realm is session-scoped and users cannot share the same email