### PR TITLE
Add support for Kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: commit-acceptance pylint mypy black reformat test performance authorino poetry poetry-no-dev container-image polish-junit reportportal authorino-standalone limitador kuadrant kuadrant-only
+.PHONY: commit-acceptance pylint mypy black reformat test performance authorino poetry poetry-no-dev mgc container-image polish-junit reportportal authorino-standalone limitador kuadrant kuadrant-only
 
 TB ?= short
 LOGLEVEL ?= INFO
@@ -61,7 +61,7 @@ kuadrant: poetry-no-dev
 
 kuadrant-only: ## Run Kuadrant-only tests
 kuadrant-only: poetry-no-dev
-	$(PYTEST) -n4 -m 'kuadrant_only' --dist loadfile --enforce $(flags) testsuite
+	$(PYTEST) -n4 -m 'kuadrant_only and not standalone_only' --dist loadfile --enforce $(flags) testsuite
 
 performance: ## Run performance tests
 performance: poetry-no-dev

--- a/testsuite/config/__init__.py
+++ b/testsuite/config/__init__.py
@@ -2,7 +2,7 @@
 
 from dynaconf import Dynaconf, Validator
 
-from testsuite.config.tools import fetch_route, fetch_service, fetch_secret
+from testsuite.config.tools import fetch_route, fetch_service, fetch_secret, fetch_service_ip
 
 
 # pylint: disable=too-few-public-methods
