### PR TITLE
Use uma_well_known endpoints in Rego Policy

### DIFF
--- a/testsuite/tests/kuadrant/authorino/authorization/opa/test_authorization_services.py
+++ b/testsuite/tests/kuadrant/authorino/authorization/opa/test_authorization_services.py
@@ -19,71 +19,6 @@ from testsuite.policy.authorization import JsonResponse, ValueFrom, Pattern
 pytestmark = [pytest.mark.authorino]
 
 
-# pylint: disable=line-too-long
-@pytest.fixture(scope="module")
-def rego_policy(keycloak):
-    """
-    Complex OPA REGO policy that implements the UMA authorization flow.
-    See https://www.keycloak.org/docs/latest/authorization_services/index.html#_service_uma_authorization_process
-    In short, in the end the RPT (Requesting Party Token, type of JWT with permissions encoded) is obtained.
-    If the permissions retrieved from RPT allow you to access the desired protected resource (resource ids must match)
-    under the used scope (HTTP GET) this REGO policy authorizes the request.
-    """
-    return f"""\
-pat := http.send({{"url":"{keycloak.server_url}realms/{keycloak.realm.name}/protocol/openid-connect/token",\
-"method": "post","headers":{{"Content-Type":"application/x-www-form-urlencoded"}},\
-"raw_body":"grant_type=client_credentials&client_id={keycloak.client_name}&client_secret={keycloak.client.secret}"}})\
-.body.access_token
-
-resource_id := http.send({{"url":concat("",["{keycloak.server_url}realms/{keycloak.realm.name}/authz/protection/\
-resource_set?uri=",input.context.request.http.path]),"method":"get", "headers":\
-{{"Authorization":concat(" ",["Bearer ",pat])}}}}).body[0]
-
-scope := lower(input.context.request.http.method)
-access_token := trim_prefix(input.context.request.http.headers.authorization, "Bearer ")
-default rpt = ""
-rpt = access_token {{ object.get(input.auth.identity, "authorization", {{}}).permissions }}
-else = rpt_str {{
-
-  ticket := http.send({{"url":"{keycloak.server_url}realms/{keycloak.realm.name}/authz/protection/permission",\
-"method":"post","headers":{{"Authorization":concat(" ",["Bearer ",pat]),"Content-Type":"application/json"}},\
-"raw_body":concat("",["[{{\\"resource_id\\":\\"",resource_id,"\\",\\"resource_scopes\\":[\\"",scope,"\\"]}}]"\
-])}}).body.ticket
-
-  rpt_str := object.get(http.send({{"url":"{keycloak.server_url}realms/{keycloak.realm.name}/protocol/openid-connect/token",\
-"method":"post","headers":{{"Authorization":concat(" ",\
-["Bearer ",access_token]),"Content-Type":"application/x-www-form-urlencoded"}},"raw_body":concat("",\
-["grant_type=urn:ietf:params:oauth:grant-type:uma-ticket&ticket=",ticket,"&submit_request=true"])}})\
-.body, "access_token", "")
-}}
-allow {{
-  permissions := object.get(io.jwt.decode(rpt)[1], "authorization", {{ "permissions": [] }}).permissions
-  permissions[i]
-  permissions[i].rsid = resource_id
-  permissions[i].scopes[_] = scope
-}}
-"""
-
-
-@pytest.fixture(scope="module")
-def authorization(authorization, rego_policy):
-    """
-    Adds OPA REGO policy that implements the UMA Authorization flow.
-    Also adds RPT to success header if the request was authorized using standard JWT (no permissions encoded in JWT)
-    so that the RPT can be used for subsequent requests.
-
-    allValues set to 'true' so that values of all rules declared in the Rego policy - including value in rpt variable -
-    are returned after policy evaluation so that the value from rpt variable can be added to the success header.
-    """
-    authorization.authorization.add_opa_policy("opa", rego_policy, all_values=True)
-    authorization.responses.add_success_header(
-        "x-keycloak",
-        JsonResponse({"rpt": ValueFrom("auth.authorization.opa.rpt")}),
-        when=[Pattern("auth.identity.authorization.permissions", "eq", "")],
-    )
-    return authorization
-
-
 @pytest.fixture(scope="module")
 def resource_owner_auth(keycloak):
     """
@@ -115,6 +50,69 @@ def owner_uma(keycloak, resource_owner_auth):
         realm_name=keycloak.realm_name,
     )
     return KeycloakUMA(keycloak_connection)
+
+
+@pytest.fixture(scope="module")
+def rego_policy(owner_uma):
+    """
+    Complex OPA REGO policy that implements the UMA authorization flow.
+    See https://www.keycloak.org/docs/latest/authorization_services/index.html#_service_uma_authorization_process
+    In short, in the end the RPT (Requesting Party Token, type of JWT with permissions encoded) is obtained.
+    If the permissions retrieved from RPT allow you to access the desired protected resource (resource ids must match)
+    under the used scope (HTTP GET) this REGO policy authorizes the request.
+    """
+    return f"""\
+pat := http.send({{"url": "{owner_uma.uma_well_known["token_endpoint"]}",\
+"method": "post","headers":{{"Content-Type":"application/x-www-form-urlencoded"}},\
+"raw_body":"grant_type=client_credentials&client_id={owner_uma.connection.client_id}\
+&client_secret={owner_uma.connection.client_secret_key}"}}).body.access_token
+
+resource_id := http.send({{"url":concat("",["{owner_uma.uma_well_known["resource_registration_endpoint"]}?uri=",\
+input.context.request.http.path]),"method":"get", "headers":{{"Authorization":concat(" ",["Bearer ",pat])}}}}).body[0]
+
+scope := lower(input.context.request.http.method)
+access_token := trim_prefix(input.context.request.http.headers.authorization, "Bearer ")
+default rpt = ""
+rpt = access_token {{ object.get(input.auth.identity, "authorization", {{}}).permissions }}
+else = rpt_str {{
+
+  ticket := http.send({{"url":"{owner_uma.uma_well_known["permission_endpoint"]}",\
+"method":"post","headers":{{"Authorization":concat(" ",["Bearer ",pat]),"Content-Type":"application/json"}},\
+"raw_body":concat("",["[{{\\"resource_id\\":\\"",resource_id,"\\",\\"resource_scopes\\":[\\"",scope,"\\"]}}]"\
+])}}).body.ticket
+
+  rpt_str := object.get(http.send({{"url":"{owner_uma.uma_well_known["token_endpoint"]}",\
+"method":"post","headers":{{"Authorization":concat(" ",\
+["Bearer ",access_token]),"Content-Type":"application/x-www-form-urlencoded"}},"raw_body":concat("",\
+["grant_type=urn:ietf:params:oauth:grant-type:uma-ticket&ticket=",ticket,"&submit_request=true"])}})\
+.body, "access_token", "")
+}}
+allow {{
+  permissions := object.get(io.jwt.decode(rpt)[1], "authorization", {{ "permissions": [] }}).permissions
+  permissions[i]
+  permissions[i].rsid = resource_id
+  permissions[i].scopes[_] = scope
+}}
+"""
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization, rego_policy):
+    """
+    Adds OPA REGO policy that implements the UMA Authorization flow.
+    Also adds RPT to success header if the request was authorized using standard JWT (no permissions encoded in JWT)
+    so that the RPT can be used for subsequent requests.
+
+    allValues set to 'true' so that values of all rules declared in the Rego policy - including value in rpt variable -
+    are returned after policy evaluation so that the value from rpt variable can be added to the success header.
+    """
+    authorization.authorization.add_opa_policy("opa", rego_policy, all_values=True)
+    authorization.responses.add_success_header(
+        "x-keycloak",
+        JsonResponse({"rpt": ValueFrom("auth.authorization.opa.rpt")}),
+        when=[Pattern("auth.identity.authorization.permissions", "eq", "")],
+    )
+    return authorization
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Overview
This is a further improvement of https://github.com/Kuadrant/testsuite/pull/412

Instead of having several endpoints hard-coded the well known endpoints are used.

## What was done
All the hard-coded endpoints replaced with endpoints from `uma_well_known`
Client ID and secret got differently so that `rego_policy` fixture is not dependent on `keycloak` fixture directly
The `rego_policy` and `authorization` fixtures moved a bit down after `owner_uma` fixture since these two now defends on `owner_uma`.
Removal of `# pylint: disable=line-too-long`

## Verification Steps
Eye review, run the test to see that it passes