### PR TITLE
Add Route Select for Rate Limit

### DIFF
--- a/testsuite/gateway/__init__.py
+++ b/testsuite/gateway/__init__.py
@@ -1,5 +1,4 @@
 """Classes related to Gateways"""
-import abc
 import enum
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -9,7 +8,7 @@ from httpx import Client
 
 from testsuite.certificates import Certificate
 from testsuite.lifecycle import LifecycleObject
-from testsuite.utils import asdict, _asdict_recurse
+from testsuite.utils import asdict
 
 if TYPE_CHECKING:
     from testsuite.openshift.client import OpenShiftClient
@@ -76,10 +75,6 @@ class PathMatch:
     type: Optional[MatchType] = None
     value: Optional[str] = None
 
-    # def asdict(self):
-    #     """Custom dict due to nested structure of matchers."""
-    #     return {"path": _asdict_recurse(self, False)}
-
 
 @dataclass
 class HeadersMatch:
@@ -89,10 +84,6 @@ class HeadersMatch:
     value: str
     type: Optional[Literal[MatchType.EXACT, MatchType.REGULAR_EXPRESSION]] = None
 
-    # def asdict(self):
-    #     """Custom dict due to nested structure of matchers."""
-    #     return {"headers": [_asdict_recurse(self, False)]}
-
 
 @dataclass
 class QueryParamsMatch:
@@ -101,23 +92,6 @@ class QueryParamsMatch:
     name: str
     value: str
     type: Optional[Literal[MatchType.EXACT, MatchType.REGULAR_EXPRESSION]] = None
-
-    # def asdict(self):
-    #     """Custom dict due to nested structure of matchers."""
-    #     return {"queryParams": [_asdict_recurse(self, False)]}
-
-
-@dataclass
-class MethodMatch:
-    """
-    HTTPMethod describes how to select a HTTP route by matching the HTTP method. The value is expected in upper case.
-    """
-
-    value: HTTPMethod = None
-
-    def asdict(self):
-        """Custom dict due to nested structure of matchers."""
-        return {"method": self.value.value}
 
 
 @dataclass
@@ -132,7 +106,7 @@ class RouteMatch:
     path: Optional[PathMatch] = None
     headers: Optional[List[HeadersMatch]] = None
     query_params: Optional[List[QueryParamsMatch]] = None
-    method: HTTPMethod = None
+    method: Optional[HTTPMethod] = None
 
 
 class Gateway(LifecycleObject, Referencable):

--- a/testsuite/gateway/__init__.py
+++ b/testsuite/gateway/__init__.py
@@ -1,13 +1,15 @@
 """Classes related to Gateways"""
+import abc
+import enum
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, Optional, TYPE_CHECKING, Literal, List
 
 from httpx import Client
 
 from testsuite.certificates import Certificate
 from testsuite.lifecycle import LifecycleObject
-from testsuite.utils import asdict
+from testsuite.utils import asdict, _asdict_recurse
 
 if TYPE_CHECKING:
     from testsuite.openshift.client import OpenShiftClient
@@ -43,6 +45,94 @@ class CustomReference(Referencable):
     namespace: Optional[str] = None
     sectionName: Optional[str] = None  # pylint: disable=invalid-name
     port: Optional[int] = None
+
+
+class HTTPMethod(enum.Enum):
+    """HTTP methods supported by Matchers"""
+
+    CONNECT = "CONNECT"
+    DELETE = "DELETE"
+    GET = "GET"
+    HEAD = "HEAD"
+    OPTIONS = "OPTIONS"
+    PATCH = "PATCH"
+    POST = "POST"
+    PUT = "PUT"
+    TRACE = "TRACE"
+
+
+class MatchType(enum.Enum):
+    """MatchType specifies the semantics of how HTTP header values should be compared."""
+
+    EXACT = "Exact"
+    PATH_PREFIX = "PathPrefix"
+    REGULAR_EXPRESSION = "RegularExpression"
+
+
+@dataclass
+class PathMatch:
+    """HTTPPathMatch describes how to select an HTTP route by matching the HTTP request path."""
+
+    type: Optional[MatchType] = None
+    value: Optional[str] = None
+
+    # def asdict(self):
+    #     """Custom dict due to nested structure of matchers."""
+    #     return {"path": _asdict_recurse(self, False)}
+
+
+@dataclass
+class HeadersMatch:
+    """HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request headers."""
+
+    name: str
+    value: str
+    type: Optional[Literal[MatchType.EXACT, MatchType.REGULAR_EXPRESSION]] = None
+
+    # def asdict(self):
+    #     """Custom dict due to nested structure of matchers."""
+    #     return {"headers": [_asdict_recurse(self, False)]}
+
+
+@dataclass
+class QueryParamsMatch:
+    """HTTPQueryParamMatch describes how to select a HTTP route by matching HTTP query parameters."""
+
+    name: str
+    value: str
+    type: Optional[Literal[MatchType.EXACT, MatchType.REGULAR_EXPRESSION]] = None
+
+    # def asdict(self):
+    #     """Custom dict due to nested structure of matchers."""
+    #     return {"queryParams": [_asdict_recurse(self, False)]}
+
+
+@dataclass
+class MethodMatch:
+    """
+    HTTPMethod describes how to select a HTTP route by matching the HTTP method. The value is expected in upper case.
+    """
+
+    value: HTTPMethod = None
+
+    def asdict(self):
+        """Custom dict due to nested structure of matchers."""
+        return {"method": self.value.value}
+
+
+@dataclass
+class RouteMatch:
+    """
+    Abstract Dataclass for HTTPRouteMatch.
+    API specification consists of two layers: HTTPRouteMatch which can contain 4 matchers (see offsprings).
+    We merged this to a single Matcher representation for simplicity, which is why we need custom `asdict` methods.
+    https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteMatch
+    """
+
+    path: Optional[PathMatch] = None
+    headers: Optional[List[HeadersMatch]] = None
+    query_params: Optional[List[QueryParamsMatch]] = None
+    method: HTTPMethod = None
 
 
 class Gateway(LifecycleObject, Referencable):

