### PR TITLE
Use kubectl instead of oc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ Bind a dir to /test-run-results to get reports "
 RUN useradd --no-log-init -u 1001 -g root -m testsuite
 RUN dnf install -y python3.11 python3.11-pip make git && dnf clean all
 
-RUN curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz >/tmp/oc.tgz && \
-	tar xzf /tmp/oc.tgz -C /usr/local/bin && \
-	rm /tmp/oc.tgz
+RUN curl -LO "https://dl.k8s.io/release/v1.30.2/bin/linux/amd64/kubectl" && \
+    mv kubectl /usr/local/bin &&\
+    chmod +x /usr/local/bin/kubectl
 
 RUN curl -L https://github.com/cloudflare/cfssl/releases/download/v1.6.4/cfssl_1.6.4_linux_amd64 >/usr/bin/cfssl && \
     chmod +x /usr/bin/cfssl

--- a/testsuite/__init__.py
+++ b/testsuite/__init__.py
@@ -1,0 +1,8 @@
+"""Monkeypatching land"""
+
+import os
+
+from openshift_client import context
+
+# Default to kubectl instead of oc binary
+context.default_oc_path = os.getenv("OPENSHIFT_CLIENT_PYTHON_DEFAULT_OC_PATH", "kubectl")


### PR DESCRIPTION
* Replaces `oc` binary with `kubectl`
   * This is not configurable because it needs to be resolved before configuration is parsed
* Replace whoami command with kubeconfig introspection
* Replace binary in testsuite image   