### PR TITLE
Setup default name and surname for keycloak user

### DIFF
--- a/testsuite/oidc/rhsso/objects.py
+++ b/testsuite/oidc/rhsso/objects.py
@@ -34,6 +34,8 @@ class Realm:
         """Creates new user"""
         kwargs["username"] = username
         kwargs["enabled"] = True
+        kwargs.setdefault("firstName", "John")
+        kwargs.setdefault("lastName", "Doe")
         kwargs.setdefault("email", f"{username}@anything.invalid")
         self.admin.create_user(kwargs)
         user_id = self.admin.get_user_id(username)


### PR DESCRIPTION
Newer Keycloak versions require that name and surname are setup on a new user account for it to be verified and accessible