### PR TITLE
Remove unimplemented abstract method from envoy route

### DIFF
--- a/testsuite/gateway/__init__.py
+++ b/testsuite/gateway/__init__.py
@@ -163,14 +163,6 @@ class GatewayRoute(LifecycleObject, Referencable):
         """Remove all hostnames from the Route"""
 
     @abstractmethod
-    def add_rule(self, backend: "Httpbin", *route_matches: RouteMatch):
-        """Adds rule to the Route"""
-
-    @abstractmethod
-    def remove_all_rules(self):
-        """Remove all rules from the Route"""
-
-    @abstractmethod
     def add_backend(self, backend: "Httpbin", prefix):
         """Adds another backend to the Route, with specific prefix"""
 


### PR DESCRIPTION
Fix the bug where testsuite can't initialize the `EnvoyVirtualRoute` class because of unimplemented abstract methods. Introduced in https://github.com/Kuadrant/testsuite/pull/316