### PR TITLE
Improve wait_for_ready timeout errors

### DIFF
--- a/testsuite/gateway/gateway_api/gateway.py
+++ b/testsuite/gateway/gateway_api/gateway.py
@@ -76,12 +76,9 @@ class KuadrantGateway(OpenShiftObject, Gateway):
 
     def wait_for_ready(self, timeout: int = 10 * 60):
         """Waits for the gateway to be ready in the sense of is_ready(self)"""
-        with oc.timeout(timeout):
-            success, _, _ = self.self_selector().until_all(
-                success_func=lambda obj: self.__class__(obj.model).is_ready()
-            )
-            assert success, "Gateway didn't get ready in time"
-            self.refresh()
+        success = self.wait_until(lambda obj: self.__class__(obj.model).is_ready(), timelimit=timeout)
+        assert success, "Gateway didn't get ready in time"
+        self.refresh()
 
     def is_affected_by(self, policy: Policy) -> bool:
         """Returns True, if affected by status is found within the object for the specific policy"""

--- a/testsuite/openshift/deployment.py
+++ b/testsuite/openshift/deployment.py
@@ -3,8 +3,6 @@
 from dataclasses import dataclass
 from typing import Any, Optional
 
-import openshift_client as oc
-
 from testsuite.openshift import OpenShiftObject, Selector, modify
 from testsuite.utils import asdict
 
@@ -148,9 +146,8 @@ class Deployment(OpenShiftObject):
 
     def wait_for_ready(self, timeout=90):
         """Waits until Deployment is marked as ready"""
-        with oc.timeout(timeout):
-            success, _, _ = self.self_selector().until_all(success_func=lambda obj: "readyReplicas" in obj.model.status)
-            assert success, f"Deployment {self.name()} did not get ready in time"
+        success = self.wait_until(lambda obj: "readyReplicas" in obj.model.status, timelimit=timeout)
+        assert success, f"Deployment {self.name()} did not get ready in time"
 
     @property
     def template(self):

--- a/testsuite/openshift/ingress.py
+++ b/testsuite/openshift/ingress.py
@@ -66,14 +66,12 @@ class Ingress(OpenShiftObject):
         """Returns rules defined in the ingress"""
         return self.model.spec.rules
 
-    def wait_for_hosts(self, tolerate_failures: int = 5):
+    def wait_for_hosts(self):
         """Waits until all rules within the ingress have host fields filled"""
 
         def _all_rules_have_host(obj):
             return all("host" in r and len(r.get("host")) > 0 for r in obj.model.spec.rules)
 
-        success, _, _ = self.self_selector().until_all(
-            success_func=_all_rules_have_host, tolerate_failures=tolerate_failures
-        )
+        success = self.wait_until(_all_rules_have_host)
 
         return success

--- a/testsuite/policy/__init__.py
+++ b/testsuite/policy/__init__.py
@@ -1,7 +1,5 @@
 """Contains Base class for policies"""
 
-import openshift_client as oc
-
 from testsuite.openshift import OpenShiftObject
 from testsuite.utils import has_condition
 
@@ -11,9 +9,5 @@ class Policy(OpenShiftObject):
 
     def wait_for_ready(self):
         """Wait for a Policy to be Enforced"""
-        with oc.timeout(90):
-            success, _, _ = self.self_selector().until_all(
-                success_func=has_condition("Enforced", "True"),
-                tolerate_failures=5,
-            )
-            assert success, f"{self.kind()} did not get ready in time"
+        success = self.wait_until(has_condition("Enforced", "True"))
+        assert success, f"{self.kind()} did not get ready in time"

--- a/testsuite/policy/authorization/auth_config.py
+++ b/testsuite/policy/authorization/auth_config.py
@@ -3,8 +3,6 @@
 from functools import cached_property
 from typing import Dict
 
-import openshift_client as oc
-
 from testsuite.utils import asdict
 from testsuite.openshift import OpenShiftObject, modify
 from testsuite.openshift.client import OpenShiftClient
@@ -76,13 +74,12 @@ class AuthConfig(OpenShiftObject):
 
     def wait_for_ready(self):
         """Waits until authorization object reports ready status"""
-        with oc.timeout(90):
-            success, _, _ = self.self_selector().until_all(
-                success_func=lambda obj: len(obj.model.status.conditions) > 0
-                and all(x.status == "True" for x in obj.model.status.conditions)
-            )
-            assert success, f"{self.kind()} did not get ready in time"
-            self.refresh()
+        success = self.wait_until(
+            lambda obj: len(obj.model.status.conditions) > 0
+            and all(x.status == "True" for x in obj.model.status.conditions)
+        )
+        assert success, f"{self.kind()} did not get ready in time"
+        self.refresh()
 
     @modify
     def add_rule(self, when: list[Rule]):

--- a/testsuite/policy/rate_limit_policy.py
+++ b/testsuite/policy/rate_limit_policy.py
@@ -4,14 +4,12 @@ import time
 from dataclasses import dataclass
 from typing import Iterable, Literal, Optional, List
 
-from openshift_client import timeout
-
 from testsuite.gateway import Referencable, RouteMatch
 from testsuite.openshift import modify
 from testsuite.openshift.client import OpenShiftClient
 from testsuite.policy import Policy
 from testsuite.policy.authorization import Rule
-from testsuite.utils import asdict, has_condition
+from testsuite.utils import asdict
 
 
 @dataclass
@@ -81,11 +79,6 @@ class RateLimitPolicy(Policy):
 
     def wait_for_ready(self):
         """Wait for RLP to be enforced"""
-        with timeout(90):
-            success, _, _ = self.self_selector().until_all(
-                success_func=has_condition("Enforced", "True"),
-                tolerate_failures=5,
-            )
-            assert success, f"{self.kind()} did not get ready in time"
+        super().wait_for_ready()
         # Even after enforced condition RLP requires a short sleep
         time.sleep(5)

--- a/testsuite/policy/tls_policy.py
+++ b/testsuite/policy/tls_policy.py
@@ -1,7 +1,5 @@
 """Module for TLSPolicy related classes"""
 
-import openshift_client as oc
-
 from testsuite.gateway import Referencable
 from testsuite.openshift.client import OpenShiftClient
 from testsuite.policy import Policy
@@ -55,9 +53,5 @@ class TLSPolicy(Policy):
     def wait_for_ready(self):
         """TLSPolicy does not have Enforced
         https://github.com/Kuadrant/kuadrant-operator/issues/572"""
-        with oc.timeout(90):
-            success, _, _ = self.self_selector().until_all(
-                success_func=has_condition("Accepted", "True"),
-                tolerate_failures=5,
-            )
-            assert success, f"{self.kind()} did not get ready in time"
+        success = self.wait_until(has_condition("Accepted", "True"))
+        assert success, f"{self.kind()} did not get ready in time"


### PR DESCRIPTION
- Timeouts now return human readable message instead of an error for timeout
  - Any other errors will be propagated as usual 
- Use wait_until instead of until_all()
- Lower default timeout from 90sec to 60sec
   - Everything passed on my machine, we can see if it works (or I can delete it based on review)