### PR TITLE
Remove unnecessary identities management

### DIFF
--- a/testsuite/tests/kuadrant/authorino/identity/api_key/test_auth_credentials.py
+++ b/testsuite/tests/kuadrant/authorino/identity/api_key/test_auth_credentials.py
@@ -13,7 +13,6 @@ def credentials(request):
 @pytest.fixture(scope="module")
 def authorization(authorization, api_key, credentials):
     """Add API key identity to AuthConfig"""
-    authorization.identity.clear_all()
     authorization.identity.add_api_key(
         "api_key", credentials=Credentials(credentials, "APIKEY"), selector=api_key.selector
     )

--- a/testsuite/tests/kuadrant/authorino/identity/rhsso/test_auth_credentials.py
+++ b/testsuite/tests/kuadrant/authorino/identity/rhsso/test_auth_credentials.py
@@ -13,7 +13,6 @@ def credentials(request):
 @pytest.fixture(scope="module")
 def authorization(authorization, rhsso, credentials):
     """Add RHSSO identity to Authorization"""
-    authorization.identity.clear_all()
     authorization.identity.add_oidc("rhsso", rhsso.well_known["issuer"], credentials=Credentials(credentials, "Token"))
     return authorization
 

--- a/testsuite/tests/kuadrant/conftest.py
+++ b/testsuite/tests/kuadrant/conftest.py
@@ -39,9 +39,7 @@ def authorization_name(blame):
 def authorization(authorino, kuadrant, oidc_provider, route, authorization_name, openshift, module_label):
     """Authorization object (In case of Kuadrant AuthPolicy)"""
     if kuadrant:
-        policy = AuthPolicy.create_instance(openshift, authorization_name, route, labels={"testRun": module_label})
-        policy.identity.add_oidc("rhsso", oidc_provider.well_known["issuer"])
-        return policy
+        return AuthPolicy.create_instance(openshift, authorization_name, route, labels={"testRun": module_label})
     return None
 
 

--- a/testsuite/tests/kuadrant/reconciliation/conftest.py
+++ b/testsuite/tests/kuadrant/reconciliation/conftest.py
@@ -3,13 +3,6 @@ import backoff
 import pytest
 
 
-@pytest.fixture(scope="module")
-def authorization(authorization):
-    """Add anonymous identity"""
-    authorization.identity.add_anonymous("anonymous")
-    return authorization
-
-
 @pytest.fixture(scope="module", autouse=True)
 def commit(request, authorization):
     """Only commit authorization"""

--- a/testsuite/tests/kuadrant/test_rate_limit_authz.py
+++ b/testsuite/tests/kuadrant/test_rate_limit_authz.py
@@ -25,8 +25,9 @@ def rate_limit(rate_limit):
 
 
 @pytest.fixture(scope="module")
-def authorization(authorization):
-    """Adds JSON injection, that wraps the response as Envoy Dynamic Metadata for rate limit"""
+def authorization(authorization, oidc_provider):
+    """Adds rhsso identity and JSON injection, that wraps the response as Envoy Dynamic Metadata for rate limit"""
+    authorization.identity.add_oidc("rhsso", oidc_provider.well_known["issuer"])
     authorization.responses.add_success_dynamic(
         "identity", JsonResponse({"user": ValueFrom("auth.identity.preferred_username")})
     )


### PR DESCRIPTION
### Changes explanation
* Identities are already cleared out on the `identity` package level, so additional clear-out is not needed
* Oidc identity is already applied by default on the `authorino` package level to the AuthConfig/AuthPolicy. Other kuadrant packages don't take advantage of the rhsso identity features