### PR TITLE
Cleanup of Keycloak Realms created for tests

### DIFF
--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -164,7 +164,7 @@ def keycloak(request, testconfig, blame, skip_or_fail):
             cnf["test_user"]["username"],
             cnf["test_user"]["password"],
         )
-
+        request.addfinalizer(info.delete)
         info.commit()
         return info
     except KeycloakAuthenticationError:

--- a/testsuite/tests/kuadrant/authorino/dinosaur/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/dinosaur/conftest.py
@@ -26,7 +26,10 @@ def admin_rhsso(blame, keycloak):
     )
 
     info.commit()
-    return info
+    yield info
+
+    # Realm cleanup
+    info.delete()
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
### Overview

This seems to delete Keycloak Realms once the tests are over.

### Verification Steps

Eye review if it makes sense.
Run single test and verify there is no Keycloak Realm created by the test run there once the test is over. Try  `./kuadrant/authorino/dinosaur` test for instance as this one creates one additional (`admin`) Realm.

Run the whole test suite (`make kuadrant`) and verify that there is no Keycloak Realm created by the testsuite run present once the testsuite execution is over. For a quicker validation you can mark a few tests as "keycloak":
`pytestmark = [pytest.mark.authorino, pytest.mark.keycloak]`

Make sure that the marked tests use Keycloak and be sure to mark the `./kuadrant/authorino/dinosaur` test.

Then create a "keycloak" make target in Makefile:
```
keycloak: ## Run only keycloak related tests
keycloak: poetry-no-dev
	$(PYTEST) -n4 -m 'keycloak' --dist loadfile --enforce $(flags) testsuite
```

Then execute `make keycloak` and verify that there are no leftover Keycloak Realms present once the tests execution is over.