### PR TITLE
Add kuadrant components wait-for-ready

### DIFF
--- a/testsuite/policy/authorization/auth_config.py
+++ b/testsuite/policy/authorization/auth_config.py
@@ -2,6 +2,8 @@
 from functools import cached_property
 from typing import Dict
 
+import openshift as oc
+
 from testsuite.utils import asdict
 from testsuite.openshift import OpenShiftObject, modify
 from testsuite.openshift.client import OpenShiftClient
@@ -69,6 +71,16 @@ class AuthConfig(OpenShiftObject):
     def remove_all_hosts(self):
         """Remove all hosts"""
         self.model.spec.hosts = []
+
+    def wait_for_ready(self):
+        """Waits until authorization object reports ready status"""
+        with oc.timeout(90):
+            success, _, _ = self.self_selector().until_all(
+                success_func=lambda obj: len(obj.model.status.conditions) > 0
+                and all(x.status == "True" for x in obj.model.status.conditions)
+            )
+            assert success, f"{self.kind()} did not get ready in time"
+            self.refresh()
 
     @modify
     def add_rule(self, when: list[Rule]):

--- a/testsuite/tests/kuadrant/authorino/caching/metadata/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/caching/metadata/conftest.py
@@ -26,10 +26,3 @@ def authorization(authorization):
     """Adds `aut.metadata` to the AuthJson"""
     authorization.responses.add_simple("auth.metadata")
     return authorization
-
-
-@pytest.fixture(autouse=True)
-def commit(request, authorization):
-    """Commits all important stuff before tests"""
-    request.addfinalizer(authorization.delete)
-    authorization.commit()

--- a/testsuite/tests/kuadrant/authorino/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/conftest.py
@@ -86,3 +86,4 @@ def commit(request, authorization):
     """Commits all important stuff before tests"""
     request.addfinalizer(authorization.delete)
     authorization.commit()
+    authorization.wait_for_ready()

--- a/testsuite/tests/kuadrant/authorino/metadata/test_uma.py
+++ b/testsuite/tests/kuadrant/authorino/metadata/test_uma.py
@@ -41,7 +41,8 @@ def auth2(rhsso):
 
 
 @pytest.fixture(scope="module")
-def authorization(authorization, rhsso, client):
+def authorization(client_secret, authorization, rhsso, client):
+    # pylint: disable=unused-argument
     """
     Adds UMA resource-level authorization metadata feature and OPA policy that authorize user access to the resource.
     Creates two client resources on RHSSO client:

--- a/testsuite/tests/kuadrant/authorino/operator/clusterwide/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/clusterwide/conftest.py
@@ -39,3 +39,4 @@ def commit(request, commit, authorization2):
     """Commits all important stuff before tests"""
     request.addfinalizer(authorization2.delete)
     authorization2.commit()
+    authorization2.wait_for_ready()

--- a/testsuite/tests/kuadrant/authorino/wristband/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/wristband/conftest.py
@@ -135,3 +135,4 @@ def commit(request, commit, wristband_authorization):
     """Commits all important stuff before tests"""
     request.addfinalizer(wristband_authorization.delete)
     wristband_authorization.commit()
+    wristband_authorization.wait_for_ready()

--- a/testsuite/tests/kuadrant/conftest.py
+++ b/testsuite/tests/kuadrant/conftest.py
@@ -60,3 +60,4 @@ def commit(request, authorization, rate_limit):
         if component is not None:
             request.addfinalizer(component.delete)
             component.commit()
+            component.wait_for_ready()

--- a/testsuite/tests/kuadrant/limitador/conftest.py
+++ b/testsuite/tests/kuadrant/limitador/conftest.py
@@ -16,3 +16,4 @@ def commit(request, rate_limit):
     """Commits all important stuff before tests"""
     request.addfinalizer(rate_limit.delete)
     rate_limit.commit()
+    rate_limit.wait_for_ready()

--- a/testsuite/tests/kuadrant/reconciliation/conftest.py
+++ b/testsuite/tests/kuadrant/reconciliation/conftest.py
@@ -8,6 +8,7 @@ def commit(request, authorization):
     """Only commit authorization"""
     request.addfinalizer(authorization.delete)
     authorization.commit()
+    authorization.wait_for_ready()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
### Changes

- Add wait-for-ready methods for authorization and `RateLimitPolicy` components
- Add wait-for-ready method calls after the kuadrants components commit
- Add uma test dependency for client secret so it is created before authorization using it