### PR TITLE
Add another gateway CR name for cleaning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ help: ## Print this help
 CR_NAMES = $\
 authorinos.operator.authorino.kuadrant.io,$\
 gateways.networking.istio.io,$\
+gateways.gateway.networking.k8s.io,$\
 httproutes.gateway.networking.k8s.io,$\
 deployments.apps,$\
 services,$\


### PR DESCRIPTION
So we clean the Gateways.
Not sure when this changed but keeping two names for gateways should not be a problem anyways.