### PR TITLE
Fix capitalizazion in test_response_condition.py test

### DIFF
--- a/testsuite/tests/kuadrant/authorino/conditions/section_conditions/test_response_condition.py
+++ b/testsuite/tests/kuadrant/authorino/conditions/section_conditions/test_response_condition.py
@@ -23,7 +23,7 @@ def test_skip_response(client, auth):
     assert response.status_code == 200
 
     # verify that response was not returned on a GET request
-    assert "simple" not in response.json()["headers"]
+    assert "Simple" not in response.json()["headers"]
 
     response = client.post("/post", auth=auth)
     assert response.status_code == 200


### PR DESCRIPTION
Fix bug introduced in #214 testing wrong header name resulting in always True assert. Asserted string should be `Simple` because HTTP headers capitalize first letter of header name. 