### PR TITLE
Add capabilities

### DIFF
--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -1,7 +1,7 @@
 #default:
 #  skip_cleanup: false
 #  tester: "someuser"                          # Optional: name of the user, who is running the tests, defaults to whoami/uid
-#  gateway_api: true                           # True, if Testsuite should test with Gateway API enabled (e.g. Full Kuadrant) or individual components (e.g. Authorino)
+#  standalone: false                           # True, if Testsuite should test only individual components (e.g. Authorino/limitador operators)
 #  cluster:                                    # Workload cluster where tests should run, will get overriden if run on Multicluster
 #    project: "kuadrant"                       # Optional: Default namespace for this cluster
 #    api_url: "https://api.openshift.com"      # Optional: OpenShift API URL, if None it will OpenShift that you are logged in

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,7 +1,7 @@
 default:
   skip_cleanup: false
   dynaconf_merge: true
-  gateway_api: true
+  standalone: false
   cluster: {}
   tools:
     project: "tools"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,11 @@ line-length = 120
 markers = [
     "issue: Reference to covered issue",
     "performance: Performance tests have unique needs",
-    "mgc: MGC tests have specific needs"
+    "mgc: Test is using MGC specific features",
+    "authorino: Test is using Authorino features",
+    "standalone_only: Test is using features available only in standalone mode, without Kuadrant",
+    "kuadrant_only: Test is using features available only in Kuadrant mode",
+    "limitador: Test is using Limitador features",
 ]
 filterwarnings = [
     "ignore: WARNING the new order is not taken into account:UserWarning",

--- a/testsuite/capabilities.py
+++ b/testsuite/capabilities.py
@@ -1,0 +1,56 @@
+"""Contains capability related classes"""
+
+import functools
+
+from weakget import weakget
+
+from testsuite.config import settings
+
+
+@functools.cache
+def has_kuadrant():
+    """Returns True, if Kuadrant deployment is present and should be used"""
+    spokes = weakget(settings)["control_plane"]["spokes"] % {}
+
+    if settings.get("standalone", False):
+        return False, "Standalone mode is enabled"
+
+    for name, openshift in spokes.items():
+        # Try if Kuadrant is deployed
+        if not openshift.connected:
+            return False, f"Spoke {name} is not connected"
+        project = settings["service_protection"]["system_project"]
+        kuadrant_openshift = openshift.change_project(project)
+        kuadrants = kuadrant_openshift.do_action("get", "kuadrant", "-o", "json", parse_output=True)
+        if len(kuadrants.model["items"]) == 0:
+            return False, f"Spoke {name} does not have Kuadrant resource in project {project}"
+
+    return True, None
+
+
+@functools.cache
+def is_standalone():
+    """Return True, if the testsuite is configured to run with envoy in standalone mode, without Gateway API"""
+    if not settings.get("standalone", False):
+        return False, "Standalone mode is disabled"
+    return True, None
+
+
+@functools.cache
+def has_mgc():
+    """Returns True, if MGC is configured and deployed"""
+    spokes = weakget(settings)["control_plane"]["spokes"] % {}
+
+    if settings.get("standalone", False):
+        return False, "Standalone mode is enabled"
+
+    if len(spokes) == 0:
+        return False, "Spokes are not configured"
+
+    hub_openshift = settings["control_plane"]["hub"]
+    if not hub_openshift.connected:
+        return False, "Control Plane Hub Openshift is not connected"
+
+    if "managedzones" not in hub_openshift.do_action("api-resources", "--api-group=kuadrant.io").out():
+        return False, "MGC custom resources are missing on hub cluster"
+    return True, None

--- a/testsuite/config/__init__.py
+++ b/testsuite/config/__init__.py
@@ -41,7 +41,7 @@ settings = Dynaconf(
         DefaultValueValidator("rhsso.url", default=fetch_route("no-ssl-sso")),
         DefaultValueValidator("rhsso.password", default=fetch_secret("credential-sso", "ADMIN_PASSWORD")),
         DefaultValueValidator("mockserver.url", default=fetch_route("mockserver", force_http=True)),
-        Validator("gateway_api", must_exist=False, eq=False)
+        Validator("standalone", must_exist=False, eq=True)
         | Validator("service_protection.gateway.name", must_exist=True),
     ],
     validate_only=["authorino", "kuadrant"],

--- a/testsuite/tests/kuadrant/authorino/authorization/opa/external_registry/test_auto_refresh_policy.py
+++ b/testsuite/tests/kuadrant/authorino/authorization/opa/external_registry/test_auto_refresh_policy.py
@@ -10,6 +10,9 @@ import pytest
 from testsuite.utils import rego_allow_header
 
 
+pytestmark = [pytest.mark.authorino]
+
+
 @pytest.fixture(scope="module")
 def updated_header():
     """Header for updated OPA policy"""

--- a/testsuite/tests/kuadrant/authorino/authorization/opa/external_registry/test_external_registry.py
+++ b/testsuite/tests/kuadrant/authorino/authorization/opa/external_registry/test_external_registry.py
@@ -1,5 +1,9 @@
 """Tests for Open Policy Agent (OPA) using Mockserver Expectations as http endpoint with Rego query"""
 
+import pytest
+
+pytestmark = [pytest.mark.authorino]
+
 
 def test_allowed_by_opa(client, auth, header):
     """Tests a request that should be authorized by OPA external registry declaration"""

--- a/testsuite/tests/kuadrant/authorino/authorization/opa/test_inline_rego.py
+++ b/testsuite/tests/kuadrant/authorino/authorization/opa/test_inline_rego.py
@@ -4,6 +4,8 @@ import pytest
 
 from testsuite.utils import rego_allow_header
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def header():

--- a/testsuite/tests/kuadrant/authorino/caching/metadata/test_caching.py
+++ b/testsuite/tests/kuadrant/authorino/caching/metadata/test_caching.py
@@ -8,6 +8,9 @@ from testsuite.policy.authorization import ValueFrom, Cache
 from testsuite.utils import extract_response
 
 
+pytestmark = [pytest.mark.authorino]
+
+
 @pytest.fixture(scope="module")
 def cache_ttl():
     """Returns TTL in seconds for Cached Metadata"""

--- a/testsuite/tests/kuadrant/authorino/caching/metadata/test_not_cached.py
+++ b/testsuite/tests/kuadrant/authorino/caching/metadata/test_not_cached.py
@@ -4,6 +4,8 @@ import pytest
 
 from testsuite.utils import extract_response
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization, module_label, expectation_path):

