### PR TITLE
Replace standalone config option for --standalone flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ authorino: poetry-no-dev
 
 authorino-standalone: ## Run only test capable of running with standalone Authorino
 authorino-standalone: poetry-no-dev
-	$(PYTEST) -n4 -m 'authorino and not kuadrant_only' --dist loadfile --enforce $(flags) testsuite/tests/kuadrant/authorino
+	$(PYTEST) -n4 -m 'authorino and not kuadrant_only' --dist loadfile --enforce --standalone $(flags) testsuite/tests/kuadrant/authorino
 
 limitador: ## Run only Limitador related tests
 limitador: poetry-no-dev

--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -1,7 +1,6 @@
 #default:
 #  skip_cleanup: false
 #  tester: "someuser"                          # Optional: name of the user, who is running the tests, defaults to whoami/uid
-#  standalone: false                           # True, if Testsuite should test only individual components (e.g. Authorino/limitador operators)
 #  cluster:                                    # Workload cluster where tests should run, will get overriden if run on Multicluster
 #    project: "kuadrant"                       # Optional: Default namespace for this cluster
 #    api_url: "https://api.openshift.com"      # Optional: OpenShift API URL, if None it will OpenShift that you are logged in

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,7 +1,6 @@
 default:
   skip_cleanup: false
   dynaconf_merge: true
-  standalone: false
   cluster: {}
   tools:
     project: "tools"

--- a/testsuite/capabilities.py
+++ b/testsuite/capabilities.py
@@ -12,9 +12,6 @@ def has_kuadrant():
     """Returns True, if Kuadrant deployment is present and should be used"""
     spokes = weakget(settings)["control_plane"]["spokes"] % {}
 
-    if settings.get("standalone", False):
-        return False, "Standalone mode is enabled"
-
     for name, openshift in spokes.items():
         # Try if Kuadrant is deployed
         if not openshift.connected:
@@ -29,20 +26,9 @@ def has_kuadrant():
 
 
 @functools.cache
-def is_standalone():
-    """Return True, if the testsuite is configured to run with envoy in standalone mode, without Gateway API"""
-    if not settings.get("standalone", False):
-        return False, "Standalone mode is disabled"
-    return True, None
-
-
-@functools.cache
 def has_mgc():
     """Returns True, if MGC is configured and deployed"""
     spokes = weakget(settings)["control_plane"]["spokes"] % {}
-
-    if settings.get("standalone", False):
-        return False, "Standalone mode is enabled"
 
     if len(spokes) == 0:
         return False, "Spokes are not configured"

--- a/testsuite/config/__init__.py
+++ b/testsuite/config/__init__.py
@@ -41,8 +41,6 @@ settings = Dynaconf(
         DefaultValueValidator("rhsso.url", default=fetch_route("no-ssl-sso")),
         DefaultValueValidator("rhsso.password", default=fetch_secret("credential-sso", "ADMIN_PASSWORD")),
         DefaultValueValidator("mockserver.url", default=fetch_route("mockserver", force_http=True)),
-        Validator("standalone", must_exist=False, eq=True)
-        | Validator("service_protection.gateway.name", must_exist=True),
     ],
     validate_only=["authorino", "kuadrant"],
     loaders=["dynaconf.loaders.env_loader", "testsuite.config.openshift_loader"],


### PR DESCRIPTION
Makes configuring standalone run to be all done through flags instead of config + flag