### PR TITLE
Mark dinosaur tests as excepted fail

### DIFF
--- a/testsuite/tests/kuadrant/authorino/dinosaur/test_dinosaur.py
+++ b/testsuite/tests/kuadrant/authorino/dinosaur/test_dinosaur.py
@@ -3,8 +3,15 @@ Test for complex AuthConfig
 """
 
 import pytest
+from openshift_client import OpenShiftPythonException
 
-pytestmark = [pytest.mark.authorino]
+pytestmark = [
+    pytest.mark.authorino,
+    pytest.mark.xfail(
+        reason="AuthPolicy max limit - https://github.com/Kuadrant/testsuite/issues/378",
+        raises=OpenShiftPythonException,
+    ),
+]
 
 ERROR_MESSAGE = {
     "kind": "Error",


### PR DESCRIPTION
Mark dinosaur tests as expected fail due to https://github.com/Kuadrant/testsuite/issues/378