### PR TITLE
Fix kuadrant route cleanup

### DIFF
--- a/testsuite/openshift/objects/gateway_api/gateway.py
+++ b/testsuite/openshift/objects/gateway_api/gateway.py
@@ -200,7 +200,7 @@ class GatewayProxy(Proxy):
             self.route.commit()
         else:
             self.route.add_hostname(route.model.spec.host)
-        self.selector.union(route.self_selector())
+        self.selector = self.selector.union(route.self_selector())
         return HostnameWrapper(self.route, route.model.spec.host)
 
     def commit(self):


### PR DESCRIPTION
`selector.union` doesn't assign to a variable by itself