### PR TITLE
Add tests for overrides

### DIFF
--- a/testsuite/tests/singlecluster/overrides/test_basic_auth.py
+++ b/testsuite/tests/singlecluster/overrides/test_basic_auth.py
@@ -1,0 +1,39 @@
+"""Test basic enforcement of the rules inside the 'overrides' block of the RateLimitPolicy assigned to a Gateway"""
+
+import pytest
+
+from testsuite.httpx.auth import HttpxOidcClientAuth
+from testsuite.kuadrant.policy.authorization.auth_policy import AuthPolicy
+
+pytestmark = [pytest.mark.kuadrant_only]
+
+
+@pytest.fixture(scope="module")
+def authorization(route, gateway, blame, cluster, label, oidc_provider):  # pylint: disable=unused-argument
+    """Add oidc identity to overrides block of gateway-attached AuthPolicy"""
+    auth_policy = AuthPolicy.create_instance(cluster, blame("authz"), gateway, labels={"testRun": label})
+    auth_policy.overrides.identity.add_oidc("override", oidc_provider.well_known["issuer"])
+    return auth_policy
+
+
+@pytest.fixture(scope="module")
+def auth(oidc_provider):
+    """Returns Authentication object for HTTPX"""
+    return HttpxOidcClientAuth(oidc_provider.get_token, "authorization")
+
+
+@pytest.fixture(scope="module")
+def rate_limit():
+    """No RateLimitPolicy is required for this test"""
+    return None
+
+
+def test_basic_auth(route, authorization, client, auth):
+    """Test if rules inside overrides block of Gateway's AuthPolicy are inherited by the HTTPRoute
+    and enforced like any other normal rule"""
+    route.refresh()
+    assert route.is_affected_by(authorization)
+
+    response = client.get("/get")
+    assert response.status_code == 401
+    assert client.get("/get", auth=auth).status_code == 200  # assert that AuthPolicy is enforced

--- a/testsuite/tests/singlecluster/overrides/test_basic_rate_limit.py
+++ b/testsuite/tests/singlecluster/overrides/test_basic_rate_limit.py
@@ -1,0 +1,48 @@
+"""Test basic enforcement of the rules inside the 'overrides' block of the RateLimitPolicy assigned to a Gateway"""
+
+import pytest
+
+from testsuite.kuadrant.policy.rate_limit import Limit, RateLimitPolicy
+
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.limitador]
+
+GATEWAY_LIMIT = Limit(3, 5)
+ROUTE_LIMIT = Limit(2, 5)
+
+
+@pytest.fixture(scope="module")
+def authorization():
+    """No authorization is required for this test"""
+    return None
+
+
+@pytest.fixture(scope="module")
+def rate_limit_gw(request, cluster, blame, module_label, gateway):
+    """Add a RateLimitPolicy to the Gateway with an overrides block to override the Route-level policy."""
+    rate_limit_gateway = RateLimitPolicy.create_instance(
+        cluster, blame("limit-gateway"), gateway, labels={"testRun": module_label}
+    )
+    rate_limit_gateway.overrides.add_limit("basic", [GATEWAY_LIMIT])
+    request.addfinalizer(rate_limit_gateway.delete)
+    rate_limit_gateway.commit()
+    rate_limit_gateway.wait_for_ready()
+    return rate_limit_gateway
+
+
+@pytest.fixture(scope="module")
+def rate_limit(rate_limit):
+    """Add basic requests limit to RateLimitPolicy"""
+    rate_limit.add_limit("basic", [ROUTE_LIMIT])
+    return rate_limit
+
+
+def test_basic_rate_limit(rate_limit, rate_limit_gw, route, client):
+    """Test if rules inside overrides block of Gateway's RateLimitPolicy are inherited by the HTTPRoute
+    and enforced like any other normal rule"""
+    route.refresh()
+    assert route.is_affected_by(rate_limit)
+    rate_limit_gw.wait_for_full_enforced()
+
+    responses = client.get_many("/get", GATEWAY_LIMIT.limit)
+    responses.assert_all(status_code=200)
+    assert client.get("/get").status_code == 429  # assert that RateLimitPolicy is enforced

