### PR TITLE
Remove reconciliation resilient requests

### DIFF
--- a/testsuite/tests/kuadrant/reconciliation/conftest.py
+++ b/testsuite/tests/kuadrant/reconciliation/conftest.py
@@ -1,6 +1,5 @@
 """Conftest for reconciliation tests"""
 
-import backoff
 import pytest
 
 
@@ -10,15 +9,3 @@ def commit(request, authorization):
     request.addfinalizer(authorization.delete)
     authorization.commit()
     authorization.wait_for_ready()
-
-
-@pytest.fixture(scope="module")
-def resilient_request(client):
-    """Fixture which allows to send retrying requests until the expected status code is returned"""
-
-    def _request(path, method="get", expected_status=200, http_client=client, max_tries=4):
-        return backoff.on_predicate(
-            backoff.expo, lambda x: x.status_code == expected_status, max_tries=max_tries, jitter=None
-        )(lambda: getattr(http_client, method)(path))()
-
-    return _request

--- a/testsuite/tests/kuadrant/reconciliation/test_httproute_delete.py
+++ b/testsuite/tests/kuadrant/reconciliation/test_httproute_delete.py
@@ -6,7 +6,7 @@ pytestmark = [pytest.mark.kuadrant_only]
 
 
 @pytest.mark.issue("https://github.com/Kuadrant/kuadrant-operator/issues/124")
-def test_delete(client, route, authorization, resilient_request):
+def test_delete(client, route, authorization):
     """
     Tests that after deleting HTTPRoute, status.conditions shows it missing:
       * Test that that client works
@@ -21,7 +21,7 @@ def test_delete(client, route, authorization, resilient_request):
 
     route.delete()
 
-    response = resilient_request("/get", http_client=client, expected_status=404)
+    response = client.get("/get")
     assert response.status_code == 404, "Removing HTTPRoute was not reconciled"
 
     authorization.refresh()

--- a/testsuite/tests/kuadrant/reconciliation/test_httproute_hosts.py
+++ b/testsuite/tests/kuadrant/reconciliation/test_httproute_hosts.py
@@ -19,7 +19,7 @@ def client2(second_hostname):
     client.close()
 
 
-def test_add_host(client, client2, second_hostname, route, resilient_request):
+def test_add_host(client, client2, second_hostname, route):
     """
     Tests that HTTPRoute spec.hostnames changes are reconciled when changed:
       * Test that both hostnames work
@@ -38,10 +38,10 @@ def test_add_host(client, client2, second_hostname, route, resilient_request):
 
     route.remove_hostname(second_hostname.hostname)
 
-    response = resilient_request("/get", http_client=client2, expected_status=404)
+    response = client2.get("/get")
     assert response.status_code == 404, "Removing host was not reconciled"
 
     route.add_hostname(second_hostname.hostname)
 
-    response = resilient_request("/get", http_client=client2)
+    response = client2.get("/get")
     assert response.status_code == 200, "Adding host was not reconciled"

--- a/testsuite/tests/kuadrant/reconciliation/test_httproute_matches.py
+++ b/testsuite/tests/kuadrant/reconciliation/test_httproute_matches.py
@@ -7,7 +7,7 @@ from testsuite.gateway import RouteMatch, PathMatch
 pytestmark = [pytest.mark.kuadrant_only]
 
 
-def test_matches(client, backend, route, resilient_request):
+def test_matches(client, backend, route):
     """
     Tests that HTTPRoute spec.routes.matches changes are reconciled when changed
       * Test that /get works
@@ -21,7 +21,7 @@ def test_matches(client, backend, route, resilient_request):
     route.remove_all_rules()
     route.add_rule(backend, RouteMatch(path=PathMatch(value="/anything")))
 
-    response = resilient_request("/get", expected_status=404)
+    response = client.get("/get")
     assert response.status_code == 404, "Matches were not reconciled"
 
     response = client.get("/anything/get")


### PR DESCRIPTION
New `KuadrantClient` performs backoff by default and adding/removing hosts reconciliation is immediate now