### PR TITLE
Add support methods for CR objects

### DIFF
--- a/testsuite/openshift/authorino.py
+++ b/testsuite/openshift/authorino.py
@@ -1,14 +1,14 @@
 """Authorino CR object"""
 
 import abc
-from typing import Any, Optional, Dict, List
 from dataclasses import dataclass
+from typing import Any, Optional, Dict, List
 
 from openshift_client import selector, timeout
 
-from testsuite.openshift.client import OpenShiftClient
-from testsuite.openshift import OpenShiftObject
 from testsuite.lifecycle import LifecycleObject
+from testsuite.openshift import CustomResource
+from testsuite.openshift.client import OpenShiftClient
 from testsuite.utils import asdict
 
 
@@ -44,7 +44,7 @@ class Authorino(LifecycleObject):
         """Authorino oidc url"""
 
 
-class AuthorinoCR(OpenShiftObject, Authorino):
+class AuthorinoCR(CustomResource, Authorino):
     """Represents Authorino CR objects from Authorino-operator"""
 
     @classmethod

--- a/testsuite/openshift/kuadrant.py
+++ b/testsuite/openshift/kuadrant.py
@@ -1,29 +1,69 @@
 """Kuadrant CR object"""
 
-from openshift_client import selector
+import dataclasses
 
-from testsuite.openshift import OpenShiftObject, modify
+from openshift_client import selector, timeout
+
+from testsuite.openshift import CustomResource
 from testsuite.openshift.deployment import Deployment
+from testsuite.utils import asdict
 
 
-class KuadrantCR(OpenShiftObject):
+class KuadrantSection:
+    """
+    Base class for Kuadrant sub components:
+        Authorino - spec.authorino
+        Limitador - spec.limitador
+    """
+
+    def __init__(self, kuadrant_cr, spec_name):
+        super().__init__()
+        self.kuadrant_cr = kuadrant_cr
+        self.spec_name = spec_name
+
+    def __getitem__(self, name):
+        return self.kuadrant_cr.model.spec[self.spec_name][name]
+
+    def __setitem__(self, name, value):
+        if dataclasses.is_dataclass(value):
+            self.kuadrant_cr.model.spec[self.spec_name][name] = asdict(value)
+        else:
+            self.kuadrant_cr.model.spec[self.spec_name][name] = value
+
+    def __getattr__(self, item):
+        try:
+            return getattr(self.kuadrant_cr, item)
+        except AttributeError as exc:
+            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{item}'") from exc
+
+
+class KuadrantCR(CustomResource):
     """Represents Kuadrant CR objects"""
 
     LIMITADOR = "limitador-limitador"
 
     @property
-    def limitador(self) -> dict:
-        """Returns spec.limitador from Kuadrant object"""
-        return self.model.spec.setdefault("limitador", {})
+    def authorino(self) -> KuadrantSection:
+        """Returns spec.authorino from Kuadrant object"""
+        return KuadrantSection(self, "authorino")
 
-    @limitador.setter
-    @modify
-    def limitador(self, value: dict):
-        """Sets the value of spec.limitador"""
-        self.model.spec["limitador"] = value
+    @property
+    def limitador(self) -> KuadrantSection:
+        """Returns spec.limitador from Kuadrant object"""
+        return KuadrantSection(self, "limitador")
 
     @property
     def limitador_deployment(self):
         """Returns Deployment object for this Authorino"""
         with self.context:
             return selector(f"deployment/{self.LIMITADOR}").object(cls=Deployment)
+
+    def wait_for_ready(self):
+        """Waits until Kuadrant CR reports ready status"""
+        with timeout(90):
+            success, _, _ = self.self_selector().until_all(
+                success_func=lambda obj: len(obj.model.status.conditions) > 0
+                and all(x.status == "True" for x in obj.model.status.conditions)
+            )
+            assert success, "Kuadrant did got get ready in time"
+            self.refresh()


### PR DESCRIPTION
This PR adds dunder `__getitem__` and `__setitem__` methods for CR objects. Also Implements authorino-like and limitador-like objects for Kuadrant CR to enable similar manipulation with Limitador and sub-component Limitador from Kuadrant CR.
I had to remove `from testsuite.config import settings` from utils because of cyclical import.