--- a/testsuite/tests/singlecluster/overrides/test_route_override.py
+++ b/testsuite/tests/singlecluster/overrides/test_route_override.py
@@ -1,0 +1,43 @@
+"""Test that overrides block can not be defined in AuthPolicy and RateLimitPolicy attached to a HTTPRoute"""
+
+import pytest
+from openshift_client import OpenShiftPythonException
+
+from testsuite.kuadrant.policy.rate_limit import Limit
+
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.limitador]
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization, oidc_provider):
+    """Create AuthPolicy with basic oidc rules in the overrides block"""
+    authorization.overrides.identity.add_oidc("override", oidc_provider.well_known["issuer"])
+    return authorization
+
+
+@pytest.fixture(scope="module")
+def rate_limit(rate_limit):
+    """Add basic rate limiting rules in the overrides block"""
+    rate_limit.overrides.add_limit("override", [Limit(2, 5)])
+    return rate_limit
+
+
+@pytest.fixture(scope="module")
+def commit():
+    """We need to try to commit objects during the actual test"""
+    return None
+
+
+@pytest.mark.parametrize(
+    "component_fixture",
+    [
+        pytest.param("authorization", id="AuthPolicy"),
+        pytest.param("rate_limit", id="RateLimitPolicy"),
+    ],
+)
+@pytest.mark.issue("https://github.com/Kuadrant/kuadrant-operator/issues/775")
+def test_route_override(request, component_fixture):
+    """Test that server will reject policy attached to a HTTPRoute containing an overrides block"""
+    component = request.getfixturevalue(component_fixture)
+    with pytest.raises(OpenShiftPythonException, match="Overrides are.*"):
+        component.commit()

--- a/testsuite/tests/singlecluster/overrides/test_rules_exclusivity.py
+++ b/testsuite/tests/singlecluster/overrides/test_rules_exclusivity.py
@@ -1,0 +1,63 @@
+"""Test mutual exclusivity of overrides block with explicit and implicit defaults"""
+
+import pytest
+from openshift_client import OpenShiftPythonException
+
+from testsuite.kuadrant.policy.authorization.auth_policy import AuthPolicy
+from testsuite.kuadrant.policy.rate_limit import RateLimitPolicy, Limit
+
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.limitador]
+
+
+@pytest.fixture(scope="module")
+def commit():
+    """We need to try to commit objects during the actual test"""
+    return None
+
+
+@pytest.mark.issue("https://github.com/Kuadrant/kuadrant-operator/issues/775")
+def test_rules_exclusivity_implicit_authorization(cluster, route, oidc_provider, module_label, blame):
+    """Test that server will reject an AuthPolicy with overrides and implicit defaults defined simultaneously"""
+    authorization = AuthPolicy.create_instance(cluster, blame("authz"), route, labels={"testRun": module_label})
+    authorization.overrides.identity.add_oidc("overrides", oidc_provider.well_known["issuer"])
+    authorization.identity.add_oidc("implicit-defaults", oidc_provider.well_known["issuer"])
+
+    with pytest.raises(
+        OpenShiftPythonException, match="Implicit defaults and explicit overrides are mutually exclusive"
+    ):
+        authorization.commit()
+
+
+@pytest.mark.issue("https://github.com/Kuadrant/kuadrant-operator/issues/775")
+def test_rules_exclusivity_explicit_authorization(cluster, route, oidc_provider, module_label, blame):
+    """Test that server will reject an AuthPolicy with overrides and implicit defaults defined simultaneously"""
+    authorization = AuthPolicy.create_instance(cluster, blame("authz"), route, labels={"testRun": module_label})
+    authorization.overrides.identity.add_oidc("overrides", oidc_provider.well_known["issuer"])
+    authorization.defaults.identity.add_oidc("explicit-defaults", oidc_provider.well_known["issuer"])
+
+    with pytest.raises(
+        OpenShiftPythonException, match="Explicit overrides and explicit defaults are mutually exclusive"
+    ):
+        authorization.commit()
+
+
+@pytest.mark.issue("https://github.com/Kuadrant/kuadrant-operator/issues/775")
+def test_rules_exclusivity_implicit_rate_limit(cluster, route, module_label, blame):
+    """Test that server will reject a RateLimitPolicy with overrides and implicit defaults defined simultaneously"""
+    rate_limit = RateLimitPolicy.create_instance(cluster, blame("limit"), route, labels={"testRun": module_label})
+    rate_limit.overrides.add_limit("overrides", [Limit(2, 5)])
+    rate_limit.add_limit("implicit-defaults", [Limit(2, 5)])
+
+    with pytest.raises(OpenShiftPythonException, match="Overrides and implicit defaults are mutually exclusive"):
+        rate_limit.commit()
+
+
+@pytest.mark.issue("https://github.com/Kuadrant/kuadrant-operator/issues/775")
+def test_rules_exclusivity_explicit_rate_limit(cluster, route, module_label, blame):
+    """Test that server will reject a RateLimitPolicy with overrides and explicit defaults defined simultaneously"""
+    rate_limit = RateLimitPolicy.create_instance(cluster, blame("limit"), route, labels={"testRun": module_label})
+    rate_limit.overrides.add_limit("overrides", [Limit(2, 5)])
+    rate_limit.defaults.add_limit("explicit-defaults", [Limit(2, 5)])
+
+    with pytest.raises(OpenShiftPythonException, match="Overrides and explicit defaults are mutually exclusive"):
+        rate_limit.commit()


### PR DESCRIPTION
## Changes
- Add tests for Overrides

Reason for regexes in checking error messages: Kuadrant/kuadrant-operator#775 , can be fixed after
Closes #380 