### PR TITLE
Add hyperfoil default url

### DIFF
--- a/testsuite/config/__init__.py
+++ b/testsuite/config/__init__.py
@@ -45,6 +45,7 @@ settings = Dynaconf(
         DefaultValueValidator("rhsso.url", default=fetch_route("no-ssl-sso")),
         DefaultValueValidator("rhsso.password", default=fetch_secret("credential-sso", "ADMIN_PASSWORD")),
         DefaultValueValidator("mockserver.url", default=fetch_route("mockserver", force_http=True)),
+        DefaultValueValidator("hyperfoil.url", default=fetch_route("hyperfoil", force_http=True)),
     ],
     validate_only=["authorino", "kuadrant"],
     loaders=["dynaconf.loaders.env_loader", "testsuite.config.openshift_loader"],


### PR DESCRIPTION
Depends on: https://github.com/3scale-qe/tools/issues/35

The solution of this PR does not load the url and therefore skips the performance tests. I do not know yet how to fix it yet.