### PR TITLE
Add test for gateway attached to AuthPolicy

### DIFF
--- a/testsuite/policy/authorization/auth_config.py
+++ b/testsuite/policy/authorization/auth_config.py
@@ -41,7 +41,7 @@ class AuthConfig(OpenShiftObject):
         cls,
         openshift: OpenShiftClient,
         name,
-        route,
+        target,
         labels: Dict[str, str] = None,
     ):
         """Creates base instance"""
@@ -52,7 +52,7 @@ class AuthConfig(OpenShiftObject):
             "spec": {"hosts": []},
         }
         obj = cls(model, context=openshift.context)
-        route.add_auth_config(obj)
+        target.add_auth_config(obj)
         return obj
 
     @modify

--- a/testsuite/policy/authorization/auth_policy.py
+++ b/testsuite/policy/authorization/auth_policy.py
@@ -18,13 +18,12 @@ class AuthPolicy(AuthConfig):
     def auth_section(self):
         return self.model.spec.setdefault("rules", {})
 
-    # pylint: disable=unused-argument
     @classmethod
-    def create_instance(  # type: ignore
+    def create_instance(
         cls,
         openshift: OpenShiftClient,
         name,
-        route: Referencable,
+        target: Referencable,
         labels: Dict[str, str] = None,
     ):
         """Creates base instance"""
@@ -33,7 +32,8 @@ class AuthPolicy(AuthConfig):
             "kind": "AuthPolicy",
             "metadata": {"name": name, "namespace": openshift.project, "labels": labels},
             "spec": {
-                "targetRef": route.reference,
+                "targetRef": target.reference,
+                "rules": {},
             },
         }
 

--- a/testsuite/tests/kuadrant/gateway/conftest.py
+++ b/testsuite/tests/kuadrant/gateway/conftest.py
@@ -1,0 +1,37 @@
+"""Conftest for gateway tests"""
+import pytest
+
+from testsuite.httpx.auth import HttpxOidcClientAuth
+from testsuite.policy.authorization.auth_policy import AuthPolicy
+
+
+@pytest.fixture(scope="module")
+def kuadrant(kuadrant):
+    """Skip if not running on Kuadrant"""
+    if not kuadrant:
+        pytest.skip("Gateway tests are only for Kuadrant")
+    return kuadrant
+
+
+@pytest.fixture(scope="module")
+def gateway_ready(gateway):
+    """Returns ready gateway"""
+    gateway.wait_for_ready()
+    return gateway
+
+
+@pytest.fixture(scope="module")
+def authorization(gateway_ready, route, oidc_provider, authorization_name, openshift, module_label):
+    # pylint: disable=unused-argument
+    """Create AuthPolicy attached to gateway"""
+    authorization = AuthPolicy.create_instance(
+        openshift, authorization_name, gateway_ready, labels={"testRun": module_label}
+    )
+    authorization.identity.add_oidc("rhsso", oidc_provider.well_known["issuer"])
+    return authorization
+
+
+@pytest.fixture(scope="module")
+def auth(oidc_provider):
+    """Returns RHSSO authentication object for HTTPX"""
+    return HttpxOidcClientAuth(oidc_provider.get_token, "authorization")

--- a/testsuite/tests/kuadrant/gateway/test_basic.py
+++ b/testsuite/tests/kuadrant/gateway/test_basic.py
@@ -1,0 +1,18 @@
+"""Test for AuthPolicy attached directly to gateway"""
+import pytest
+
+
+@pytest.fixture(scope="module")
+def rate_limit():
+    """Basic gateway test doesn't utilize RateLimitPolicy component"""
+    return None
+
+
+@pytest.mark.issue("https://github.com/Kuadrant/kuadrant-operator/pull/287")
+def test_smoke(client, auth):
+    """Test if AuthPolicy attached directly to gateway works"""
+    response = client.get("/get", auth=auth)
+    assert response.status_code == 200
+
+    response = client.get("/get")
+    assert response.status_code == 401


### PR DESCRIPTION
### Test case
AuthPolicy attached straight to gateway

### Changes
- Change authorization `targetRef` parameter name from `route` to `target`
- Add smoke test for AuthPolicy attached straight to gateway

### Note
Also an automatization for the following issue: https://github.com/Kuadrant/kuadrant-operator/pull/287

closes #269