### PR TITLE
Add identical hostnames tests for desired behavior

### DIFF
--- a/testsuite/tests/singlecluster/identical_hostnames/test_identical_hostnames_auth_on_gw_and_route_desired.py
+++ b/testsuite/tests/singlecluster/identical_hostnames/test_identical_hostnames_auth_on_gw_and_route_desired.py
@@ -1,0 +1,53 @@
+"""
+Tests desired behavior of using one HTTPRoute declaring the same hostname as parent Gateway related to AuthPolicy.
+https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/auth.md#limitation-multiple-network-resources-with-identical-hostnames
+(see second topology mentioned there). This test should start passing once the policy-2 affects the route-b which is
+considered to be desired behavior.
+"""
+
+import pytest
+
+from testsuite.policy.authorization.auth_policy import AuthPolicy
+
+pytestmark = [pytest.mark.kuadrant_only]
+
+
+@pytest.fixture(scope="class", autouse=True)
+def authorization2(request, gateway, blame, openshift, label):
+    """2nd 'deny-all' Authorization object"""
+    auth_policy = AuthPolicy.create_instance(openshift, blame("authz2"), gateway, labels={"testRun": label})
+    auth_policy.authorization.add_opa_policy("rego", "allow = false")
+    request.addfinalizer(auth_policy.delete)
+    auth_policy.commit()
+    auth_policy.wait_for_ready()
+    return auth_policy
+
+
+@pytest.mark.issue("https://github.com/Kuadrant/kuadrant-operator/issues/431")
+@pytest.mark.xfail(
+    reason="Currently the Gateway-attached Policy is ignored so 200 (OK) is returned instead of 403 (Forbidden)"
+)
+def test_identical_hostnames_auth_on_gw_and_route_enforced(client, authorization):
+    """
+    Tests that Gateway-attached AuthPolicy is successfully enforced on 'route2' even if both 'route' and 'route2'
+    declare identical hostname and there is another AuthPolicy already successfully enforced on 'route'.
+    Setup:
+        - Two HTTPRoutes declaring identical hostnames but different paths: '/anything/route1' and '/anything/route2'
+        - Empty AuthPolicy enforced on the '/anything/route1' HTTPRoute
+        - 'deny-all' AuthPolicy (created after Empty AuthPolicy) enforced on the Gateway
+    Test:
+        - Send a request via 'route' and assert that response status code is 200
+        - Send a request via 'route2' and assert that response status code is 403 (it is expected to fail)
+    """
+
+    # Verify that the Empty AuthPolicy is still enforced despite 'deny-all' AuthPolicy being enforced too now
+    authorization.wait_for_ready()
+
+    # Access via 'route' is allowed due to Empty AuthPolicy
+    response = client.get("/anything/route1/get")
+    assert response.status_code == 200
+
+    # Access via 'route2' should be forbidden due to 'deny-all' Gateway-attached AuthPolicy
+    # However, this is currently expected to fail
+    response = client.get("/anything/route2/get")
+    assert response.status_code == 403