--- a/testsuite/tests/kuadrant/authorino/conditions/section_conditions/test_authorization_condition.py
+++ b/testsuite/tests/kuadrant/authorino/conditions/section_conditions/test_authorization_condition.py
@@ -4,6 +4,8 @@ import pytest
 
 from testsuite.policy.authorization import Pattern
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization):

--- a/testsuite/tests/kuadrant/authorino/conditions/section_conditions/test_identity_condition.py
+++ b/testsuite/tests/kuadrant/authorino/conditions/section_conditions/test_identity_condition.py
@@ -5,6 +5,8 @@ import pytest
 from testsuite.policy.authorization import Pattern
 from testsuite.httpx.auth import HeaderApiKeyAuth
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def api_key(create_api_key, module_label):

--- a/testsuite/tests/kuadrant/authorino/conditions/section_conditions/test_metadata_condition.py
+++ b/testsuite/tests/kuadrant/authorino/conditions/section_conditions/test_metadata_condition.py
@@ -4,6 +4,8 @@ import pytest
 
 from testsuite.policy.authorization import Pattern
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def mockserver_expectation(request, mockserver, module_label):

--- a/testsuite/tests/kuadrant/authorino/conditions/section_conditions/test_response_condition.py
+++ b/testsuite/tests/kuadrant/authorino/conditions/section_conditions/test_response_condition.py
@@ -5,6 +5,8 @@ import pytest
 from testsuite.policy.authorization import Pattern, Value, JsonResponse
 from testsuite.utils import extract_response
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization):

