### PR TITLE
Remove pytest-asyncio lib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ python = "^3.11"
 typing_extensions = "*"
 pytest-xdist = "*"
 pytest = "*"
-pytest-asyncio = ">=0.23.4"
 pytest-html = "*"
 dynaconf = "*"
 dnspython = "*"
@@ -61,7 +60,6 @@ log_date_format = "%H:%M:%S %z"
 log_level = "INFO"
 junit_logging = "all"
 junit_family = "xunit2"
-asyncio_mode = "auto"
 xfail_strict = true
 
 # Pylint:


### PR DESCRIPTION
We never used this library and currently its printing many warnings in test report so its good time to remove it.

For verification I would just run the testsuite and see no errors or text search for `asyncio` string in code and see no results.