### PR TITLE
Responses section refactor

### DIFF
--- a/testsuite/tests/kuadrant/authorino/conditions/section_conditions/test_response_condition.py
+++ b/testsuite/tests/kuadrant/authorino/conditions/section_conditions/test_response_condition.py
@@ -1,15 +1,15 @@
 """Test condition to skip the response section of AuthConfig"""
 import pytest
 
-from testsuite.objects import Rule, Value
+from testsuite.objects import Rule, Value, JsonResponse
 from testsuite.utils import extract_response
 
 
 @pytest.fixture(scope="module")
 def authorization(authorization):
     """Add to the AuthConfig response, which will only trigger on POST requests"""
-    authorization.responses.add_json(
-        "simple", {"data": Value("response")}, when=[Rule("context.request.http.method", "eq", "POST")]
+    authorization.responses.add_success_header(
+        "simple", JsonResponse({"data": Value("response")}), when=[Rule("context.request.http.method", "eq", "POST")]
     )
     return authorization
 

--- a/testsuite/tests/kuadrant/authorino/identity/rhsso/test_rhsso_context.py
+++ b/testsuite/tests/kuadrant/authorino/identity/rhsso/test_rhsso_context.py
@@ -4,18 +4,20 @@ import time
 
 import pytest
 
-from testsuite.objects import ValueFrom
+from testsuite.objects import ValueFrom, JsonResponse
 
 
 @pytest.fixture(scope="module")
 def authorization(authorization):
     """Setup AuthConfig for test"""
-    authorization.responses.add_json(
+    authorization.responses.add_success_header(
         "auth-json",
-        {
-            "auth": ValueFrom("auth.identity"),
-            "context": ValueFrom("context.request.http.headers.authorization"),
-        },
+        JsonResponse(
+            {
+                "auth": ValueFrom("auth.identity"),
+                "context": ValueFrom("context.request.http.headers.authorization"),
+            }
+        ),
     )
     return authorization
 

--- a/testsuite/tests/kuadrant/authorino/metrics/test_deep_metrics.py
+++ b/testsuite/tests/kuadrant/authorino/metrics/test_deep_metrics.py
@@ -1,7 +1,7 @@
 """Tests for the functionality of the deep-evaluator metric samples"""
 import pytest
 
-from testsuite.objects import Value
+from testsuite.objects import Value, JsonResponse
 
 
 @pytest.fixture(scope="module")
@@ -25,7 +25,7 @@ def authorization(authorization, mockserver_expectation):
     authorization.identity.add_anonymous("anonymous", metrics=True)
     authorization.authorization.add_opa_policy("opa", "allow { true }", metrics=True)
     authorization.metadata.add_http("http", mockserver_expectation, "GET", metrics=True)
-    authorization.responses.add_json("json", {"auth": Value("response")}, metrics=True)
+    authorization.responses.add_success_header("json", JsonResponse({"auth": Value("response")}), metrics=True)
 
     return authorization
 

--- a/testsuite/tests/kuadrant/authorino/operator/clusterwide/test_wildcard_collision.py
+++ b/testsuite/tests/kuadrant/authorino/operator/clusterwide/test_wildcard_collision.py
@@ -4,7 +4,7 @@ Test for wildcard collisions with clusterwide authorino
 
 import pytest
 
-from testsuite.objects import Value
+from testsuite.objects import Value, JsonResponse
 from testsuite.openshift.objects.auth_config import AuthConfig
 
 
@@ -15,7 +15,7 @@ def authorization(authorino, blame, openshift, module_label, proxy, wildcard_dom
     auth = AuthConfig.create_instance(
         openshift, blame("ac"), None, hostnames=[wildcard_domain], labels={"testRun": module_label}
     )
-    auth.responses.add_json("header", {"anything": Value("one")})
+    auth.responses.add_success_header("header", JsonResponse({"anything": Value("one")}))
     return auth
 
 
@@ -26,7 +26,7 @@ def authorization2(authorino, blame, openshift2, module_label, proxy, wildcard_d
     auth = AuthConfig.create_instance(
         openshift2, blame("ac"), None, hostnames=[wildcard_domain], labels={"testRun": module_label}
     )
-    auth.responses.add_json("header", {"anything": Value("two")})
+    auth.responses.add_success_header("header", JsonResponse({"anything": Value("two")}))
     return auth
 
 

--- a/testsuite/tests/kuadrant/authorino/operator/http/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/http/conftest.py
@@ -1,7 +1,7 @@
 """Conftest for all tests requiring custom deployment of Authorino"""
 import pytest
 
-from testsuite.objects import Value
+from testsuite.objects import Value, JsonResponse
 from testsuite.httpx import HttpxBackoffClient
 from testsuite.openshift.objects.auth_config import AuthConfig
 from testsuite.openshift.objects.route import OpenshiftRoute
@@ -13,7 +13,7 @@ def authorization(authorization, wildcard_domain, openshift, module_label) -> Au
     """In case of Authorino, AuthConfig used for authorization"""
     authorization.remove_all_hosts()
     authorization.add_host(wildcard_domain)
-    authorization.responses.add_json("x-ext-auth-other-json", {"propX": Value("valueX")})
+    authorization.responses.add_success_header("x-ext-auth-other-json", JsonResponse({"propX": Value("valueX")}))
     return authorization
 
 

--- a/testsuite/tests/kuadrant/authorino/operator/sharding/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/sharding/conftest.py
@@ -1,7 +1,7 @@
 """Conftest for authorino sharding tests"""
 import pytest
 
-from testsuite.objects import Value
+from testsuite.objects import Value, JsonResponse
 from testsuite.openshift.envoy import Envoy
 from testsuite.openshift.objects.auth_config import AuthConfig
 
@@ -34,7 +34,7 @@ def authorization(request, authorino, blame, openshift, module_label):
             hostnames=[hostname],
             labels={"testRun": module_label, "sharding": sharding_label},
         )
-        auth.responses.add_json("header", {"anything": Value(sharding_label)})
+        auth.responses.add_success_header("header", JsonResponse({"anything": Value(sharding_label)}))
         request.addfinalizer(auth.delete)
         auth.commit()
         return auth

--- a/testsuite/tests/kuadrant/authorino/response/test_auth_json.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_auth_json.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from testsuite.objects import ValueFrom
+from testsuite.objects import ValueFrom, JsonResponse
 
 
 @pytest.fixture(scope="module")
@@ -31,7 +31,7 @@ def authorization(authorization, path_and_value):
     path, _ = path_and_value
 
     authorization.responses.clear_all()  # delete previous responses due to the parametrization
-    authorization.responses.add_json("header", {"anything": ValueFrom(path)})
+    authorization.responses.add_success_header("header", JsonResponse({"anything": ValueFrom(path)}))
     return authorization
 
 

--- a/testsuite/tests/kuadrant/authorino/response/test_base64.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_base64.py
@@ -6,14 +6,14 @@ from base64 import standard_b64encode
 
 import pytest
 
-from testsuite.objects import ValueFrom
+from testsuite.objects import ValueFrom, JsonResponse
 
 
 @pytest.fixture(scope="module")
 def authorization(authorization):
     """Add response to Authorization"""
-    authorization.responses.add_json(
-        "header", {"anything": ValueFrom("context.request.http.headers.test|@base64:decode")}
+    authorization.responses.add_success_header(
+        "header", JsonResponse({"anything": ValueFrom("context.request.http.headers.test|@base64:decode")})
     )
     return authorization
 

--- a/testsuite/tests/kuadrant/authorino/response/test_deny_with.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_deny_with.py
@@ -2,7 +2,7 @@
 from json import loads
 import pytest
 
-from testsuite.objects import Value, ValueFrom, Rule
+from testsuite.objects import Value, ValueFrom, Rule, DenyResponse
 
 HEADERS = {
     "x-string-header": Value("abc"),
@@ -18,19 +18,21 @@ TESTING_PATH = "/deny"
 @pytest.fixture(scope="module")
 def authorization(authorization):
     """Set custom deny responses and auth rule with only allowed path '/allow'"""
-    authorization.responses.set_deny_with(
-        "unauthenticated",
-        code=333,
-        headers=HEADERS,
-        message=Value("Unauthenticated message"),
-        body=Value("You are unauthenticated."),
+    authorization.responses.set_unauthenticated(
+        DenyResponse(
+            code=333,
+            headers=HEADERS,
+            message=Value("Unauthenticated message"),
+            body=Value("You are unauthenticated."),
+        )
     )
-    authorization.responses.set_deny_with(
-        "unauthorized",
-        code=444,
-        headers=HEADERS,
-        message=ValueFrom("My path is: " + "{context.request.http.path}"),
-        body=ValueFrom("You are not authorized to access path: " + "{context.request.http.path}"),
+    authorization.responses.set_unauthorized(
+        DenyResponse(
+            code=444,
+            headers=HEADERS,
+            message=ValueFrom("My path is: " + "{context.request.http.path}"),
+            body=ValueFrom("You are not authorized to access path: " + "{context.request.http.path}"),
+        )
     )
     # Authorize only when url path is "/allow"
     authorization.authorization.add_auth_rules("Whitelist", [Rule("context.request.http.path", "eq", "/allow")])

--- a/testsuite/tests/kuadrant/authorino/response/test_headers.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_headers.py
@@ -3,7 +3,7 @@ import json
 
 import pytest
 
-from testsuite.objects import Value
+from testsuite.objects import Value, JsonResponse
 
 
 @pytest.fixture(scope="module", params=["123456789", "standardCharacters", "specialcharacters+*-."])
@@ -16,7 +16,7 @@ def header_name(request):
 def authorization(authorization, header_name):
     """Add response to Authorization"""
     authorization.responses.clear_all()  # delete previous responses due to the parametrization
-    authorization.responses.add_json(header_name, {"anything": Value("one")})
+    authorization.responses.add_success_header(header_name, JsonResponse({"anything": Value("one")}))
     return authorization
 
 

--- a/testsuite/tests/kuadrant/authorino/response/test_multiple_responses.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_multiple_responses.py
@@ -3,14 +3,14 @@ import json
 
 import pytest
 
-from testsuite.objects import Value
+from testsuite.objects import Value, JsonResponse
 
 
 @pytest.fixture(scope="module")
 def authorization(authorization):
     """Add response to Authorization"""
-    authorization.responses.add_json("header", {"anything": Value("one")})
-    authorization.responses.add_json("X-Test", {"anything": Value("two")})
+    authorization.responses.add_success_header("header", JsonResponse({"anything": Value("one")}))
+    authorization.responses.add_success_header("X-Test", JsonResponse({"anything": Value("two")}))
     return authorization
 
 

--- a/testsuite/tests/kuadrant/authorino/response/test_simple_response.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_simple_response.py
@@ -3,13 +3,13 @@ import json
 
 import pytest
 
-from testsuite.objects import Value
+from testsuite.objects import Value, JsonResponse
 
 
 @pytest.fixture(scope="module")
 def authorization(authorization):
     """Add response to Authorization"""
-    authorization.responses.add_json("header", {"anything": Value("one")})
+    authorization.responses.add_success_header("header", JsonResponse({"anything": Value("one")}))
     return authorization
 
 

--- a/testsuite/tests/kuadrant/authorino/test_redirect.py
+++ b/testsuite/tests/kuadrant/authorino/test_redirect.py
@@ -3,7 +3,7 @@ Test for authorino redirect
 """
 import pytest
 
-from testsuite.objects import ValueFrom
+from testsuite.objects import ValueFrom, DenyResponse
 
 STATUS_CODE = 302
 REDIRECT_URL = "http://anything.inavlid?redirect_to="
@@ -12,10 +12,11 @@ REDIRECT_URL = "http://anything.inavlid?redirect_to="
 @pytest.fixture(scope="module")
 def authorization(authorization):
     """In case of Authorino, AuthConfig used for authorization"""
-    authorization.responses.set_deny_with(
-        "unauthenticated",
-        code=STATUS_CODE,
-        headers={"Location": ValueFrom(REDIRECT_URL + "{context.request.http.path}")},
+    authorization.responses.set_unauthenticated(
+        DenyResponse(
+            code=STATUS_CODE,
+            headers={"Location": ValueFrom(REDIRECT_URL + "{context.request.http.path}")},
+        )
     )
     return authorization
 

--- a/testsuite/tests/kuadrant/authorino/wristband/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/wristband/conftest.py
@@ -3,6 +3,7 @@ from importlib import resources
 
 import pytest
 
+from testsuite.objects import WristbandSigningKeyRef, WristbandResponse
 from testsuite.openshift.objects.auth_config import AuthConfig
 from testsuite.openshift.envoy import Envoy
 from testsuite.certificates import CertInfo
@@ -70,7 +71,11 @@ def wristband_endpoint(openshift, authorino, authorization_name):
 @pytest.fixture(scope="module")
 def authorization(authorization, wristband_secret, wristband_endpoint) -> AuthConfig:
     """Add wristband response with the signing key to the AuthConfig"""
-    authorization.responses.add_wristband("wristband", wristband_endpoint, wristband_secret, wrapper="dynamicMetadata")
+
+    authorization.responses.add_success_dynamic(
+        "wristband",
+        WristbandResponse(issuer=wristband_endpoint, signingKeyRefs=[WristbandSigningKeyRef(wristband_secret)]),
+    )
     return authorization
 
 

--- a/testsuite/tests/kuadrant/test_rate_limit_authz.py
+++ b/testsuite/tests/kuadrant/test_rate_limit_authz.py
@@ -3,7 +3,7 @@
 import pytest
 
 from testsuite.httpx.auth import HttpxOidcClientAuth
-from testsuite.objects import ValueFrom
+from testsuite.objects import ValueFrom, JsonResponse
 from testsuite.openshift.objects.rate_limit import Limit
 
 
@@ -19,8 +19,8 @@ def rate_limit(rate_limit):
 @pytest.fixture(scope="module")
 def authorization(authorization):
     """Adds JSON injection, that wraps the response as Envoy Dynamic Metadata for rate limit"""
-    authorization.responses.add_json(
-        "identity", {"user": ValueFrom("auth.identity.preferred_username")}, wrapper="dynamicMetadata"
+    authorization.responses.add_success_dynamic(
+        "identity", JsonResponse({"user": ValueFrom("auth.identity.preferred_username")})
     )
     return authorization
 


### PR DESCRIPTION
As discussed with @pehala this PR refactores Responses section and usage to closer mimic real AuthConfig/AuthPolicy structure. There are 4(+1) functions in authorization object now:

- `authorization.responses.add_success_header()` - Add response as header
- `authorization.responses.add_success_dynamic()` - Add response as dynamic Envoy metadata

These functions use dataclasses contain different types of responses `JsonResponse, PlainResponse, WristbandResponse`

- `set_unauthenticated()`
- `set_unauthorized()`

These functions use dataclass `DenyResponse`

The usage of `authorization.responses.add_simple` was not changed.