--- a/testsuite/tests/kuadrant/authorino/conditions/test_patternref_expressions.py
+++ b/testsuite/tests/kuadrant/authorino/conditions/test_patternref_expressions.py
@@ -4,6 +4,8 @@ import pytest
 
 from testsuite.policy.authorization import Pattern, PatternRef, AnyPattern, AllPattern
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization):

--- a/testsuite/tests/kuadrant/authorino/conditions/test_top_level_condition.py
+++ b/testsuite/tests/kuadrant/authorino/conditions/test_top_level_condition.py
@@ -4,6 +4,8 @@ import pytest
 
 from testsuite.policy.authorization import Pattern
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization, module_label):

--- a/testsuite/tests/kuadrant/authorino/dinosaur/test_dinosaur.py
+++ b/testsuite/tests/kuadrant/authorino/dinosaur/test_dinosaur.py
@@ -4,6 +4,8 @@ Test for complex AuthConfig
 
 import pytest
 
+pytestmark = [pytest.mark.authorino]
+
 ERROR_MESSAGE = {
     "kind": "Error",
     "id": "403",

--- a/testsuite/tests/kuadrant/authorino/identity/anonymous/test_anonymous_context.py
+++ b/testsuite/tests/kuadrant/authorino/identity/anonymous/test_anonymous_context.py
@@ -4,6 +4,8 @@ import pytest
 
 from testsuite.utils import extract_response
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization):

--- a/testsuite/tests/kuadrant/authorino/identity/anonymous/test_anonymous_identity.py
+++ b/testsuite/tests/kuadrant/authorino/identity/anonymous/test_anonymous_identity.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization, rhsso):

--- a/testsuite/tests/kuadrant/authorino/identity/api_key/test_api_key_context.py
+++ b/testsuite/tests/kuadrant/authorino/identity/api_key/test_api_key_context.py
@@ -4,6 +4,8 @@ import pytest
 
 from testsuite.utils import extract_response
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization, api_key):

--- a/testsuite/tests/kuadrant/authorino/identity/api_key/test_auth_credentials.py
+++ b/testsuite/tests/kuadrant/authorino/identity/api_key/test_auth_credentials.py
@@ -4,6 +4,8 @@ import pytest
 
 from testsuite.policy.authorization import Credentials
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module", params=["authorizationHeader", "customHeader", "queryString", "cookie"])
 def credentials(request):

--- a/testsuite/tests/kuadrant/authorino/identity/api_key/test_match_expression.py
+++ b/testsuite/tests/kuadrant/authorino/identity/api_key/test_match_expression.py
@@ -9,6 +9,9 @@ import pytest
 from testsuite.openshift import Selector, MatchExpression
 
 
+pytestmark = [pytest.mark.authorino]
+
+
 @pytest.fixture(scope="module")
 def valid_label_selectors(module_label):
     """Accepted labels for selector.matchExpressions in AuthConfig"""

--- a/testsuite/tests/kuadrant/authorino/identity/api_key/test_match_label.py
+++ b/testsuite/tests/kuadrant/authorino/identity/api_key/test_match_label.py
@@ -3,6 +3,9 @@
 import pytest
 
 
+pytestmark = [pytest.mark.authorino]
+
+
 @pytest.fixture(scope="module")
 def authorization(authorization, api_key):
     """Creates AuthConfig with API key identity"""

--- a/testsuite/tests/kuadrant/authorino/identity/api_key/test_reconciliation.py
+++ b/testsuite/tests/kuadrant/authorino/identity/api_key/test_reconciliation.py
@@ -5,6 +5,8 @@ import pytest
 from testsuite.httpx.auth import HeaderApiKeyAuth
 from testsuite.openshift import Selector
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="function")
 def api_key(create_api_key, module_label):

--- a/testsuite/tests/kuadrant/authorino/identity/auth/test_auth_identity.py
+++ b/testsuite/tests/kuadrant/authorino/identity/auth/test_auth_identity.py
@@ -6,6 +6,8 @@ from testsuite.httpx.auth import HttpxOidcClientAuth
 from testsuite.oidc import OIDCProvider
 from testsuite.oidc.rhsso import RHSSO
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization, oidc_provider):

