### PR TITLE
Using trepel quay rather than no-longer red hatters ones

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -11,13 +11,13 @@ default:
       username: "testUser"
       password: "testPassword"
   httpbin:
-    image: "quay.io/jsmadis/httpbin:latest"
+    image: "quay.io/trepel/httpbin:jsmadis"
   service_protection:
     system_project: "kuadrant-system"
     project: "kuadrant"
     project2: "kuadrant2"
     envoy:
-      image: "quay.io/phala/envoy:v1.28-latest"
+      image: "quay.io/trepel/envoy:v1.31.0"
     gateway:
        project: "istio-system"
        name: "istio-ingressgateway"


### PR DESCRIPTION
## Overview

I is better to use my quay.io. Of course it would be ideal if we have some non-person based org there for these, but this is still slightly better

`quay.io/trepel/httpbin:jsmadis` is the same as `quay.io/jsmadis/httpbin:latest`
- you can pull and inspect if you don't believe me

Validation is required due to other change, since it updates the envoy from 1.28 do 1.31.0 (latest at the moment)

## Verification Steps

`make target`

However, I did that and the result was:
`==== 23 failed, 172 passed, 8 skipped, 25 xfailed in 1311.03s (0:21:51) ===`

The 23 failures are due to issue discussed in slack - yesterdays nightly build does not contain proper version of wasm plugin and today's does not exist due to failure