### PR TITLE
Remove namespace from reference

### DIFF
--- a/testsuite/gateway/gateway_api/gateway.py
+++ b/testsuite/gateway/gateway_api/gateway.py
@@ -130,5 +130,4 @@ class KuadrantGateway(KubernetesObject, Gateway):
             "group": "gateway.networking.k8s.io",
             "kind": "Gateway",
             "name": self.name(),
-            "namespace": self.namespace(),
         }

--- a/testsuite/gateway/gateway_api/route.py
+++ b/testsuite/gateway/gateway_api/route.py
@@ -65,7 +65,6 @@ class HTTPRoute(KubernetesObject, GatewayRoute):
             "group": "gateway.networking.k8s.io",
             "kind": "HTTPRoute",
             "name": self.name(),
-            "namespace": self.namespace(),
         }
 
     @property


### PR DESCRIPTION
Due to merge of https://github.com/Kuadrant/kuadrant-operator/pull/780 we need to remove namespace from references in AuthPolicy and other CR. This should be the minimal change to achieve this.