--- a/testsuite/tests/kuadrant/authorino/identity/auth/test_multiple_auth_identities.py
+++ b/testsuite/tests/kuadrant/authorino/identity/auth/test_multiple_auth_identities.py
@@ -6,6 +6,8 @@ import pytest
 
 from testsuite.httpx.auth import HttpxOidcClientAuth
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def auth0_auth(auth0):

--- a/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_extended_properties.py
+++ b/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_extended_properties.py
@@ -5,6 +5,8 @@ import pytest
 from testsuite.policy.authorization import Value, ValueFrom
 from testsuite.utils import extract_response
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization, rhsso):

--- a/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_overwriting.py
+++ b/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_overwriting.py
@@ -5,6 +5,8 @@ import pytest
 from testsuite.policy.authorization import Value
 from testsuite.utils import extract_response
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization):

--- a/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_token_normalization.py
+++ b/testsuite/tests/kuadrant/authorino/identity/extended_properties/test_token_normalization.py
@@ -4,6 +4,8 @@ import pytest
 from testsuite.policy.authorization import Pattern, Value, ValueFrom
 from testsuite.httpx.auth import HeaderApiKeyAuth, HttpxOidcClientAuth
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def api_key(create_api_key, module_label):

--- a/testsuite/tests/kuadrant/authorino/identity/rhsso/test_auth_credentials.py
+++ b/testsuite/tests/kuadrant/authorino/identity/rhsso/test_auth_credentials.py
@@ -4,6 +4,8 @@ import pytest
 
 from testsuite.policy.authorization import Credentials
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module", params=["authorizationHeader", "customHeader", "queryString", "cookie"])
 def credentials(request):

--- a/testsuite/tests/kuadrant/authorino/identity/rhsso/test_rhsso_context.py
+++ b/testsuite/tests/kuadrant/authorino/identity/rhsso/test_rhsso_context.py
@@ -7,6 +7,8 @@ import pytest
 
 from testsuite.policy.authorization import ValueFrom, JsonResponse
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization):

--- a/testsuite/tests/kuadrant/authorino/identity/rhsso/test_rhsso_roles.py
+++ b/testsuite/tests/kuadrant/authorino/identity/rhsso/test_rhsso_roles.py
@@ -3,6 +3,8 @@
 import pytest
 from testsuite.httpx.auth import HttpxOidcClientAuth
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="function")
 def user_with_role(rhsso, realm_role, blame):

--- a/testsuite/tests/kuadrant/authorino/metadata/test_http.py
+++ b/testsuite/tests/kuadrant/authorino/metadata/test_http.py
@@ -12,6 +12,9 @@ import pytest
 
 from testsuite.utils import ContentType
 
+pytestmark = [pytest.mark.authorino]
+
+
 ALLOWED_COUNTRY = {"countryCode": "SK"}
 CHECK_COUNTRY_REGO = """allow {
 split(input.context.request.http.path, "/") = [_, _, country_code]

--- a/testsuite/tests/kuadrant/authorino/metadata/test_multi_element_json.py
+++ b/testsuite/tests/kuadrant/authorino/metadata/test_multi_element_json.py
@@ -7,6 +7,7 @@ import pytest
 
 from testsuite.utils import ContentType, extract_response
 
+pytestmark = [pytest.mark.authorino]
 
 MULTI_ELEMENT_JSON = '{"foo": "bar"}\n{"blah": "bleh"}'
 

--- a/testsuite/tests/kuadrant/authorino/metadata/test_uma.py
+++ b/testsuite/tests/kuadrant/authorino/metadata/test_uma.py
@@ -12,6 +12,8 @@ import pytest
 
 from testsuite.httpx.auth import HttpxOidcClientAuth
 
+pytestmark = [pytest.mark.authorino]
+
 VALIDATE_RESOURCE_OWNER = """
 metadata := object.get(input.auth.metadata, "resource-data", [])[0]
 

