### PR TITLE
Fix authorino clusterwide tests

### DIFF
--- a/testsuite/tests/kuadrant/authorino/operator/clusterwide/test_wildcard_collision.py
+++ b/testsuite/tests/kuadrant/authorino/operator/clusterwide/test_wildcard_collision.py
@@ -20,8 +20,8 @@ def route(route, wildcard_domain, hostname):
 
 # pylint: disable = unused-argument
 @pytest.fixture(scope="module")
-def authorization(authorino, blame, wildcard_domain, route, openshift, module_label, gateway):
-    """In case of Authorino, AuthConfig used for authorization"""
+def authorization(authorino, blame, route, openshift, module_label, gateway):
+    """Create AuthConfig with host set to wildcard_domain"""
     auth = AuthConfig.create_instance(openshift, blame("ac"), route, labels={"testRun": module_label})
     auth.responses.add_success_header("header", JsonResponse({"anything": Value("one")}))
     return auth
@@ -30,33 +30,59 @@ def authorization(authorino, blame, wildcard_domain, route, openshift, module_la
 # pylint: disable = unused-argument
 @pytest.fixture(scope="module")
 def authorization2(authorino, blame, route, openshift2, module_label, gateway):
-    """In case of Authorino, AuthConfig used for authorization"""
+    """Create AuthConfig with host set to wildcard_domain in another project"""
     auth = AuthConfig.create_instance(openshift2, blame("ac"), route, labels={"testRun": module_label})
     auth.responses.add_success_header("header", JsonResponse({"anything": Value("two")}))
     return auth
 
 
-@pytest.mark.parametrize(
-    ("client_fixture", "auth_fixture", "hosts"),
-    [
-        pytest.param("client", "authorization", "wildcard_domain", id="First namespace"),
-        pytest.param("client2", "authorization2", [], id="Second namespace"),
-    ],
-)
-def test_wildcard_collision(client_fixture, auth_fixture, hosts, request):
+@pytest.fixture(scope="module", autouse=True)
+def commit(request, authorization, authorization2):
+    """Commits both AuthConfigs. Don't wait on second AuthConfig here, because it should fail to reconcile"""
+    request.addfinalizer(authorization.delete)
+    authorization.commit()
+    authorization.wait_for_ready()
+
+    request.addfinalizer(authorization2.delete)
+    authorization2.commit()
+
+
+def test_wildcard_first_authorization(client, authorization, wildcard_domain):
     """
-    Preparation:
-        - Create AuthConfig with host set to wildcard_domain
-        - Create AuthConfig with host set to wildcard_domain in another project
-    Test:
-        - Send request to authorino
-        - Assert that the correct AuthConfig was used
+    - Send successful request to the Authorino
+    - Verify that first AuthConfig was used
+    - Assert that the first AuthConfig have wildcard domain host ready
     """
-    if hosts:
-        hosts = [request.getfixturevalue(hosts)]
-    client = request.getfixturevalue(client_fixture)
     response = client.get("/get")
     assert response.status_code == 200
     assert response.json()["headers"]["Header"] == '{"anything":"one"}'
-    authorization = request.getfixturevalue(auth_fixture)
-    assert authorization.model.status.summary.hostsReady == hosts
+
+    assert authorization.model.status.summary.hostsReady == [wildcard_domain]
+
+
+def test_wildcard_second_authorization(client2, authorization2):
+    """
+    - Assert that the second AuthConfig is not ready
+    - Send successful request to the Authorino
+    - Verify that first AuthConfig was used
+    - Assert that the second AuthConfig have no hosts ready
+    """
+
+    def hosts_not_linked(auth_obj):
+        for condition in auth_obj.model.status.conditions:
+            if (
+                condition.type == "Ready"
+                and condition.status == "False"
+                and "One or more hosts are not linked to the resource" in condition.message
+                and condition.reason == "HostsNotLinked"
+            ):
+                return True
+        return False
+
+    assert authorization2.wait_until(hosts_not_linked)
+
+    response = client2.get("/get")
+    assert response.status_code == 200
+    assert response.json()["headers"]["Header"] == '{"anything":"one"}'
+
+    assert authorization2.model.status.summary.hostsReady == []


### PR DESCRIPTION
First authconfig now contains only first hostname, second authconfig - only second hostname.
The wildcard collision test is divided into 2 separate tests