### PR TITLE
Add gateway listeners scaling test

### DIFF
--- a/testsuite/gateway/gateway_api/gateway.py
+++ b/testsuite/gateway/gateway_api/gateway.py
@@ -54,6 +54,18 @@ class KuadrantGateway(KubernetesObject, Gateway):
 
         return cls(model, context=cluster.context)
 
+    def add_listener(self, name: str, hostname: str):
+        """Adds new listener to the Gateway"""
+        self.model.spec.listeners.append(
+            {
+                "name": name,
+                "port": 80,
+                "protocol": "HTTP",
+                "hostname": hostname,
+                "allowedRoutes": {"namespaces": {"from": "All"}},
+            }
+        )
+
     @property
     def service_name(self) -> str:
         return f"{self.name()}-istio"

--- a/testsuite/kuadrant/policy/__init__.py
+++ b/testsuite/kuadrant/policy/__init__.py
@@ -35,9 +35,10 @@ class Policy(KubernetesObject):
         )
         assert success, f"{self.kind(False)} did not get partially enforced in time"
 
-    def wait_for_full_enforced(self):
+    def wait_for_full_enforced(self, timelimit=60):
         """Wait for a Policy to be fully Enforced"""
         success = self.wait_until(
-            has_condition("Enforced", "True", "Enforced", f"{self.kind(False)} has been successfully enforced")
+            has_condition("Enforced", "True", "Enforced", f"{self.kind(False)} has been successfully enforced"),
+            timelimit=timelimit,
         )
         assert success, f"{self.kind()} did not get fully enforced in time"

--- a/testsuite/kuadrant/policy/dns.py
+++ b/testsuite/kuadrant/policy/dns.py
@@ -67,3 +67,7 @@ class DNSPolicy(Policy):
             model["spec"]["loadBalancing"] = asdict(load_balancing)
 
         return cls(model, context=cluster.context)
+
+    def wait_for_full_enforced(self, timelimit=300):
+        """Wait for a Policy to be fully Enforced with increased timelimit for DNSPolicy"""
+        super().wait_for_full_enforced(timelimit=timelimit)

--- a/testsuite/tests/singlecluster/gateway/test_scale_listeners.py
+++ b/testsuite/tests/singlecluster/gateway/test_scale_listeners.py
@@ -1,0 +1,76 @@
+"""Create 2 gateways with 64 listeners each and confirm they are reachable with DNSPolicy applied"""
+
+import pytest
+
+from testsuite.httpx import KuadrantClient
+from testsuite.gateway.gateway_api.route import HTTPRoute
+from testsuite.gateway.gateway_api.gateway import KuadrantGateway
+from testsuite.kuadrant.policy.dns import DNSPolicy
+
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.dnspolicy]
+
+MAX_GATEWAY_LISTENERS = 64
+
+
+@pytest.fixture(scope="module")
+def gateway(request, cluster, blame, base_domain, module_label):
+    """Create first gateway with 64 listeners"""
+    gw = KuadrantGateway.create_instance(cluster, blame("gw"), f"gw1-api.{base_domain}", {"app": module_label})
+    for i in range(1, MAX_GATEWAY_LISTENERS):
+        gw.add_listener(f"api{i}", f"gw1-api{i}.{base_domain}")
+    request.addfinalizer(gw.delete)
+    gw.commit()
+    gw.wait_for_ready()
+    return gw
+
+
+@pytest.fixture(scope="module")
+def gateway2(request, cluster, blame, base_domain, module_label):
+    """Create second gateway with 64 listeners"""
+    gw = KuadrantGateway.create_instance(cluster, blame("gw"), f"gw2-api.{base_domain}", {"app": module_label})
+    for i in range(1, MAX_GATEWAY_LISTENERS):
+        gw.add_listener(f"api{i}", f"gw2-api{i}.{base_domain}")
+    request.addfinalizer(gw.delete)
+    gw.commit()
+    gw.wait_for_ready()
+    return gw
+
+
+@pytest.fixture(scope="module")
+def dns_policy2(blame, gateway2, module_label, dns_provider_secret):
+    """Create DNSPolicy for second gateway"""
+    return DNSPolicy.create_instance(
+        gateway2.cluster, blame("dns"), gateway2, dns_provider_secret, labels={"app": module_label}
+    )
+
+
+@pytest.fixture(scope="module")
+def routes(request, gateway, gateway2, blame, wildcard_domain, backend, module_label):
+    """Create routes for both gateways"""
+    for g in [gateway, gateway2]:
+        route = HTTPRoute.create_instance(g.cluster, blame("route"), g, {"app": module_label})
+        route.add_hostname(wildcard_domain)
+        route.add_backend(backend)
+        request.addfinalizer(route.delete)
+        route.commit()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def commit(request, routes, dns_policy, dns_policy2):  # pylint: disable=unused-argument
+    """Commit and wait for DNSPolicies to be fully enforced"""
+    for component in [dns_policy, dns_policy2]:
+        request.addfinalizer(component.delete)
+        component.commit()
+        component.wait_for_ready()
+
+
+def test_gateway_max_listeners(gateway, gateway2, dns_policy, dns_policy2, base_domain):
+    """Verify that both gateways are affected by DNSPolicy and their listeners are reachable"""
+    assert gateway.refresh().is_affected_by(dns_policy)
+    assert gateway2.refresh().is_affected_by(dns_policy2)
+
+    assert KuadrantClient(base_url=f"http://gw1-api.{base_domain}").get("/get").response.status_code == 200
+    assert KuadrantClient(base_url=f"http://gw1-api63.{base_domain}").get("/get").response.status_code == 200
+
+    assert KuadrantClient(base_url=f"http://gw2-api21.{base_domain}").get("/get").response.status_code == 200
+    assert KuadrantClient(base_url=f"http://gw2-api53.{base_domain}").get("/get").response.status_code == 200


### PR DESCRIPTION
**Changes**
- Overwrite `wait_for_ready` for DNSPolicy with timeout increased to 5 min instead of 1 min, large amount of DNS records take some time to create
- Create 2 gateways with max listeners and see if both dns policies are enforced and some random listeners are reachable

Closes #528