--- a/testsuite/gateway/__init__.py
+++ b/testsuite/gateway/__init__.py
@@ -97,9 +97,8 @@ class QueryParamsMatch:
 @dataclass
 class RouteMatch:
     """
-    Abstract Dataclass for HTTPRouteMatch.
-    API specification consists of two layers: HTTPRouteMatch which can contain 4 matchers (see offsprings).
-    We merged this to a single Matcher representation for simplicity, which is why we need custom `asdict` methods.
+    HTTPRouteMatch defines the predicate used to match requests to a given action.
+    Multiple match types are ANDed together, i.e. the match will evaluate to true only if all conditions are satisfied.
     https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteMatch
     """
 
@@ -162,6 +161,14 @@ class GatewayRoute(LifecycleObject, Referencable):
     @abstractmethod
     def remove_all_hostnames(self):
         """Remove all hostnames from the Route"""
+
+    @abstractmethod
+    def add_rule(self, backend: "Httpbin", *route_matches: RouteMatch):
+        """Adds rule to the Route"""
+
+    @abstractmethod
+    def remove_all_rules(self):
+        """Remove all rules from the Route"""
 
     @abstractmethod
     def add_backend(self, backend: "Httpbin", prefix):

--- a/testsuite/policy/rate_limit_policy.py
+++ b/testsuite/policy/rate_limit_policy.py
@@ -25,7 +25,7 @@ class Limit:
 class RouteSelector:
     """
     RouteSelector is an object composed of a set of HTTPRouteMatch objects (from Gateway API -
-    HTRTPPathMatch, HTTPHeaderMatch, HTTPQueryParamMatch, HTTPMethodMatch),
+    HTTPPathMatch, HTTPHeaderMatch, HTTPQueryParamMatch, HTTPMethodMatch),
     and an additional hostnames field.
     https://docs.kuadrant.io/kuadrant-operator/doc/reference/route-selectors/#routeselector
     """

--- a/testsuite/tests/kuadrant/reconciliation/test_httproute_matches.py
+++ b/testsuite/tests/kuadrant/reconciliation/test_httproute_matches.py
@@ -1,4 +1,5 @@
 """Tests that HTTPRoute spec.routes.matches changes are reconciled when changed."""
+from testsuite.gateway import RouteMatch, PathMatch
 
 
 def test_matches(client, backend, route, resilient_request):
@@ -12,7 +13,8 @@ def test_matches(client, backend, route, resilient_request):
     response = client.get("/get")
     assert response.status_code == 200
 
-    route.set_match(backend, path_prefix="/anything")
+    route.remove_all_rules()
+    route.add_rule(backend, RouteMatch(path=PathMatch(value="/anything")))
 
     response = resilient_request("/get", expected_status=404)
     assert response.status_code == 404, "Matches were not reconciled"

--- a/testsuite/utils.py
+++ b/testsuite/utils.py
@@ -138,6 +138,9 @@ def asdict(obj) -> dict[str, JSONValues]:
 
 
 def _asdict_recurse(obj):
+    if hasattr(obj, "asdict"):
+        return obj.asdict()
+
     if not is_dataclass(obj):
         return deepcopy(obj)
 

--- a/testsuite/utils.py
+++ b/testsuite/utils.py
@@ -138,9 +138,6 @@ def asdict(obj) -> dict[str, JSONValues]:
 
 
 def _asdict_recurse(obj):
-    if hasattr(obj, "asdict"):
-        return obj.asdict()
-
     if not is_dataclass(obj):
         return deepcopy(obj)
 
@@ -156,6 +153,8 @@ def _asdict_recurse(obj):
             result[field.name] = type(value)(_asdict_recurse(i) for i in value)
         elif isinstance(value, dict):
             result[field.name] = type(value)((_asdict_recurse(k), _asdict_recurse(v)) for k, v in value.items())
+        elif isinstance(value, enum.Enum):
+            result[field.name] = value.value
         else:
             result[field.name] = deepcopy(value)
     return result


### PR DESCRIPTION
This PR creates two new sets of objects:

- `RouteSelect`: https://docs.kuadrant.io/kuadrant-operator/doc/reference/route-selectors/#routeselector
- `HTTP Route Matchers`: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRouteMatch

The placement of these resources can be discussed as I was not 100% sure.
Tests will be added later to this PR.

Usage example:
```
   selector = RouteSelector(
        RouteMatch(
            path=HTTPPathMatch(type=MatchType.EXACT, value="/get"),
            headers=[HeadersMatch(name="header", value="value"), HeadersMatch(name="another", value="value")],
            query_params=[HTTPQueryParamsMatch(name="param", value="value")]
            method=HTTPMethod.GET,
        )
    )
    rate_limit.add_limit("multiple", [limit], route_selectors=[selector])
```