### PR TITLE
Configurable issuer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This repository contains end-to-end tests for Kuadrant project. It supports runn
 * Existing ManagedZone, named `aws-mz` (name defined in `control_plane.managedzone`)
 
 ### TLSPolicy tests
-* Existing ClusterIssuer, named `selfsigned-cluster-issuer`
-
+* Existing self-signed ClusterIssuer, named `selfsigned-cluster-issuer` (name defined in `control_plane.clusterissuer`)
+* (Optional) Existing lets-encrypt ClusterIssuer, named `letsencrypt-staging` (name defined in `letsencrypt.clusterissuer`)
 
 ## Configuration
 

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -28,3 +28,6 @@ default:
   default_exposer: "openshift"
   control_plane:
     managedzone: "aws-mz"
+    clusterissuer: "selfsigned-cluster-issuer"
+  letsencrypt:
+    clusterissuer: "letsencrypt-staging"

--- a/testsuite/config/__init__.py
+++ b/testsuite/config/__init__.py
@@ -50,6 +50,8 @@ settings = Dynaconf(
             messages={"condition": "{value} is not valid exposer"},
         ),
         Validator("control_plane.managedzone", must_exist=True, ne=None),
+        Validator("control_plane.clusterissuer", must_exist=True, ne=None),
+        Validator("letsencrypt.clusterissuer", must_exist=True, ne=None),
         DefaultValueValidator("rhsso.url", default=fetch_route("no-ssl-sso")),
         DefaultValueValidator("rhsso.password", default=fetch_secret("credential-sso", "ADMIN_PASSWORD")),
         DefaultValueValidator("mockserver.url", default=fetch_route("mockserver", force_http=True)),

--- a/testsuite/tests/kuadrant/gateway/conftest.py
+++ b/testsuite/tests/kuadrant/gateway/conftest.py
@@ -44,12 +44,12 @@ def exposer(request, hub_openshift) -> Exposer:
 
 
 @pytest.fixture(scope="session")
-def cluster_issuer():
+def cluster_issuer(testconfig):
     """Reference to cluster self-signed certificate issuer"""
     return CustomReference(
         group="cert-manager.io",
         kind="ClusterIssuer",
-        name="selfsigned-cluster-issuer",
+        name=testconfig["control_plane"]["clusterissuer"],
     )
 
 

--- a/testsuite/tests/kuadrant/gateway/test_external_ca.py
+++ b/testsuite/tests/kuadrant/gateway/test_external_ca.py
@@ -44,16 +44,18 @@ pytestmark = [pytest.mark.kuadrant_only]
 
 
 @pytest.fixture(scope="module")
-def cluster_issuer(hub_openshift):
+def cluster_issuer(testconfig, hub_openshift):
     """Reference to cluster Let's Encrypt certificate issuer"""
+    testconfig.validators.validate(only="letsencrypt")
+    name = testconfig["letsencrypt"]["clusterissuer"]
     try:
-        selector("clusterissuer/letsencrypt-staging", static_context=hub_openshift.context).object()
+        selector(f"clusterissuer/{name}", static_context=hub_openshift.context).object()
     except OpenShiftPythonException as exc:
-        pytest.skip(f"letsencrypt-staging ClusterIssuer is not present on the cluster: {exc}")
+        pytest.skip(f"{name} ClusterIssuer is not present on the cluster: {exc}")
     return CustomReference(
         group="cert-manager.io",
         kind="ClusterIssuer",
-        name="letsencrypt-staging",
+        name=name,
     )
 
 


### PR DESCRIPTION
* Add configuration options for ClusterIssuer names used in tests
   * One option for selfsigned and one option for letsencrypt one
   
* Depends on #385 