--- a/testsuite/tests/kuadrant/authorino/metadata/test_user_info.py
+++ b/testsuite/tests/kuadrant/authorino/metadata/test_user_info.py
@@ -8,6 +8,8 @@ import pytest
 from testsuite.httpx.auth import HttpxOidcClientAuth
 from testsuite.policy.authorization import Pattern
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def user2(rhsso, blame):

--- a/testsuite/tests/kuadrant/authorino/metrics/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/metrics/conftest.py
@@ -10,12 +10,6 @@ from testsuite.openshift.metrics import ServiceMonitor, MetricsEndpoint, Prometh
 
 
 @pytest.fixture(scope="module")
-def run_on_kuadrant():
-    """Kuadrant doesn't allow customization of Authorino parameters"""
-    return False
-
-
-@pytest.fixture(scope="module")
 def prometheus(request, openshift):
     """
     Return an instance of OpenShift metrics client

--- a/testsuite/tests/kuadrant/authorino/metrics/test_deep_metrics.py
+++ b/testsuite/tests/kuadrant/authorino/metrics/test_deep_metrics.py
@@ -4,6 +4,8 @@ import pytest
 
 from testsuite.policy.authorization import Value, JsonResponse
 
+pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
+
 
 @pytest.fixture(scope="module")
 def mockserver_expectation(request, mockserver, module_label):

--- a/testsuite/tests/kuadrant/authorino/metrics/test_metrics.py
+++ b/testsuite/tests/kuadrant/authorino/metrics/test_metrics.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
 
 METRICS = [
     "controller_runtime_reconcile_total",

--- a/testsuite/tests/kuadrant/authorino/multiple_hosts/test_multiple_hosts.py
+++ b/testsuite/tests/kuadrant/authorino/multiple_hosts/test_multiple_hosts.py
@@ -1,5 +1,9 @@
 """Tests AuthConfig with multiple specified hosts"""
 
+import pytest
+
+pytestmark = [pytest.mark.authorino]
+
 
 def test_original_host(client, auth):
     """Tests correct host"""

--- a/testsuite/tests/kuadrant/authorino/multiple_hosts/test_remove_host.py
+++ b/testsuite/tests/kuadrant/authorino/multiple_hosts/test_remove_host.py
@@ -1,5 +1,9 @@
 """Test host removal"""
 
+import pytest
+
+pytestmark = [pytest.mark.authorino]
+
 
 def test_removing_host(client, client2, auth, route, second_hostname):
     """Tests that after removal of the second host, it stops working, while the first one still works"""

--- a/testsuite/tests/kuadrant/authorino/operator/clusterwide/test_all_namespace_api_key.py
+++ b/testsuite/tests/kuadrant/authorino/operator/clusterwide/test_all_namespace_api_key.py
@@ -7,6 +7,8 @@ import pytest
 
 from testsuite.httpx.auth import HeaderApiKeyAuth
 
+pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
+
 
 @pytest.fixture(scope="module")
 def api_key(create_api_key, module_label, openshift2):

--- a/testsuite/tests/kuadrant/authorino/operator/clusterwide/test_clusterwide.py
+++ b/testsuite/tests/kuadrant/authorino/operator/clusterwide/test_clusterwide.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
+
 
 @pytest.mark.parametrize(
     "client_fixture",

--- a/testsuite/tests/kuadrant/authorino/operator/clusterwide/test_wildcard_collision.py
+++ b/testsuite/tests/kuadrant/authorino/operator/clusterwide/test_wildcard_collision.py
@@ -7,6 +7,8 @@ import pytest
 from testsuite.policy.authorization import Value, JsonResponse
 from testsuite.policy.authorization.auth_config import AuthConfig
 
+pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
+
 
 @pytest.fixture(scope="module")
 def route(route, wildcard_domain, hostname):

--- a/testsuite/tests/kuadrant/authorino/operator/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/conftest.py
@@ -1,9 +1,0 @@
-"""Module containing common features of all Operator tests"""
-
-import pytest
-
-
-@pytest.fixture(scope="module")
-def run_on_kuadrant():
-    """Kuadrant doesn't allow customization of Authorino parameters"""
-    return False

