### PR TITLE
Wait for Gateway to be ready before using it

### DIFF
--- a/testsuite/tests/singlecluster/authorino/operator/sharding/conftest.py
+++ b/testsuite/tests/singlecluster/authorino/operator/sharding/conftest.py
@@ -22,6 +22,7 @@ def setup_gateway(request, cluster, blame, testconfig, module_label):
         )
         request.addfinalizer(gw.delete)
         gw.commit()
+        gw.wait_for_ready()
         return gw
 
     return _envoy


### PR DESCRIPTION
## Overview

This is a small try to further stabilze the test_preexisting_auth, see 
https://github.com/Kuadrant/testsuite/issues/427

## Verification Steps
Execute

`flags="-vvv --standalone" make testsuite/tests/singlecluster/authorino/operator/sharding/test_preexisting_auth.py`

and

`flags="-vvv --standalone" make testsuite/tests/singlecluster/authorino/operator/sharding/test_sharding.py`

Both should pass. We will see in nightlies whether this actually helped or not.