### PR TITLE
Ignore useless-return

### DIFF
--- a/testsuite/config/exposer.py
+++ b/testsuite/config/exposer.py
@@ -11,4 +11,4 @@ def load(obj, env=None, silent=True, key=None, filename=None):
     try:
         obj["default_exposer"] = EXPOSERS[obj["default_exposer"]]
     except KeyError:
-        return
+        pass


### PR DESCRIPTION
Not sure if there is better way to handle this specific case, and I am not sure if this is a bug with pylint.

Introduced in pylint 3.2.0