### PR TITLE
Improve extract_response to return None for empty content only

### DIFF
--- a/testsuite/utils.py
+++ b/testsuite/utils.py
@@ -40,7 +40,7 @@ def generate_tail(tail=5):
 
 
 def randomize(name, tail=5):
-    "To avoid conflicts returns modified name with random sufffix"
+    "To avoid conflicts returns modified name with random suffix"
     return f"{name}-{generate_tail(tail)}"
 
 
@@ -125,8 +125,8 @@ def extract_response(response, header="Simple", key="data"):
     :return: Extracted value
     """
 
-    # Returning None for non-200 responses because the content of such responses might not be a valid JSON
-    if response.status_code != 200:
+    # Returning None if content is empty, this typically happens for non-200 responses
+    if len(response.content) == 0:
         return weakget(None)
 
     return weakget(json.loads(response.json()["headers"][header]))[key]


### PR DESCRIPTION
## Overview
Improvement of `extract_response` function. It should attempt to extract stuff from the response regardless the response status code. There are valid use cases there, for example 500 responses might contain details about error etc.

The only good reason for skipping the actual extraction is when there is nothing to do the extraction from. In case of non-empty content the function proceeds as before (no matter what the status_code is) - it converts the content to JSON (it throws an error in case of invalid JSON) and tries to extract the data from given location.

## Changes
- Return None right away if the content of the response is empty
- Trivial typo fix

## Verification steps
Eye review might suffice. If you have a cluster you can run the whole test suite (I did that though and there were no suspicious errors, just expected `Unable to run Standalone only test: Standalone mode is disabled` ones. For a quick check you can execute:
`make ./testsuite/tests/kuadrant/authorino/identity/plain/test_plain_identity.py` since this test does the extraction from both 200 and 401 responses.
