### PR TITLE
Refactor clusterissuer to issuer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This repository contains end-to-end tests for Kuadrant project. It supports runn
 * Existing ManagedZone, named `aws-mz` (name defined in `control_plane.managedzone`)
 
 ### TLSPolicy tests
-* Existing self-signed ClusterIssuer, named `selfsigned-cluster-issuer` (name defined in `control_plane.clusterissuer`)
-* (Optional) Existing lets-encrypt ClusterIssuer, named `letsencrypt-staging` (name defined in `letsencrypt.clusterissuer`)
+* Existing self-signed ClusterIssuer or Issuer, named `selfsigned-issuer` (name defined in `control_plane.issuer.name`)
+* (Optional) Existing lets-encrypt ClusterIssuer or Issuer, named `letsencrypt-staging-issuer` (name defined in `letsencrypt.issuer.name`)
 
 ## Configuration
 

--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -46,3 +46,10 @@
 #  default_exposer: "openshift"                    # Exposer type that should be used, options: 'openshift'
 #  control_plane:
 #    managedzone: aws-mz                           # Name of the ManagedZone resource
+#    issuer:                                       # Issuer object for testing TLSPolicy
+#      name: "selfsigned-cluster-issuer"           # Name of Issuer CR
+#      kind: "ClusterIssuer"                       # Kind of Issuer, can be "Issuer" or "ClusterIssuer"
+#  letsencrypt:
+#    issuer:                                       # Issuer object for testing TLSPolicy
+#      name: "letsencrypt-staging-issuer"          # Name of Issuer CR
+#      kind: "Issuer"                              # Kind of Issuer, can be "Issuer" or "ClusterIssuer"

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -27,6 +27,10 @@ default:
   default_exposer: "openshift"
   control_plane:
     managedzone: "aws-mz"
-    clusterissuer: "selfsigned-cluster-issuer"
+    issuer:
+      name: "selfsigned-issuer"
+      kind: "ClusterIssuer"
   letsencrypt:
-    clusterissuer: "letsencrypt-staging"
+    issuer:
+      name: "letsencrypt-staging-issuer"
+      kind: "Issuer"

--- a/testsuite/config/__init__.py
+++ b/testsuite/config/__init__.py
@@ -50,8 +50,14 @@ settings = Dynaconf(
             messages={"condition": "{value} is not valid exposer"},
         ),
         Validator("control_plane.managedzone", must_exist=True, ne=None),
-        Validator("control_plane.clusterissuer", must_exist=True, ne=None),
-        Validator("letsencrypt.clusterissuer", must_exist=True, ne=None),
+        (
+            Validator("control_plane.issuer.name", must_exist=True, ne=None)
+            & Validator("control_plane.issuer.kind", must_exist=True, is_in={"Issuer", "ClusterIssuer"})
+        ),
+        (
+            Validator("letsencrypt.issuer.name", must_exist=True, ne=None)
+            & Validator("letsencrypt.issuer.kind", must_exist=True, is_in={"Issuer", "ClusterIssuer"})
+        ),
         DefaultValueValidator("keycloak.url", default=fetch_service_ip("keycloak", force_http=True, port=8080)),
         DefaultValueValidator("keycloak.password", default=fetch_secret("credential-sso", "ADMIN_PASSWORD")),
         DefaultValueValidator("mockserver.url", default=fetch_service_ip("mockserver", force_http=True, port=1080)),

--- a/testsuite/tests/kuadrant/gateway/conftest.py
+++ b/testsuite/tests/kuadrant/gateway/conftest.py
@@ -48,8 +48,8 @@ def cluster_issuer(testconfig):
     """Reference to cluster self-signed certificate issuer"""
     return CustomReference(
         group="cert-manager.io",
-        kind="ClusterIssuer",
-        name=testconfig["control_plane"]["clusterissuer"],
+        kind=testconfig["control_plane"]["issuer"]["kind"],
+        name=testconfig["control_plane"]["issuer"]["name"],
     )
 
 

--- a/testsuite/tests/kuadrant/gateway/test_external_ca.py
+++ b/testsuite/tests/kuadrant/gateway/test_external_ca.py
@@ -1,17 +1,17 @@
 """
 This module contains the most basic happy path test for both DNSPolicy and TLSPolicy
-for a cluster with Let's Encrypt ClusterIssuer
+for a cluster with Let's Encrypt Issuer
 
 Prerequisites:
 * multi-cluster-gateways ns is created and set as openshift["project"]
 * managedclustersetbinding is created in openshift["project"]
 * gateway class "kuadrant-multi-cluster-gateway-instance-per-cluster" is created
 * cert-manager Operator installed
-* Let's Encrypt ClusterIssuer object configured on the cluster matching the template:
+* Let's Encrypt Issuer object configured on the cluster matching the template:
 apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
+kind: ClusterIssuer | Issuer
 metadata:
-  name: letsencrypt-staging
+  name: letsencrypt-staging-issuer
 spec:
   acme:
     email: <email_address>
@@ -47,14 +47,15 @@ pytestmark = [pytest.mark.kuadrant_only]
 def cluster_issuer(testconfig, hub_openshift):
     """Reference to cluster Let's Encrypt certificate issuer"""
     testconfig.validators.validate(only="letsencrypt")
-    name = testconfig["letsencrypt"]["clusterissuer"]
+    name = testconfig["letsencrypt"]["issuer"]["name"]
+    kind = testconfig["letsencrypt"]["issuer"]["kind"]
     try:
-        selector(f"clusterissuer/{name}", static_context=hub_openshift.context).object()
+        selector(f"{kind}/{name}", static_context=hub_openshift.context).object()
     except OpenShiftPythonException as exc:
-        pytest.skip(f"{name} ClusterIssuer is not present on the cluster: {exc}")
+        pytest.skip(f"{name} {kind} is not present on the cluster: {exc}")
     return CustomReference(
         group="cert-manager.io",
-        kind="ClusterIssuer",
+        kind=kind,
         name=name,
     )
 


### PR DESCRIPTION
The Letsecrypt issuer requires a Secret which provides secret for DNS01 verification. If ClusterIssuer object is used, the Secret needs to be stored in the namespace where the CertManager operator is installed. I propose using Issuer object inside the testing namespace which already contains secrets for DNSPolicy testing (the `mgc-aws-credentials` and `mgc-gcp-credentials`) to keep all the secrets in the same namespace. Another reason is to prevent accidental deletion of the secret in case of nightly testing.

This PR also adds entries to settings template file.