### PR TITLE
Rename anonymous rate limiting test

### DIFF
--- a/testsuite/tests/singlecluster/test_rate_limit_anonymous.py
+++ b/testsuite/tests/singlecluster/test_rate_limit_anonymous.py
@@ -51,7 +51,7 @@ def test_no_limit_for_auth_user(client, auth):
     responses.assert_all(status_code=200)
 
 
-def test_anonymous_identity(client, auth):
+def test_limit_for_anonymous_identity(client, auth):
     """Test that an anonymous requests are correctly limited"""
     assert client.get("/get", auth=auth).status_code == 200
 


### PR DESCRIPTION
## Summary

The test was renamed because there already is a test with identical name (https://github.com/Kuadrant/testsuite/blob/main/testsuite/tests/singlecluster/authorino/identity/anonymous/test_anonymous_identity.py#L15) which causes troubles in ReportPortal

## Verification Steps
Eye review should suffice.