### PR TITLE
Remove need to specify committed property

### DIFF
--- a/testsuite/openshift/service.py
+++ b/testsuite/openshift/service.py
@@ -64,5 +64,4 @@ class Service(OpenShiftObject):
         """Deletes Service, introduces bigger waiting times due to LoadBalancer type"""
         with timeout(10 * 60):
             deleted = super(OpenShiftObject, self).delete(ignore_not_found, cmd_args)
-            self.committed = False
             return deleted

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -280,7 +280,6 @@ def kuadrant(request, testconfig):
     try:
         with kuadrant_openshift.context:
             kuadrant = selector("kuadrant").object(cls=KuadrantCR)
-            kuadrant.committed = True
     except OpenShiftPythonException:
         pytest.fail("Running Kuadrant tests, but Kuadrant resource was not found")
 


### PR DESCRIPTION
Advantage: No need to specify committed when fetching object from Kubernetes
Disadvantage: One call to Kubernetes to check if it exists per object (it is cached)

Let me know what you think :)