### PR TITLE
Add make clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,5 +99,27 @@ reportportal: polish-junit
 help: ## Print this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
+CR_NAMES = "$\
+Gateway,$\
+HTTPRoute,$\
+Deployment,$\
+Service,$\
+Route,$\
+ServiceAccount,$\
+Secret,$\
+AuthConfig,$\
+AuthPolicy,$\
+RateLimitPolicy,$\
+DNSPolicy,$\
+TLSPolicy,$\
+Authorino,$\
+WasmPlugin"
+
+clean: ## Clean all objects in Openshift created by running this testsuite
+	test -n "$(USER)"  # exit if $$USER is empty
+	oc get --chunk-size=0 -n kuadrant -o name $(CR_NAMES) \
+	| grep "$(USER)" \
+	| xargs --no-run-if-empty -P 20 -n 1 oc delete --ignore-not-found -n kuadrant
+
 # this ensures dependent target is run everytime
 FORCE:


### PR DESCRIPTION
This make target will clean objects from Openshift cluster created by current user or additionally any other user when specified like so: 
```
USER=<name> make clean
```
Testsuite by default cleans up these objects but if test ends in error it is common some objects will not be removed.
This make target will make it easy to clean such left-overs while developing tests.

Please comment if I forgot some CR categories!

Note:
Yes the construction `$\` followed by new-line is [official](https://www.gnu.org/software/make/manual/html_node/Splitting-Lines.html) way to split string to multiple lines...