### PR TITLE
Extend OpenShiftObject class with LifecycleObject

### DIFF
--- a/testsuite/objects/__init__.py
+++ b/testsuite/objects/__init__.py
@@ -151,7 +151,7 @@ class LifecycleObject(abc.ABC):
 
 
 class Authorino(LifecycleObject):
-    """Authorino instance"""
+    """Authorino interface"""
 
     @abc.abstractmethod
     def wait_for_ready(self):

--- a/testsuite/openshift/objects/__init__.py
+++ b/testsuite/openshift/objects/__init__.py
@@ -3,6 +3,8 @@ import functools
 
 from openshift import APIObject
 
+from testsuite.objects import LifecycleObject
+
 
 def modify(func):
     """Wraps method of a subclass of OpenShiftObject to use modify_and_apply when the object
@@ -28,7 +30,7 @@ def modify(func):
     return _wrap
 
 
-class OpenShiftObject(APIObject):
+class OpenShiftObject(APIObject, LifecycleObject):
     """Custom APIObjects which tracks if the object was already committed to the server or not"""
 
     def __init__(self, dict_to_model=None, string_to_model=None, context=None):

--- a/testsuite/openshift/objects/ingress.py
+++ b/testsuite/openshift/objects/ingress.py
@@ -1,7 +1,6 @@
 """Kubernetes Ingress object"""
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
-from testsuite.objects import LifecycleObject
 from testsuite.openshift.objects import OpenShiftObject
 
 if TYPE_CHECKING:
@@ -9,7 +8,7 @@ if TYPE_CHECKING:
     from testsuite.openshift.client import OpenShiftClient
 
 
-class Ingress(OpenShiftObject, LifecycleObject):
+class Ingress(OpenShiftObject):
     """Represents Kubernetes Ingress object"""
 
     @classmethod


### PR DESCRIPTION
`OpenShiftObject` already implements `commit` and `delete`. This PR formaly adding already existing inheritence. 