### PR TITLE
Unify ApyProxy clients

### DIFF
--- a/testsuite/mockserver.py
+++ b/testsuite/mockserver.py
@@ -3,9 +3,9 @@
 from typing import Union
 
 from apyproxy import ApyProxy
+from httpx import Client
 
 from testsuite.utils import ContentType
-from testsuite.httpx import KuadrantClient
 
 
 class Mockserver:
@@ -13,8 +13,9 @@ class Mockserver:
     Mockserver deployed in Kubernetes (located in Tools or self-managed)
     """
 
-    def __init__(self, url, client: KuadrantClient = None):
-        self.client = ApyProxy(url, session=client or KuadrantClient(verify=False))
+    def __init__(self, client: Client):
+        self.url = str(client.base_url)
+        self.client = ApyProxy(self.url, session=client)
 
     def _expectation(self, expectation_id, json_data):
         """

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -158,9 +158,11 @@ def mockserver(testconfig, skip_or_fail):
     """Returns mockserver"""
     try:
         testconfig.validators.validate(only=["mockserver"])
-        return Mockserver(testconfig["mockserver"]["url"])
     except (KeyError, ValidationError) as exc:
-        return skip_or_fail(f"Mockserver configuration item is missing: {exc}")
+        skip_or_fail(f"Mockserver configuration item is missing: {exc}")
+
+    with KuadrantClient(base_url=testconfig["mockserver"]["url"]) as client:
+        yield Mockserver(client)
 
 
 @pytest.fixture(scope="session")

--- a/testsuite/tests/singlecluster/authorino/caching/metadata/conftest.py
+++ b/testsuite/tests/singlecluster/authorino/caching/metadata/conftest.py
@@ -17,8 +17,7 @@ def uuid_expectation(request, mockserver, module_label):
 @pytest.fixture(scope="module")
 def expectation_path(mockserver, module_label):
     """Returns expectation path"""
-    # pylint: disable=protected-access
-    return f"{mockserver.client._url}/{module_label}"
+    return f"{mockserver.url}/{module_label}"
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
* Client is required now
   * Fixture will take care of client creation and cleaning up and initial setup (auth + verify)
* Remove verify=false from Mockserver, we use HTTP anyways   
* Small updates to fixtures that use that
* Tracing will get separate PR later with bigger changes  