--- a/testsuite/tests/kuadrant/authorino/operator/raw_http/test_raw_http.py
+++ b/testsuite/tests/kuadrant/authorino/operator/raw_http/test_raw_http.py
@@ -2,6 +2,10 @@
 Test raw http authorization interface.
 """
 
+import pytest
+
+pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
+
 
 # pylint: disable=unused-argument
 def test_authorized_via_http(authorization, client, auth):

--- a/testsuite/tests/kuadrant/authorino/operator/sharding/test_preexisting_auth.py
+++ b/testsuite/tests/kuadrant/authorino/operator/sharding/test_preexisting_auth.py
@@ -5,6 +5,8 @@ from weakget import weakget
 
 from testsuite.openshift.authorino import AuthorinoCR
 
+pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
+
 
 @pytest.fixture(scope="module")
 def setup_authorino(openshift, blame, testconfig, module_label, request):

--- a/testsuite/tests/kuadrant/authorino/operator/sharding/test_sharding.py
+++ b/testsuite/tests/kuadrant/authorino/operator/sharding/test_sharding.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
+
 
 @pytest.fixture(scope="module")
 def authorino_parameters(authorino_parameters):

--- a/testsuite/tests/kuadrant/authorino/operator/test_deploy_authorino.py
+++ b/testsuite/tests/kuadrant/authorino/operator/test_deploy_authorino.py
@@ -1,5 +1,9 @@
 """Tests that when you deploy Authorino through operator, when the Authorino CR reports ready, the deployment is too"""
 
+import pytest
+
+pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
+
 
 def test_authorino_ready(authorino):
     """Test authorino deploy readiness"""

--- a/testsuite/tests/kuadrant/authorino/operator/test_wildcard.py
+++ b/testsuite/tests/kuadrant/authorino/operator/test_wildcard.py
@@ -6,6 +6,8 @@ import pytest
 
 from testsuite.policy.authorization.auth_config import AuthConfig
 
+pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
+
 
 @pytest.fixture(scope="module")
 def route(route, wildcard_domain, hostname):

--- a/testsuite/tests/kuadrant/authorino/operator/tls/test_tls.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/test_tls.py
@@ -1,5 +1,9 @@
 """Tests that envoy deployed with TLS security works with Authorino"""
 
+import pytest
+
+pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
+
 
 def test_valid_certificate(envoy_authority, valid_cert, auth, hostname):
     """Tests that valid certificate will be accepted"""

--- a/testsuite/tests/kuadrant/authorino/operator/tls/test_webhook.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/test_webhook.py
@@ -15,6 +15,8 @@ from testsuite.policy.authorization.auth_config import AuthConfig
 from testsuite.utils import cert_builder
 from testsuite.openshift.ingress import Ingress
 
+pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
+
 OPA_POLICY = """
     request := json.unmarshal(input.context.request.http.body).request
     verb := request.operation

--- a/testsuite/tests/kuadrant/authorino/priority/test_dependency.py
+++ b/testsuite/tests/kuadrant/authorino/priority/test_dependency.py
@@ -4,6 +4,8 @@ import pytest
 
 from testsuite.utils import extract_response
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def mockserver_expectation(request, mockserver, module_label):

--- a/testsuite/tests/kuadrant/authorino/priority/test_sequence_anonymous.py
+++ b/testsuite/tests/kuadrant/authorino/priority/test_sequence_anonymous.py
@@ -7,6 +7,8 @@ import pytest
 
 from testsuite.utils import extract_response
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization):

--- a/testsuite/tests/kuadrant/authorino/priority/test_sequence_api_key.py
+++ b/testsuite/tests/kuadrant/authorino/priority/test_sequence_api_key.py
@@ -5,6 +5,8 @@ import pytest
 from testsuite.policy.authorization import Credentials
 from testsuite.utils import extract_response
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def first_label(blame):

