### PR TITLE
Fix DefaultValueValidator validating only once

### DIFF
--- a/testsuite/config/__init__.py
+++ b/testsuite/config/__init__.py
@@ -20,7 +20,7 @@ class DefaultValueValidator(Validator):
                 )
             },
             default=default,
-            when=Validator(name, must_exist=False),
+            when=Validator(name, must_exist=False) | Validator(name, eq=None),
             **kwargs
         )
 


### PR DESCRIPTION
DefaultValueValidator validator only triggers when the value is missing entirely, however after first validation it became None instead and subsequent validation would pass.