### PR TITLE
Rework Prometheus

### DIFF
--- a/testsuite/openshift/metrics/service_monitor.py
+++ b/testsuite/openshift/metrics/service_monitor.py
@@ -14,6 +14,7 @@ class MetricsEndpoint:
 
     path: str = "/metrics"
     port: str = "http"
+    interval: str = "30s"
 
 
 class ServiceMonitor(OpenShiftObject):

--- a/testsuite/tests/kuadrant/authorino/metrics/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/metrics/conftest.py
@@ -70,7 +70,8 @@ def service_monitor(openshift, prometheus, blame, module_label):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def commit(commit, request, service_monitor):  # pylint: disable=unused-argument
+def commit(commit, prometheus, request, service_monitor):  # pylint: disable=unused-argument
     """Commit service monitor object"""
     request.addfinalizer(service_monitor.delete)
     service_monitor.commit()
+    assert prometheus.is_reconciled(service_monitor), "Service Monitor didn't get reconciled in time"

--- a/testsuite/tests/kuadrant/authorino/metrics/test_deep_metrics.py
+++ b/testsuite/tests/kuadrant/authorino/metrics/test_deep_metrics.py
@@ -34,12 +34,12 @@ def authorization(authorization, mockserver_expectation):
 
 
 @pytest.fixture(scope="module")
-def deep_metrics(authorino, prometheus, client, auth):
+def deep_metrics(authorino, service_monitor, prometheus, client, auth):
     """Send a simple get request so that a few metrics can appear and return all scraped evaluator(deep) metrics"""
     response = client.get("/get", auth=auth)
     assert response.status_code == 200
 
-    prometheus.wait_for_scrape(authorino.metrics_service.name(), "/server-metrics")
+    prometheus.wait_for_scrape(service_monitor, "/server-metrics")
 
     return prometheus.get_metrics("auth_server_evaluator_total", labels={"service": authorino.metrics_service.name()})
 

--- a/testsuite/tests/kuadrant/authorino/metrics/test_metrics.py
+++ b/testsuite/tests/kuadrant/authorino/metrics/test_metrics.py
@@ -39,7 +39,7 @@ SERVER_METRICS_HISTOGRAM = [
 
 
 @pytest.fixture(scope="module")
-def metrics_keys(authorino, prometheus, client, auth):
+def metrics_keys(authorino, service_monitor, prometheus, client, auth):
     """
     Send a simple get request so that a few metrics can appear and
     return all metrics defined for the Authorino metrics service
@@ -47,8 +47,8 @@ def metrics_keys(authorino, prometheus, client, auth):
     response = client.get("/get", auth=auth)
     assert response.status_code == 200
 
-    prometheus.wait_for_scrape(authorino.metrics_service.name(), "/metrics")
-    prometheus.wait_for_scrape(authorino.metrics_service.name(), "/server-metrics")
+    prometheus.wait_for_scrape(service_monitor, "/metrics")
+    prometheus.wait_for_scrape(service_monitor, "/server-metrics")
 
     return prometheus.get_metrics(labels={"service": authorino.metrics_service.name()}).names
 


### PR DESCRIPTION
- Separate wait for reconciliation
   - Increase timeout to 350 second 
- Make Prometheus a Lifecycle object
   - Move client stuff to commit  
- Add default Interval for MetricsEndpoint
   - To better aim new wait_for_scrape backoff 
- Use ServiceMonitor as base for methods instead of `service_url`
   - I found it more natural as that is the actual metric definition 