### PR TITLE
Fix TLSPolicy timeouts

### DIFF
--- a/testsuite/policy/__init__.py
+++ b/testsuite/policy/__init__.py
@@ -19,9 +19,9 @@ def has_condition(condition_type, status="True", reason=None, message=None):
 class Policy(OpenShiftObject):
     """Base class with common functionality for all policies"""
 
-    def wait_for_ready(self):
+    def wait_for_ready(self, timelimit=60):
         """Wait for a Policy to be Enforced"""
-        success = self.wait_until(has_condition("Enforced", "True"))
+        success = self.wait_until(has_condition("Enforced", "True"), timelimit=timelimit)
         assert success, f"{self.kind()} did not get ready in time"
 
     def wait_for_accepted(self):

--- a/testsuite/policy/rate_limit_policy.py
+++ b/testsuite/policy/rate_limit_policy.py
@@ -77,8 +77,8 @@ class RateLimitPolicy(Policy):
             limit["routeSelectors"] = [asdict(rule) for rule in route_selectors]
         self.model.spec.limits[name] = limit
 
-    def wait_for_ready(self):
+    def wait_for_ready(self, timelimit=60):
         """Wait for RLP to be enforced"""
-        super().wait_for_ready()
+        super().wait_for_ready(timelimit=timelimit)
         # Even after enforced condition RLP requires a short sleep
         time.sleep(5)

--- a/testsuite/policy/tls_policy.py
+++ b/testsuite/policy/tls_policy.py
@@ -48,3 +48,6 @@ class TLSPolicy(Policy):
 
     def __getitem__(self, key):
         return self.model.spec[key]
+
+    def wait_for_ready(self, timelimit=180):
+        super().wait_for_ready(timelimit=timelimit)

--- a/testsuite/tests/kuadrant/gateway/test_external_ca.py
+++ b/testsuite/tests/kuadrant/gateway/test_external_ca.py
@@ -31,7 +31,6 @@ spec:
 """
 
 import dataclasses
-import time
 from importlib import resources
 
 import pytest
@@ -63,7 +62,6 @@ def cluster_issuer(testconfig, hub_openshift):
 @pytest.fixture(scope="module")
 def client(commit, hostname, gateway):  # pylint: disable=unused-argument
     """Returns httpx client to be used for requests, it also commits AuthConfig"""
-    time.sleep(180)  # it takes a bit for the lets encrypt secret to be actually created
     root_cert = resources.files("testsuite.resources").joinpath("letsencrypt-stg-root-x1.pem").read_text()
     old_cert = gateway.get_tls_cert()
     cert = dataclasses.replace(old_cert, chain=old_cert.certificate + root_cert)


### PR DESCRIPTION
Some previous change lowered the TLSPolicy wait timeout resulting in TLSPolicy not getting ready erros, this PR will raise it to 180s which is sufficient even for the Letsecrypt test. 
From my testing when the TLSPolicy is `Enforced: true` additional waits are not needed, thats why I removed the sleep in the client fixture.
I also added parameter for the `wait_for_ready` function to set the timeout/timelimit duration more easily.
