### PR TITLE
Always run Kuadrant check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ testsuite/%: FORCE poetry-no-dev
 
 test: ## Run all non mgc tests
 test pytest tests: poetry-no-dev
-	$(PYTEST) -n4 -m 'not mgc' --dist loadfile $(flags) testsuite
+	$(PYTEST) -n4 -m 'not mgc' --dist loadfile --enforce $(flags) testsuite
 
 authorino: ## Run only authorino related tests
 authorino: poetry-no-dev

--- a/testsuite/capabilities.py
+++ b/testsuite/capabilities.py
@@ -10,17 +10,24 @@ from testsuite.config import settings
 @functools.cache
 def has_kuadrant():
     """Returns True, if Kuadrant deployment is present and should be used"""
-    spokes = weakget(settings)["control_plane"]["spokes"] % {}
+    if spokes := weakget(settings)["control_plane"]["spokes"] % {}:
+        for name, openshift in spokes.items():
+            # Try if Kuadrant is deployed
+            if not openshift.connected:
+                return False, f"Spoke {name} is not connected"
+            project = settings["service_protection"]["system_project"]
+            kuadrant_openshift = openshift.change_project(project)
+            kuadrants = kuadrant_openshift.do_action("get", "kuadrant", "-o", "json", parse_output=True)
+            if len(kuadrants.model["items"]) == 0:
+                return False, f"Spoke {name} does not have Kuadrant resource in project {project}"
 
-    for name, openshift in spokes.items():
-        # Try if Kuadrant is deployed
-        if not openshift.connected:
-            return False, f"Spoke {name} is not connected"
+    else:
+        openshift = settings["service_protection"]["project"]
         project = settings["service_protection"]["system_project"]
         kuadrant_openshift = openshift.change_project(project)
         kuadrants = kuadrant_openshift.do_action("get", "kuadrant", "-o", "json", parse_output=True)
         if len(kuadrants.model["items"]) == 0:
-            return False, f"Spoke {name} does not have Kuadrant resource in project {project}"
+            return False, f"Kuadrant resource is not installed in project {project}"
 
     return True, None
 

--- a/testsuite/config/openshift_loader.py
+++ b/testsuite/config/openshift_loader.py
@@ -27,7 +27,6 @@ def load(obj, env=None, silent=True, key=None, filename=None):
     obj["tools"] = tools
 
     service_protection = obj.setdefault("service_protection", {})
-    inject_client(service_protection, client, "system_project")
     inject_client(service_protection, client, "project")
     inject_client(service_protection, client, "project2")
 

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -57,14 +57,13 @@ def pytest_runtest_setup(item):
             skip_or_fail(
                 "Unable to run Standalone only test: Standalone mode is disabled, please use --standalone flag"
             )
-        if "kuadrant_only" in marks:
-            kuadrant, error = has_kuadrant()
-            if not kuadrant:
-                skip_or_fail(f"Unable to locate Kuadrant installation: {error}")
         if "mgc" in marks:
             mgc, error = has_mgc()
             if not mgc:
                 skip_or_fail(f"Unable to locate MGC installation: {error}")
+        kuadrant, error = has_kuadrant()
+        if not kuadrant:
+            skip_or_fail(f"Unable to locate Kuadrant installation: {error}")
 
 
 @pytest.hookimpl(hookwrapper=True)
@@ -251,16 +250,10 @@ def module_label(label):
 
 
 @pytest.fixture(scope="module")
-def kuadrant(request, testconfig, openshift):
+def kuadrant(request):
     """Returns Kuadrant instance if exists, or None"""
     if request.config.getoption("--standalone"):
         return None
-
-    # Try if Kuadrant is deployed
-    kuadrant_openshift = testconfig["service_protection"]["system_project"]
-    kuadrants = kuadrant_openshift.do_action("get", "kuadrant", "-o", "json", parse_output=True)
-    if len(kuadrants.model["items"]) == 0:
-        pytest.fail("Running Kuadrant tests, but Kuadrant resource was not found")
 
     # TODO: Return actual Kuadrant object
     return True


### PR DESCRIPTION
* Run Kuadrant check every time in the beginning, unless there is a `--standalone` flag
* `make test` now has `--enforce` flag
* Run Kuadrant check against default cluster, if no spokes are configured