@@ -41,7 +41,7 @@ settings = Dynaconf(
         DefaultValueValidator(
             "tracing.collector_url", default=fetch_service("jaeger-collector", protocol="rpc", port=4317)
         ),
-        DefaultValueValidator("tracing.query_url", default=fetch_route("jaeger-query", force_http=True)),
+        DefaultValueValidator("tracing.query_url", default=fetch_service_ip("jaeger-query", force_http=True, port=80)),
         Validator(
             "default_exposer",
             # If exposer was successfully converted, it will no longer be a string"""
@@ -52,9 +52,9 @@ settings = Dynaconf(
         Validator("control_plane.managedzone", must_exist=True, ne=None),
         Validator("control_plane.clusterissuer", must_exist=True, ne=None),
         Validator("letsencrypt.clusterissuer", must_exist=True, ne=None),
-        DefaultValueValidator("keycloak.url", default=fetch_route("no-ssl-sso")),
+        DefaultValueValidator("keycloak.url", default=fetch_service_ip("keycloak", force_http=True, port=8080)),
         DefaultValueValidator("keycloak.password", default=fetch_secret("credential-sso", "ADMIN_PASSWORD")),
-        DefaultValueValidator("mockserver.url", default=fetch_route("mockserver", force_http=True)),
+        DefaultValueValidator("mockserver.url", default=fetch_service_ip("mockserver", force_http=True, port=1080)),
     ],
     validate_only=["authorino", "kuadrant", "default_exposer", "control_plane"],
     loaders=["dynaconf.loaders.env_loader", "testsuite.config.openshift_loader", "testsuite.config.exposer"],

--- a/testsuite/config/exposer.py
+++ b/testsuite/config/exposer.py
@@ -1,8 +1,8 @@
 """Translates string to an Exposer class that can initialized"""
 
-from testsuite.gateway.exposers import OpenShiftExposer
+from testsuite.gateway.exposers import OpenShiftExposer, KindExposer
 
-EXPOSERS = {"openshift": OpenShiftExposer}
+EXPOSERS = {"openshift": OpenShiftExposer, "kind": KindExposer}
 
 
 # pylint: disable=unused-argument

--- a/testsuite/config/tools.py
+++ b/testsuite/config/tools.py
@@ -9,7 +9,7 @@ from testsuite.openshift.service import Service
 logger = logging.getLogger(__name__)
 
 
-def fetch_route(name, force_http=False, service_port=None):
+def fetch_route(name, force_http=False):
     """Fetches the URL of a route with specific name"""
 
     def _fetcher(settings, _):
@@ -61,6 +61,7 @@ def fetch_service_ip(name, port, force_http=False):
             with openshift.context:
                 ip = selector(f"service/{name}").object(cls=Service).external_ip
                 return f"http://{ip}:{port}" if force_http else f"https://{ip}:{port}"
+        # pylint: disable=broad-except
         except Exception:
             logger.warning("Unable to fetch route %s from tools", name)
             return None

--- a/testsuite/gateway/__init__.py
+++ b/testsuite/gateway/__init__.py
@@ -127,6 +127,10 @@ class Gateway(LifecycleObject, Referencable):
         """Service name for this gateway"""
 
     @abstractmethod
+    def external_ip(self) -> str:
+        """Returns loadBalanced IP and port to access this Gateway"""
+
+    @abstractmethod
     def wait_for_ready(self, timeout: int = 90):
         """Waits until the gateway is ready"""
 

--- a/testsuite/gateway/envoy/__init__.py
+++ b/testsuite/gateway/envoy/__init__.py
@@ -92,6 +92,7 @@ class Envoy(Gateway):  # pylint: disable=too-many-instance-attributes
             self.name,
             selector={"deployment": self.name, **self.labels},
             ports=[ServicePort(name="api", port=8080, targetPort="api")],
+            service_type="LoadBalancer",
         )
         self.service.commit()
 

--- a/testsuite/gateway/envoy/__init__.py
+++ b/testsuite/gateway/envoy/__init__.py
@@ -47,6 +47,9 @@ class Envoy(Gateway):  # pylint: disable=too-many-instance-attributes
     def service_name(self) -> str:
         return self.name
 
+    def external_ip(self) -> str:
+        return f"{self.service.external_ip}:{self.service.get_port('api').port}"  # type: ignore
+
     def rollout(self):
         """Restarts Envoy to apply newest config changes"""
         self.openshift.do_action("rollout", ["restart", f"deployment/{self.name}"])

--- a/testsuite/gateway/exposers.py
+++ b/testsuite/gateway/exposers.py
@@ -1,7 +1,5 @@
 """General exposers, not tied to Envoy or Gateway API"""
 
-from httpx import Client
-
 from testsuite.certificates import Certificate
 from testsuite.gateway import Exposer, Gateway, Hostname
 from testsuite.httpx import KuadrantClient
@@ -43,13 +41,15 @@ class OpenShiftExposer(Exposer):
 
 
 class StaticLocalHostname(Hostname):
+    """Static local IP hostname"""
+
     def __init__(self, hostname, ip_getter, verify: Certificate = None, force_https: bool = False):
         self._hostname = hostname
         self.verify = verify
         self.ip_getter = ip_getter
         self.force_https = force_https
 
-    def client(self, **kwargs) -> Client:
+    def client(self, **kwargs) -> KuadrantClient:
         headers = kwargs.setdefault("headers", {})
         headers["Host"] = self.hostname
         protocol = "http"
@@ -64,6 +64,8 @@ class StaticLocalHostname(Hostname):
 
 
 class KindExposer(Exposer):
+    """Exposer using loadbalancer service for Gateway"""
+
     def expose_hostname(self, name, gateway: Gateway) -> Hostname:
         return StaticLocalHostname(
             f"{name}.{self.base_domain}", gateway.external_ip, gateway.get_tls_cert(), force_https=self.passthrough

--- a/testsuite/gateway/gateway_api/gateway.py
+++ b/testsuite/gateway/gateway_api/gateway.py
@@ -8,7 +8,6 @@ from testsuite.certificates import Certificate
 from testsuite.gateway import Gateway
 from testsuite.openshift.client import OpenShiftClient
 from testsuite.openshift import OpenShiftObject
-from testsuite.openshift.service import Service
 
 
 class KuadrantGateway(OpenShiftObject, Gateway):

--- a/testsuite/gateway/gateway_api/gateway.py
+++ b/testsuite/gateway/gateway_api/gateway.py
@@ -8,6 +8,7 @@ from testsuite.certificates import Certificate
 from testsuite.gateway import Gateway
 from testsuite.openshift.client import OpenShiftClient
 from testsuite.openshift import OpenShiftObject
+from testsuite.openshift.service import Service
 
 
 class KuadrantGateway(OpenShiftObject, Gateway):
@@ -55,6 +56,10 @@ class KuadrantGateway(OpenShiftObject, Gateway):
     @property
     def service_name(self) -> str:
         return f"{self.name()}-istio"
+
+    def external_ip(self) -> str:
+        with self.context:
+            return f"{self.refresh().model.status.addresses[0].value}:80"
 
     @property
     def openshift(self):

--- a/testsuite/openshift/client.py
+++ b/testsuite/openshift/client.py
@@ -73,7 +73,7 @@ class OpenShiftClient:
     def connected(self):
         """Returns True, if user is logged in and the project exists"""
         try:
-            self.do_action("status")
+            self.do_action("get", "ns", self._project)
         except OpenShiftPythonException:
             return False
         return True

--- a/testsuite/openshift/service.py
+++ b/testsuite/openshift/service.py
@@ -55,6 +55,7 @@ class Service(OpenShiftObject):
 
     @property
     def external_ip(self):
+        """Returns LoadBalancer IP for this service"""
         if self.model.spec.type != "LoadBalancer":
             raise AttributeError("External IP can be only used with LoadBalancer services")
         return self.model.status.loadBalancer.ingress[0].ip

--- a/testsuite/openshift/service.py
+++ b/testsuite/openshift/service.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass, asdict
 from typing import Literal
 
-from openshift_client import timeout, APIObject
+from openshift_client import timeout
 
 from testsuite.openshift import OpenShiftObject
 

--- a/testsuite/tests/kuadrant/authorino/metrics/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/metrics/conftest.py
@@ -62,7 +62,7 @@ def authorino(authorino, module_label):
 
 
 @pytest.fixture(scope="module")
-def service_monitor(openshift, blame, module_label):
+def service_monitor(openshift, prometheus, blame, module_label):
     """Create ServiceMonitor object to follow Authorino /metrics and /server-metrics endpoints"""
     endpoints = [MetricsEndpoint("/metrics", "http"), MetricsEndpoint("/server-metrics", "http")]
     return ServiceMonitor.create_instance(openshift, blame("sm"), endpoints, match_labels={"app": module_label})

--- a/testsuite/tests/kuadrant/authorino/metrics/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/metrics/conftest.py
@@ -61,6 +61,7 @@ def authorino(authorino, module_label):
     return authorino
 
 
+# pylint: disable=unused-argument
 @pytest.fixture(scope="module")
 def service_monitor(openshift, prometheus, blame, module_label):
     """Create ServiceMonitor object to follow Authorino /metrics and /server-metrics endpoints"""

--- a/testsuite/tests/kuadrant/authorino/operator/raw_http/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/raw_http/conftest.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from testsuite.gateway.exposers import KindExposer
 from testsuite.policy.authorization import Value, JsonResponse
 from testsuite.httpx import KuadrantClient
 from testsuite.policy.authorization.auth_config import AuthConfig
@@ -27,8 +28,11 @@ def client(authorization, authorino_route):
 
 
 @pytest.fixture(scope="module")
-def authorino_route(request, authorino, blame, openshift):
+def authorino_route(request, exposer, authorino, blame, openshift):
     """Add route for authorino http port to be able to access it."""
+    if isinstance(exposer, KindExposer):
+        pytest.skip("raw_http is not available on Kind")
+
     route = OpenshiftRoute.create_instance(
         openshift, blame("route"), f"{authorino.name()}-authorino-authorization", target_port="http"
     )

--- a/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
@@ -8,7 +8,7 @@ from testsuite.certificates import Certificate, CertInfo
 from testsuite.openshift import Selector
 from testsuite.gateway import Exposer
 from testsuite.gateway.envoy.tls import TLSEnvoy
-from testsuite.gateway.exposers import OpenShiftExposer
+from testsuite.gateway.exposers import OpenShiftExposer, KindExposer
 from testsuite.openshift.secret import TLSSecret
 from testsuite.utils import cert_builder
 
@@ -181,12 +181,11 @@ def gateway(
 
 
 @pytest.fixture(scope="session")
-def exposer(request, hub_openshift) -> Exposer:
+def exposer(exposer) -> Exposer:
     """Exposer object instance with TLS passthrough"""
-    exposer = OpenShiftExposer(hub_openshift)
+    if isinstance(exposer, KindExposer):
+        pytest.skip("TLS tests dont work with Kind")
     exposer.passthrough = True
-    request.addfinalizer(exposer.delete)
-    exposer.commit()
     return exposer
 
 

--- a/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
@@ -8,7 +8,7 @@ from testsuite.certificates import Certificate, CertInfo
 from testsuite.openshift import Selector
 from testsuite.gateway import Exposer
 from testsuite.gateway.envoy.tls import TLSEnvoy
-from testsuite.gateway.exposers import OpenShiftExposer, KindExposer
+from testsuite.gateway.exposers import KindExposer
 from testsuite.openshift.secret import TLSSecret
 from testsuite.utils import cert_builder
 


### PR DESCRIPTION
* Use LoadBalancer service for tools
  * https://github.com/3scale-qe/tools/pull/36
  * RHSSO is still not done in that PR
* Add `not standalone_only` to test target
* Fix Prometheus check for metrics tests
* Add KindExposer
   * Some tests needs to be explicitly skipped (TLS, raw_http) when used with Kind exposed
