### PR TITLE
Use CustomReference in test_invalid_issuer_reference.py

### DIFF
--- a/testsuite/tests/kuadrant/gateway/reconciliation/test_invalid_issuer_reference.py
+++ b/testsuite/tests/kuadrant/gateway/reconciliation/test_invalid_issuer_reference.py
@@ -22,7 +22,11 @@ def test_wrong_issuer_type(request, gateway, blame, module_label):
         gateway.openshift,
         blame("resource"),
         gateway,
-        gateway,
+        CustomReference(
+            group="gateway.networking.k8s.io",
+            kind="Gateway",
+            name=gateway.name(),
+        ),
         labels={"app": module_label},
     )
     request.addfinalizer(policy.delete)


### PR DESCRIPTION
`gateway.reference` returns also `namespace`, which is not supported for issuers