--- a/testsuite/tests/singlecluster/identical_hostnames/test_identical_hostnames_on_routes_desired.py
+++ b/testsuite/tests/singlecluster/identical_hostnames/test_identical_hostnames_on_routes_desired.py
@@ -1,0 +1,93 @@
+"""
+Tests desired behavior of using two HTTPRoutes declaring the same hostname using both AuthPolicy and RateLimitPolicy.
+https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/auth.md#limitation-multiple-network-resources-with-identical-hostnames
+https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/rate-limiting.md#limitation-multiple-network-resources-with-identical-hostnames
+(see the first topology mentioned in both links).
+For AuthPolicy, the test should start passing once the policy-2 is enforced on route-b
+For RateLimitPolicy (RLP) the test should start passing once the policy-1 is effectively enforced on route-a
+"""
+
+import pytest
+
+from testsuite.policy.authorization.auth_policy import AuthPolicy
+from testsuite.policy.rate_limit_policy import Limit, RateLimitPolicy
+
+pytestmark = [pytest.mark.kuadrant_only]
+
+
+@pytest.fixture(scope="class")
+def authorization2(request, route2, blame, openshift, label):
+    """2nd Authorization object"""
+    auth_policy = AuthPolicy.create_instance(openshift, blame("authz2"), route2, labels={"testRun": label})
+    auth_policy.authorization.add_opa_policy("rego", "allow = false")
+    request.addfinalizer(auth_policy.delete)
+    auth_policy.commit()
+    auth_policy.wait_for_accepted()
+    return auth_policy
+
+
+@pytest.fixture(scope="module")
+def rate_limit(rate_limit):
+    """Add limit to 1st RateLimitPolicy allowing 1 request per 10 minutes (a.k.a. '1rp10m' RateLimitPolicy)"""
+    rate_limit.add_limit("1rp10m", [Limit(1, 10)])
+    return rate_limit
+
+
+@pytest.fixture(scope="class", autouse=True)
+def rate_limit2(request, route2, blame, openshift, label):
+    """2nd RateLimitPolicy allowing 2 requests per 10 minutes (a.k.a. '2rp10m' RateLimitPolicy)"""
+    rlp = RateLimitPolicy.create_instance(openshift, blame("2rp10m"), route2, labels={"testRun": label})
+    request.addfinalizer(rlp.delete)
+    rlp.add_limit("2rp10m", [Limit(2, 10)])
+    rlp.commit()
+    rlp.wait_for_ready()
+    return rlp
+
+
+@pytest.mark.issue("https://github.com/Kuadrant/kuadrant-operator/issues/431")
+@pytest.mark.xfail(reason="Currently the 2nd AuthPolicy fails with: AuthScheme is not ready yet, see issue 431, Tier2")
+def test_identical_hostnames_auth_on_routes_enforced(client, authorization2):
+    """
+    Tests that 2nd AuthPolicy is enforced on 'route2' declaring identical hostname as 'route' with another
+    AuthPolicy already successfully enforced on 'route'.
+    Setup:
+        - Two HTTPRoutes declaring identical hostnames but different paths: '/anything/route1' and '/anything/route2'
+        - Empty AuthPolicy enforced on the '/anything/route1' HTTPRoute
+        - 2nd 'deny-all' AuthPolicy (created after Empty AuthPolicy) accepted on the '/anything/route2' HTTPRoute
+    Test:
+        - Assert that 'deny-all' AuthPolicy is enforced (expected to fail)
+    """
+
+    # 2nd 'deny-all' AuthPolicy should be enforced, this is expected to fail currently
+    assert authorization2.wait_for_ready()
+
+    # Access via route2 should be forbidden due to enforced 'deny-all' AuthPolicy, this is expected to fail currently
+    response = client.get("/anything/route2/get")
+    assert response.status_code == 403
+
+
+@pytest.mark.issue("https://github.com/Kuadrant/kuadrant-operator/issues/431")
+@pytest.mark.xfail(reason="2nd RLP wins currently whereas 1st RLP should win to be consistent with AuthPolicy behavior")
+def test_identical_hostnames_rlp_on_routes_1st_wins(client, rate_limit):
+    """
+    Tests that 1st RateLimitPolicy stays enforced on 'route' declaring identical hostname as 'route2' when another
+    RateLimitPolicy gets successfully enforced on 'route2'.
+    Setup:
+        - Two HTTPRoutes declaring identical hostnames but different paths: '/anything/route1' and '/anything/route2'
+        - '1rp10m' RateLimitPolicy enforced on the '/anything/route1' HTTPRoute
+        - '2rp10m' RateLimitPolicy (created after '1rp10m' RateLimitPolicy) enforced on the '/anything/route2' HTTPRoute
+    Test:
+        - Assert that 1st '1rp10m' RateLimitPolicy is enforced
+        - Send a request via 'route' and assert that 429s (Too Many Requests) are returned (this is expected to fail)
+    """
+
+    # Verify that the '1rp10m' RLP is still enforced despite '2rp10m' RLP being enforced too now
+    rate_limit.wait_for_ready()
+
+    # Access via 'route1' is limited by 1st '1rp10m' RLP hence the first request is 200 (OK)
+    response = client.get("/anything/route1/get")
+    assert response.status_code == 200
+
+    # This is currently expected to fail because 1st '1rp10m' RLP is actually not enforced despite its status saying so
+    response = client.get("/anything/route1/get")
+    assert response.status_code == 429


### PR DESCRIPTION
## Overview

Last piece to address https://github.com/Kuadrant/testsuite/issues/406

Follows up on https://github.com/Kuadrant/testsuite/pull/439 and https://github.com/Kuadrant/testsuite/pull/462 which added similar tests for AuthPolicy and  RateLimitPolicy (RLP) respectively, but these tests validating current behavior.

The tests in this PR cover two scenarios, both testing desired behavior. Desired behavior means that Kuadrant does not behave like that yet so the tests are expected to fail. Once they start passing it means that implementation has changed and it would be good to take a closer look how and if that makes sense and update the testsuite accordingly.

### Scenario 1.
Test that 2nd Gateway-attached AuthPolicy is actually enforced on route (currently it states that it is enforced but effectively it is ignored)

### Scenario 2.
Test that 2nd HTTPRoute-attached AuthPolicy is enforced (currently it fails with an error, status being Enforced=False)

### Scenario 3.
Test that the 1st HTTPRoute-attached RLP is effectively enforced (currently it is effectively ignored because the 2nd HTTPRoute-attached RLP "kicks" it off)

## Verification Steps

Run the three tests. Or even better run the whole dir with all the "identical hostname" tests. 4 tests should pass, 3 should be xfailed. It should take roughly 8-9 minutes:

```
$ make testsuite/tests/kuadrant/identical_hostnames/
...
======= 4 passed, 2 xfailed in 473.34s (0:07:53) =======
```

