### PR TITLE
Fix tests with credentials

### DIFF
--- a/testsuite/tests/kuadrant/authorino/identity/api_key/test_auth_credentials.py
+++ b/testsuite/tests/kuadrant/authorino/identity/api_key/test_auth_credentials.py
@@ -7,20 +7,22 @@ from testsuite.objects import Credentials
 @pytest.fixture(scope="module", params=["authorizationHeader", "customHeader", "queryString", "cookie"])
 def credentials(request):
     """Location where are auth credentials passed"""
-    return Credentials(request.param, "APIKEY")
+    return request.param
 
 
 @pytest.fixture(scope="module")
 def authorization(authorization, api_key, credentials):
     """Add API key identity to AuthConfig"""
     authorization.identity.clear_all()
-    authorization.identity.add_api_key("api_key", credentials=credentials, selector=api_key.selector)
+    authorization.identity.add_api_key(
+        "api_key", credentials=Credentials(credentials, "APIKEY"), selector=api_key.selector
+    )
     return authorization
 
 
 def test_custom_selector(client, auth, credentials):
     """Test if auth credentials are stored in right place"""
-    response = client.get("/get", headers={"authorization": "API_KEY " + auth.api_key})
+    response = client.get("/get", headers={"authorization": "APIKEY " + auth.api_key})
     if credentials == "authorizationHeader":
         assert response.status_code == 200
     else:
@@ -29,7 +31,7 @@ def test_custom_selector(client, auth, credentials):
 
 def test_custom_header(client, auth, credentials):
     """Test if auth credentials are stored in right place"""
-    response = client.get("/get", headers={"API_KEY": auth.api_key})
+    response = client.get("/get", headers={"APIKEY": auth.api_key})
     if credentials == "customHeader":
         assert response.status_code == 200
     else:
@@ -38,7 +40,7 @@ def test_custom_header(client, auth, credentials):
 
 def test_query(client, auth, credentials):
     """Test if auth credentials are stored in right place"""
-    response = client.get("/get", params={"API_KEY": auth.api_key})
+    response = client.get("/get", params={"APIKEY": auth.api_key})
     if credentials == "queryString":
         assert response.status_code == 200
     else:
@@ -47,7 +49,7 @@ def test_query(client, auth, credentials):
 
 def test_cookie(route, auth, credentials):
     """Test if auth credentials are stored in right place"""
-    with route.client(cookies={"API_KEY": auth.api_key}) as client:
+    with route.client(cookies={"APIKEY": auth.api_key}) as client:
         response = client.get("/get")
         if credentials == "cookie":
             assert response.status_code == 200


### PR DESCRIPTION
Tests compared `Credentials` dataclass with a string before, which always resulted in a false condition.