### PR TITLE
Add Kubernetes exposer

### DIFF
--- a/testsuite/config/exposer.py
+++ b/testsuite/config/exposer.py
@@ -1,8 +1,8 @@
 """Translates string to an Exposer class that can initialized"""
 
-from testsuite.gateway.exposers import OpenShiftExposer, KindExposer
+from testsuite.gateway.exposers import OpenShiftExposer, LoadBalancerServiceExposer
 
-EXPOSERS = {"openshift": OpenShiftExposer, "kind": KindExposer}
+EXPOSERS = {"openshift": OpenShiftExposer, "kind": LoadBalancerServiceExposer}
 
 
 # pylint: disable=unused-argument

--- a/testsuite/config/exposer.py
+++ b/testsuite/config/exposer.py
@@ -2,7 +2,7 @@
 
 from testsuite.gateway.exposers import OpenShiftExposer, LoadBalancerServiceExposer
 
-EXPOSERS = {"openshift": OpenShiftExposer, "kind": LoadBalancerServiceExposer}
+EXPOSERS = {"openshift": OpenShiftExposer, "kind": LoadBalancerServiceExposer, "kubernetes": LoadBalancerServiceExposer}
 
 
 # pylint: disable=unused-argument

--- a/testsuite/gateway/exposers.py
+++ b/testsuite/gateway/exposers.py
@@ -63,8 +63,8 @@ class StaticLocalHostname(Hostname):
         return self._hostname
 
 
-class KindExposer(Exposer):
-    """Exposer using loadbalancer service for Gateway"""
+class LoadBalancerServiceExposer(Exposer):
+    """Exposer using Load Balancer service for Gateway"""
 
     def expose_hostname(self, name, gateway: Gateway) -> Hostname:
         return StaticLocalHostname(

--- a/testsuite/tests/kuadrant/authorino/operator/raw_http/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/raw_http/conftest.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from testsuite.gateway.exposers import KindExposer
+from testsuite.gateway.exposers import LoadBalancerServiceExposer
 from testsuite.policy.authorization import Value, JsonResponse
 from testsuite.httpx import KuadrantClient
 from testsuite.policy.authorization.auth_config import AuthConfig
@@ -29,7 +29,7 @@ def client(authorino_route):
 @pytest.fixture(scope="module")
 def authorino_route(request, exposer, authorino, blame, openshift):
     """Add route for authorino http port to be able to access it."""
-    if isinstance(exposer, KindExposer):
+    if isinstance(exposer, LoadBalancerServiceExposer):
         pytest.skip("raw_http is not available on Kind")
 
     route = OpenshiftRoute.create_instance(

--- a/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/tls/conftest.py
@@ -8,7 +8,7 @@ from testsuite.certificates import Certificate, CertInfo
 from testsuite.openshift import Selector
 from testsuite.gateway import Exposer
 from testsuite.gateway.envoy.tls import TLSEnvoy
-from testsuite.gateway.exposers import KindExposer, OpenShiftExposer
+from testsuite.gateway.exposers import LoadBalancerServiceExposer, OpenShiftExposer
 from testsuite.openshift.secret import TLSSecret
 from testsuite.utils import cert_builder
 
@@ -183,7 +183,7 @@ def gateway(
 @pytest.fixture(scope="module")
 def exposer(request, testconfig, hub_openshift) -> Exposer:
     """Exposer object instance with TLS passthrough"""
-    if testconfig["default_exposer"] == KindExposer:
+    if testconfig["default_exposer"] == LoadBalancerServiceExposer:
         pytest.skip("TLS tests do not work on Kind")
     exposer = OpenShiftExposer(hub_openshift)
     request.addfinalizer(exposer.delete)


### PR DESCRIPTION
Since we are using LoadBalancer services, there is no reason why the previous "Kind" exposer should not work on pure Kubernetes. I tested it with Openshift and it works as well.
