### PR TITLE
Fix failing dinosaur test on Keycloak 24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ authorino: poetry-no-dev
 
 authorino-standalone: ## Run only test capable of running with standalone Authorino
 authorino-standalone: poetry-no-dev
-	$(PYTEST) -n4 -m 'authorino and not kuadrant_only' --runxfail --dist loadfile --enforce --standalone $(flags) testsuite/tests/kuadrant/authorino
+	$(PYTEST) -n4 -m 'authorino and not kuadrant_only' --dist loadfile --enforce --standalone $(flags) testsuite/tests/kuadrant/authorino
 
 limitador: ## Run only Limitador related tests
 limitador: poetry-no-dev

--- a/testsuite/tests/kuadrant/authorino/dinosaur/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/dinosaur/conftest.py
@@ -231,30 +231,31 @@ allow { method == "DELETE"; roles[_] == "admin-full" }
 @pytest.fixture(scope="module")
 def user_with_valid_org_id(keycloak, blame):
     """
-    Creates new user with valid middle name.
-    Middle name is mapped to org ID in auth config.
+    Creates new user with valid last name.
+    last name is mapped to org ID in auth config.
     """
-    user = keycloak.realm.create_user(blame("someuser"), blame("password"))
-    user.assign_attribute({"middleName": "123"})
+    user = keycloak.realm.create_user(blame("someuser"), blame("password"), lastName="123")
     return HttpxOidcClientAuth.from_user(keycloak.get_token, user=user)
 
 
-@pytest.fixture(scope="module", params=["321", None])
-def user_with_invalid_org_id(keycloak, blame, request):
+# https://github.com/Kuadrant/testsuite/issues/396
+# @pytest.fixture(scope="module", params=["321", None])
+@pytest.fixture(scope="module")
+def user_with_invalid_org_id(keycloak, blame):
     """
-    Creates new user with valid middle name.
-    Middle name is mapped to org ID in auth config.
+    Creates new user with valid last name.
+    last name is mapped to org ID in auth config.
     """
-    user = keycloak.realm.create_user(blame("someuser"), blame("password"))
-    user.assign_attribute({"middleName": request.param})
+    user = keycloak.realm.create_user(blame("someuser"), blame("password"), lastName="321")
     return HttpxOidcClientAuth.from_user(keycloak.get_token, user=user)
 
 
 @pytest.fixture(scope="module")
 def user_with_invalid_email(keycloak, blame):
     """Creates new user with invalid email"""
-    user = keycloak.realm.create_user(blame("someuser"), blame("password"), email="denied-test-user1@example.com")
-    user.assign_attribute({"middleName": "123"})
+    user = keycloak.realm.create_user(
+        blame("someuser"), blame("password"), email="denied-test-user1@example.com", lastName="123"
+    )
     return HttpxOidcClientAuth.from_user(keycloak.get_token, user=user)
 
 

--- a/testsuite/tests/kuadrant/authorino/dinosaur/test_dinosaur.py
+++ b/testsuite/tests/kuadrant/authorino/dinosaur/test_dinosaur.py
@@ -3,14 +3,9 @@ Test for complex AuthConfig
 """
 
 import pytest
-from openshift_client import OpenShiftPythonException
 
 pytestmark = [
     pytest.mark.authorino,
-    pytest.mark.xfail(
-        reason="AuthPolicy max limit",
-        raises=OpenShiftPythonException,
-    ),
     pytest.mark.issue("https://github.com/Kuadrant/kuadrant-operator/issues/566"),
 ]
 


### PR DESCRIPTION
* You cannot add custom attributes like we did before, you need to register them first. This is temporary fix that removes one test-case until #396 is done
* Fix xfail