### PR TITLE
Add Kuadrant version to pytest report

### DIFF
--- a/testsuite/capabilities.py
+++ b/testsuite/capabilities.py
@@ -24,3 +24,22 @@ def has_kuadrant():
                 return False, f"Cluster {cluster.api_url} does not have Kuadrant resource in project {project}"
 
     return True, None
+
+
+@functools.cache
+def kuadrant_version():
+    """Returns catalog image tag of deployed Kuadrant if possible."""
+    clusters = [settings["control_plane"]["cluster"]]
+    if cluster2 := settings["control_plane"]["cluster2"]:
+        clusters.append(cluster2)
+    versions = []
+    for cluster in clusters:
+        project = cluster.change_project("openshift-marketplace")
+        if not project.connected:
+            break
+        with project.context:
+            catalog_source = selector("CatalogSource/kuadrant-upstream").object(ignore_not_found=True)
+            if catalog_source is None:
+                break
+            versions.append((catalog_source.as_dict()["spec"]["image"], cluster.api_url))
+    return versions

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -4,10 +4,11 @@ import signal
 from urllib.parse import urlparse
 
 import pytest
+from pytest_metadata.plugin import metadata_key  # type: ignore
 from dynaconf import ValidationError
 from keycloak import KeycloakAuthenticationError
 
-from testsuite.capabilities import has_kuadrant
+from testsuite.capabilities import has_kuadrant, kuadrant_version
 from testsuite.certificates import CFSSLClient
 from testsuite.config import settings
 from testsuite.gateway import Exposer, CustomReference
@@ -69,6 +70,17 @@ def pytest_runtest_makereport(item, call):  # pylint: disable=unused-argument
                 label = issue
             extra.append(pytest_html.extras.url(issue, name=label))
         report.extra = extra
+
+
+def pytest_report_header(config):
+    """Adds Kuadrant version string to pytest header output for every cluster."""
+    header = ""
+    images = []
+    for image, cluster in kuadrant_version():
+        header += f"Kuadrant image: {image} on cluster {cluster}\n"
+        images.append(image)
+    config.stash[metadata_key]["Kuadrant"] = images
+    return header
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This change will add image strings of deployed Kuadrants on clusters (including second cluster if defined) in pytest report header when running testsuite with make targets. This string is taken from CatalogSource object and in case the object is not found, no string will be printed. In the future this can be expanded for Kind setup, or doing smarter job in finding the right CatalogSource.

This can make debugging easier and is mostly helpful for figuring out nightly build version as the version string in Kuadrant subscription object is "0.0.0".
