### PR TITLE
Fix missing setuptools

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.make-poetry-sync
+.make-poetry-sync-no-dev
+.github
+.mypy_cache
+.pytest_cache
+.poetry.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ Bind kubeconfig to /opt/kubeconfig \
 Bind a dir to /test-run-results to get reports "
 
 RUN useradd --no-log-init -u 1001 -g root -m testsuite
-RUN dnf install -y python311 pip make git && dnf clean all
+RUN dnf install -y python3.11 python3.11-pip make git && dnf clean all
 
 RUN curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz >/tmp/oc.tgz && \
 	tar xzf /tmp/oc.tgz -C /usr/local/bin && \
@@ -15,7 +15,7 @@ RUN curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/opensh
 RUN curl -L https://github.com/cloudflare/cfssl/releases/download/v1.6.3/cfssl_1.6.3_linux_amd64 >/usr/bin/cfssl && \
     chmod +x /usr/bin/cfssl
 
-RUN python3 -m pip --no-cache-dir install poetry
+RUN python3.11 -m pip --no-cache-dir install poetry
 
 WORKDIR /opt/workdir/kuadrant-testsuite
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 
 [tool.poetry.group.main.dependencies]
 python = "^3.11"
+setuptools = "*"  # workaround: python-keycloak depends on it
 typing_extensions = "*"
 pytest-xdist = "*"
 pytest = "*"


### PR DESCRIPTION
With poetry 1.7.0 (https://python-poetry.org/blog/announcing-poetry-1.7.0/) the `setuptools` are removed when doing `install --sync`, sadly, `python-keycloak` depends on `setuptools` but has no direct dependency yet.

See https://github.com/marcospereirampj/python-keycloak/pull/505 for more details