### PR TITLE
Change whoami with os.getlogin to getpass.getuser

### DIFF
--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -1,5 +1,6 @@
 #default:
 #  skip_cleanup: false
+#  tester: "someuser"                          # Optional: name of the user, who is running the tests, defaults to whoami/uid
 #  gateway_api: true                           # True, if Testsuite should test with Gateway API enabled (e.g. Full Kuadrant) or individual components (e.g. Authorino)
 #  cluster:                                    # Workload cluster where tests should run, will get overriden if run on Multicluster
 #    project: "kuadrant"                       # Optional: Default namespace for this cluster

--- a/testsuite/utils.py
+++ b/testsuite/utils.py
@@ -3,6 +3,7 @@ import csv
 import enum
 import json
 import os
+import getpass
 import secrets
 from collections.abc import Collection
 from copy import deepcopy
@@ -48,7 +49,7 @@ def _whoami():
         return settings["tester"]
 
     try:
-        return os.getlogin()
+        return getpass.getuser()
     # want to catch broad exception and fallback at any circumstance
     # pylint: disable=broad-except
     except Exception:


### PR DESCRIPTION
Resolve the issue where if testsuite is executed from docker then it will use the uid of the user for objects name instead of the user name itself (e.g. `testsuite:1001`). Resolved by changing to the appropriate whoami standard function: `getpass.getuser()`



From https://docs.python.org/3/library/getpass.html:

_Return the “login name” of the user._

_This function checks the environment variables LOGNAME, USER, LNAME and USERNAME, in order, and returns the value of the first one which is set to a non-empty string. If none are set, the login name from the password database is returned on systems which support the [pwd](https://docs.python.org/3/library/pwd.html#module-pwd) module, otherwise, an exception is raised._

_In general, this function should be preferred over [os.getlogin()](https://docs.python.org/3/library/os.html#os.getlogin)._