### PR TITLE
Remove xfail due to gateway listeneners bug being fixed

### DIFF
--- a/testsuite/tests/singlecluster/gateway/reconciliation/test_gateway_listeners_dns.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/test_gateway_listeners_dns.py
@@ -46,7 +46,6 @@ def route(route, wildcard_domain):
     return route
 
 
-@pytest.mark.xfail()
 @pytest.mark.issue("https://github.com/Kuadrant/kuadrant-operator/issues/794")
 def test_change_hostname(client, client_new, auth, gateway, route, new_domain, wildcard_domain):
     """


### PR DESCRIPTION
Issue has been fixed now: https://github.com/Kuadrant/kuadrant-operator/issues/794
So now we expect this test to pass.

To verify run:
```
make testsuite/tests/singlecluster/gateway/reconciliation/test_gateway_listeners_dns.py
```