--- a/testsuite/tests/kuadrant/authorino/response/test_auth_json.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_auth_json.py
@@ -6,6 +6,8 @@ import pytest
 
 from testsuite.policy.authorization import ValueFrom, JsonResponse
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def issuer(oidc_provider):

--- a/testsuite/tests/kuadrant/authorino/response/test_base64.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_base64.py
@@ -9,6 +9,8 @@ import pytest
 
 from testsuite.policy.authorization import ValueFrom, JsonResponse
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization):

--- a/testsuite/tests/kuadrant/authorino/response/test_deny_with.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_deny_with.py
@@ -15,6 +15,8 @@ HEADERS = {
 
 TESTING_PATH = "/deny"
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization):

--- a/testsuite/tests/kuadrant/authorino/response/test_headers.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_headers.py
@@ -6,6 +6,8 @@ import pytest
 
 from testsuite.policy.authorization import Value, JsonResponse
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module", params=["123456789", "standardCharacters", "specialcharacters+*-."])
 def header_name(request):

--- a/testsuite/tests/kuadrant/authorino/response/test_multiple_responses.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_multiple_responses.py
@@ -6,6 +6,8 @@ import pytest
 
 from testsuite.policy.authorization import Value, JsonResponse
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization):

--- a/testsuite/tests/kuadrant/authorino/response/test_redirect.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_redirect.py
@@ -9,6 +9,8 @@ from testsuite.policy.authorization import ValueFrom, DenyResponse
 STATUS_CODE = 302
 REDIRECT_URL = "http://anything.inavlid?redirect_to="
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization):

--- a/testsuite/tests/kuadrant/authorino/response/test_simple_response.py
+++ b/testsuite/tests/kuadrant/authorino/response/test_simple_response.py
@@ -6,6 +6,8 @@ import pytest
 
 from testsuite.policy.authorization import Value, JsonResponse
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def authorization(authorization):

--- a/testsuite/tests/kuadrant/authorino/wristband/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/wristband/conftest.py
@@ -11,12 +11,6 @@ from testsuite.openshift.secret import TLSSecret
 from testsuite.utils import cert_builder
 
 
-@pytest.fixture(scope="module")
-def run_on_kuadrant():
-    """Kuadrant doesn't allow customization of Authorino parameters"""
-    return False
-
-
 @pytest.fixture(scope="session")
 def oidc_provider(rhsso):
     """Fixture which enables switching out OIDC providers for individual modules"""

--- a/testsuite/tests/kuadrant/authorino/wristband/test_wristband.py
+++ b/testsuite/tests/kuadrant/authorino/wristband/test_wristband.py
@@ -1,6 +1,9 @@
 """Test api authentication with wristband-token that was acquired after authentication on the edge layer"""
 
+import pytest
 from jose import jwt
+
+pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
 
 
 def test_wristband_token_claims(oidc_provider, auth, wristband_token, wristband_endpoint, certificates):

--- a/testsuite/tests/kuadrant/conftest.py
+++ b/testsuite/tests/kuadrant/conftest.py
@@ -7,22 +7,9 @@ from testsuite.policy.authorization.auth_policy import AuthPolicy
 from testsuite.policy.rate_limit_policy import RateLimitPolicy
 
 
-@pytest.fixture(scope="session")
-def run_on_kuadrant():
-    """True, if the tests should pass when running on Kuadrant"""
-    return True
-
-
-@pytest.fixture(scope="module", autouse=True)
-def skip_no_kuadrant(kuadrant, run_on_kuadrant):
-    """Skips all tests that are not working with Kuadrant"""
-    if kuadrant and not run_on_kuadrant:
-        pytest.skip("This test doesn't work with Kuadrant")
-
-
 # pylint: disable=unused-argument
 @pytest.fixture(scope="module")
-def authorino(kuadrant, skip_no_kuadrant):
+def authorino(kuadrant):
     """Authorino instance when configured through Kuadrant"""
     if kuadrant:
         # No available modification

