### PR TITLE
Automatic exposer detection

### DIFF
--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -44,7 +44,7 @@
 #      auth_url: ""                                # authorization URL for already deployed Authorino
 #      oidc_url: ""                                # oidc URL for already deployed Authorino
 #      metrics_service_name: ""                    # controller metrics service name for already deployed Authorino
-#  default_exposer: "openshift"                    # Exposer type that should be used, options: 'openshift'
+#  default_exposer: "kubernetes"                   # Force Exposer typem options: 'openshift', 'kind', 'kubernetes'
 #  control_plane:
 #    managedzone: aws-mz                           # Name of the ManagedZone resource
 #    issuer:                                       # Issuer object for testing TLSPolicy

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -24,7 +24,6 @@ default:
   hyperfoil:
     generate_reports: True
     reports_dir: "reports"
-  default_exposer: "openshift"
   control_plane:
     managedzone: "aws-mz"
     issuer:

--- a/testsuite/config/exposer.py
+++ b/testsuite/config/exposer.py
@@ -8,7 +8,11 @@ EXPOSERS = {"openshift": OpenShiftExposer, "kind": LoadBalancerServiceExposer, "
 # pylint: disable=unused-argument
 def load(obj, env=None, silent=True, key=None, filename=None):
     """Selects proper Exposes class"""
-    try:
+    if "default_exposer" not in obj or not obj["default_exposer"]:
+        client = obj["cluster"]
+        if "route.openshift.io/v1" in client.do_action("api-versions").out():
+            obj["default_exposer"] = EXPOSERS["openshift"]
+        else:
+            obj["default_exposer"] = EXPOSERS["kubernetes"]
+    else:
         obj["default_exposer"] = EXPOSERS[obj["default_exposer"]]
-    except KeyError:
-        pass


### PR DESCRIPTION
* Automatic exposer detection
  * No longer need to explicitly state `openshift `or `kind `
  * WIll use OpenShift if routes exist and Kubernetes otherwise

Depends on #448 