### PR TITLE
Remove flaky library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ httpx = { version = "*", extras = ["http2"] }
 openshift-client = ">=2"
 apyproxy = "*"
 weakget = "*"
-flaky = "*"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
As it is not needed and it has currently bug causing pytest crash https://github.com/box/flaky/issues/198