--- a/testsuite/tests/kuadrant/limitador/conftest.py
+++ b/testsuite/tests/kuadrant/limitador/conftest.py
@@ -3,14 +3,6 @@
 import pytest
 
 
-@pytest.fixture(scope="module")
-def kuadrant(kuadrant):
-    """Skip if not running on Kuadrant"""
-    if not kuadrant:
-        pytest.skip("Limitador test can only run on Kuadrant for now")
-    return kuadrant
-
-
 @pytest.fixture(scope="module", autouse=True)
 def commit(request, rate_limit):
     """Commits all important stuff before tests"""

--- a/testsuite/tests/kuadrant/limitador/test_basic_limit.py
+++ b/testsuite/tests/kuadrant/limitador/test_basic_limit.py
@@ -6,6 +6,8 @@ import pytest
 
 from testsuite.policy.rate_limit_policy import Limit
 
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.limitador]
+
 
 @pytest.fixture(
     scope="module",

--- a/testsuite/tests/kuadrant/limitador/test_multiple_iterations.py
+++ b/testsuite/tests/kuadrant/limitador/test_multiple_iterations.py
@@ -8,6 +8,8 @@ import pytest
 
 from testsuite.policy.rate_limit_policy import Limit
 
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.limitador]
+
 
 @pytest.fixture(scope="module")
 def rate_limit(rate_limit):

--- a/testsuite/tests/kuadrant/limitador/test_route_rule.py
+++ b/testsuite/tests/kuadrant/limitador/test_route_rule.py
@@ -5,6 +5,8 @@ import pytest
 from testsuite.gateway import RouteMatch, PathMatch, MatchType
 from testsuite.policy.rate_limit_policy import Limit, RouteSelector
 
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.limitador]
+
 
 @pytest.fixture(scope="module")
 def route(route, backend):

--- a/testsuite/tests/kuadrant/reconciliation/test_httproute_delete.py
+++ b/testsuite/tests/kuadrant/reconciliation/test_httproute_delete.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+pytestmark = [pytest.mark.kuadrant_only]
+
 
 @pytest.mark.issue("https://github.com/Kuadrant/kuadrant-operator/issues/124")
 def test_delete(client, route, authorization, resilient_request):

--- a/testsuite/tests/kuadrant/reconciliation/test_httproute_hosts.py
+++ b/testsuite/tests/kuadrant/reconciliation/test_httproute_hosts.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+pytestmark = [pytest.mark.kuadrant_only]
+
 
 @pytest.fixture
 def second_hostname(exposer, gateway, blame):

--- a/testsuite/tests/kuadrant/reconciliation/test_httproute_matches.py
+++ b/testsuite/tests/kuadrant/reconciliation/test_httproute_matches.py
@@ -1,6 +1,10 @@
 """Tests that HTTPRoute spec.routes.matches changes are reconciled when changed."""
 
+import pytest
+
 from testsuite.gateway import RouteMatch, PathMatch
+
+pytestmark = [pytest.mark.kuadrant_only]
 
 
 def test_matches(client, backend, route, resilient_request):

--- a/testsuite/tests/kuadrant/test_rate_limit_authz.py
+++ b/testsuite/tests/kuadrant/test_rate_limit_authz.py
@@ -7,12 +7,7 @@ from testsuite.policy.authorization import ValueFrom, JsonResponse
 from testsuite.policy.rate_limit_policy import Limit
 
 
-@pytest.fixture(scope="module")
-def kuadrant(kuadrant):
-    """Skip if not running on Kuadrant"""
-    if not kuadrant:
-        pytest.skip("Limitador tests can only run on Kuadrant for now")
-    return kuadrant
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.limitador]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
# Summary

* Add marks for `authorino`, `limitador`, `kuadrant`, `mgc`, `standalone`, which serve both as metadata to select tests and a way how to skip if the requires setup is not present
* Add option `--enforce` which fails the test if the required setup is not present instead of a skip
* Add makefile options to select tests based on those marks
* Remove `--mgc` mark
* Annotate all tests
* Rename `gateway_api` option to `standalone` and use inverted values
    * Makes naming more consistent 

Fixes #164 
