### PR TITLE
Add flag for html generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PYTEST += --junitxml=$(resultsdir)/junit-$(@F).xml -o junit_suite_name=$(@F)
 endif
 
 ifdef html
-PYTEST += --html=$(resultsdir)/report-$(@F).html
+PYTEST += --html=$(resultsdir)/report-$(@F).html --self-contained-html
 endif
 
 commit-acceptance: black pylint mypy ## Runs pre-commit linting checks


### PR DESCRIPTION
Inpiration from sister testsuite https://github.com/3scale-qe/3scale-tests/blob/376263a7b94faced2698b920f9599c39e1d38b44/Makefile#L33

Makes the html report include CSS instead of creating extra directory to keep the css file.