### PR TITLE
Remove verify=false from Keycloak

### DIFF
--- a/testsuite/oidc/keycloak/__init__.py
+++ b/testsuite/oidc/keycloak/__init__.py
@@ -42,7 +42,6 @@ class Keycloak(OIDCProvider, LifecycleObject):
                 username=username,
                 password=password,
                 realm_name="master",
-                verify=False,
             )
             self.server_url = server_url
         except KeycloakPostError:
@@ -54,7 +53,6 @@ class Keycloak(OIDCProvider, LifecycleObject):
                 username=username,
                 password=password,
                 realm_name="master",
-                verify=False,
             )
 
     def create_realm(self, name: str, **kwargs) -> Realm:


### PR DESCRIPTION
- We are using http by default, no verification needed