### PR TITLE
Add RLP targetting tests

### DIFF
--- a/testsuite/tests/kuadrant/limitador/route/conftest.py
+++ b/testsuite/tests/kuadrant/limitador/route/conftest.py
@@ -1,0 +1,20 @@
+"""Conftest for RLP targeting route tests """
+
+import pytest
+
+from testsuite.gateway import PathMatch, RouteMatch, MatchType
+
+
+@pytest.fixture(scope="module")
+def route(route, backend):
+    """Add two new rules to the route"""
+    route.remove_all_rules()
+    route.add_rule(
+        backend,
+        RouteMatch(path=PathMatch(value="/get", type=MatchType.PATH_PREFIX)),
+    )
+    route.add_rule(
+        backend,
+        RouteMatch(path=PathMatch(value="/anything", type=MatchType.PATH_PREFIX)),
+    )
+    return route

--- a/testsuite/tests/kuadrant/limitador/route/test_limit_targeting_two_rules.py
+++ b/testsuite/tests/kuadrant/limitador/route/test_limit_targeting_two_rules.py
@@ -1,0 +1,33 @@
+"""Tests that one RLP limit targeting two rules limits them together"""
+
+import pytest
+
+from testsuite.gateway import RouteMatch, PathMatch, MatchType
+from testsuite.policy.rate_limit_policy import RouteSelector, Limit
+
+
+@pytest.fixture(scope="module")
+def rate_limit(rate_limit):
+    """Add limit to the policy"""
+    selector = RouteSelector(
+        RouteMatch(path=PathMatch(value="/get", type=MatchType.PATH_PREFIX)),
+        RouteMatch(path=PathMatch(value="/anything", type=MatchType.PATH_PREFIX)),
+    )
+    rate_limit.add_limit("test", [Limit(5, 10)], route_selectors=[selector])
+    return rate_limit
+
+
+def test_limit_targeting_two_rules(client):
+    """Tests that one RLP limit targeting two rules limits them together"""
+    responses = client.get_many("/get", 3)
+    assert all(
+        r.status_code == 200 for r in responses
+    ), f"Rate Limited resource unexpectedly rejected requests {responses}"
+
+    responses = client.get_many("/anything", 2)
+    assert all(
+        r.status_code == 200 for r in responses
+    ), f"Rate Limited resource unexpectedly rejected requests {responses}"
+
+    assert client.get("/get").status_code == 429
+    assert client.get("/anything").status_code == 429

--- a/testsuite/tests/kuadrant/limitador/route/test_multiple_same_rule.py
+++ b/testsuite/tests/kuadrant/limitador/route/test_multiple_same_rule.py
@@ -1,0 +1,26 @@
+"""Test that multiple limits targeting same rule are correctly applied"""
+
+import pytest
+
+from testsuite.gateway import RouteMatch, PathMatch, MatchType
+from testsuite.policy.rate_limit_policy import RouteSelector, Limit
+
+
+@pytest.fixture(scope="module")
+def rate_limit(rate_limit):
+    """Add limit to the policy"""
+    selector = RouteSelector(
+        RouteMatch(path=PathMatch(value="/get", type=MatchType.PATH_PREFIX)),
+    )
+    rate_limit.add_limit("test1", [Limit(8, 10)], route_selectors=[selector])
+    rate_limit.add_limit("test2", [Limit(3, 5)], route_selectors=[selector])
+    return rate_limit
+
+
+def test_two_rules_targeting_one_limit(client):
+    """Test that one limit ends up shadowing others"""
+    responses = client.get_many("/get", 3)
+    assert all(
+        r.status_code == 200 for r in responses
+    ), f"Rate Limited resource unexpectedly rejected requests {responses}"
+    assert client.get("/get").status_code == 429

--- a/testsuite/tests/kuadrant/limitador/route/test_route_rule.py
+++ b/testsuite/tests/kuadrant/limitador/route/test_route_rule.py
@@ -9,24 +9,9 @@ pytestmark = [pytest.mark.kuadrant_only, pytest.mark.limitador]
 
 
 @pytest.fixture(scope="module")
-def route(route, backend):
-    """Add two new rules to the route"""
-    route.remove_all_rules()
-    route.add_rule(
-        backend,
-        RouteMatch(path=PathMatch(value="/get", type=MatchType.PATH_PREFIX)),
-    )
-    route.add_rule(
-        backend,
-        RouteMatch(path=PathMatch(value="/anything", type=MatchType.PATH_PREFIX)),
-    )
-    return route
-
-
-@pytest.fixture(scope="module")
 def rate_limit(rate_limit):
     """Add limit to the policy"""
-    selector = RouteSelector(RouteMatch(path=PathMatch(value="/get", type=MatchType.PATH_PREFIX)))
+    selector = RouteSelector(RouteMatch(path=PathMatch(value="/anything", type=MatchType.PATH_PREFIX)))
     rate_limit.add_limit("multiple", [Limit(5, 10)], route_selectors=[selector])
     return rate_limit
 

--- a/testsuite/tests/kuadrant/limitador/route/test_route_rule.py
+++ b/testsuite/tests/kuadrant/limitador/route/test_route_rule.py
@@ -11,12 +11,15 @@ pytestmark = [pytest.mark.kuadrant_only, pytest.mark.limitador]
 @pytest.fixture(scope="module")
 def rate_limit(rate_limit):
     """Add limit to the policy"""
-    selector = RouteSelector(RouteMatch(path=PathMatch(value="/anything", type=MatchType.PATH_PREFIX)))
+    selector = RouteSelector(
+        RouteMatch(path=PathMatch(value="/get", type=MatchType.PATH_PREFIX)),
+        RouteMatch(path=PathMatch(value="/anything/test", type=MatchType.PATH_PREFIX)),
+    )
     rate_limit.add_limit("multiple", [Limit(5, 10)], route_selectors=[selector])
     return rate_limit
 
 
-def test_rule(client):
+def test_rule_match(client):
     """Tests that RLP correctly applies to the given HTTPRoute rule"""
     responses = client.get_many("/get", 5)
     responses.assert_all(status_code=200)


### PR DESCRIPTION
This PR implements two use cases for RLP:

1. Tests that when one limit is targeting two rules, the same limit applies for them both at once.
2. Tests that when two limits are targeting one rule, one limit ends up shadowing others.

Test cases are points 5 and 6 from [RFC](https://docs.kuadrant.io/architecture/rfcs/0001-rlp-v2/#example-6-multiple-limit-definitions-targeting-the-same-httprouterule). Please think of this cases, if they are meaningful or extendable. 