### PR TITLE
Remove preexisting authorino

### DIFF
--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -40,10 +40,6 @@
 #       name: "istio-ingressgateway"
 #    authorino:
 #      image: "quay.io/kuadrant/authorino:latest"  # If specified will override the authorino image
-#      deploy: false                               # If false, the testsuite will use already deployed authorino for testing
-#      auth_url: ""                                # authorization URL for already deployed Authorino
-#      oidc_url: ""                                # oidc URL for already deployed Authorino
-#      metrics_service_name: ""                    # controller metrics service name for already deployed Authorino
 #  default_exposer: "kubernetes"                   # Force Exposer typem options: 'openshift', 'kind', 'kubernetes'
 #  control_plane:
 #    managedzone: aws-mz                           # Name of the ManagedZone resource

--- a/testsuite/tests/kuadrant/authorino/operator/conftest.py
+++ b/testsuite/tests/kuadrant/authorino/operator/conftest.py
@@ -32,18 +32,13 @@ def authorino_parameters():
 def authorino(openshift, blame, request, testconfig, label, authorino_parameters) -> Authorino:
     """Module scoped Authorino instance, with specific parameters"""
     authorino_config = testconfig["service_protection"]["authorino"]
-    if not authorino_config["deploy"]:
-        return pytest.skip("Can't change parameters of already deployed Authorino")
-
-    labels = authorino_parameters.setdefault("label_selectors", [])
-    labels.append(f"testRun={label}")
-
-    authorino_parameters.setdefault("name", blame("authorino"))
 
     authorino = AuthorinoCR.create_instance(
         openshift,
         image=authorino_config.get("image"),
         log_level=authorino_config.get("log_level"),
+        name=blame("authorino"),
+        label_selectors=[f"testRun={label}"],
         **authorino_parameters,
     )
     request.addfinalizer(authorino.delete)


### PR DESCRIPTION
We don't use preexisting authorino (at least, I am unaware of it). I propose to remove unnecessary code for the `authorino/operator` package and the `authorino` fixture.

I would like to add another topic for discussion. `operator/conftest.py` and `authorino/conftest.py` contain the same "copy-pasted" authorino fixtures, only the scope is different. Is there a good solution for this?