### PR TITLE
Add initial kube-burner config and readme for perf testing

### DIFF
--- a/scale_test/aws-credentials.yaml
+++ b/scale_test/aws-credentials.yaml
@@ -5,8 +5,8 @@ metadata:
   name: aws-credentials
   labels:
     app: scale-test
-data:
-  AWS_ACCESS_KEY_ID: your-base64-encoded-value
-  AWS_REGION: your-base64-encoded-value
-  AWS_SECRET_ACCESS_KEY: your-base64-encoded-value
+stringData:
+  AWS_ACCESS_KEY_ID: {{ .KUADRANT_AWS_ACCESS_KEY_ID }}
+  AWS_REGION: {{ .KUADRANT_AWS_REGION }}
+  AWS_SECRET_ACCESS_KEY: {{ .KUADRANT_AWS_SECRET_ACCESS_KEY }}
 type: kuadrant.io/aws

--- a/scale_test/aws-credentials.yaml
+++ b/scale_test/aws-credentials.yaml
@@ -1,0 +1,12 @@
+---
+kind: Secret
+apiVersion: v1
+metadata:
+  name: aws-credentials
+  labels:
+    app: scale-test
+data:
+  AWS_ACCESS_KEY_ID: your-base64-encoded-value
+  AWS_REGION: your-base64-encoded-value
+  AWS_SECRET_ACCESS_KEY: your-base64-encoded-value
+type: kuadrant.io/aws

--- a/scale_test/config.yaml
+++ b/scale_test/config.yaml
@@ -4,9 +4,17 @@ metricsEndpoints:
     token: {{ .PROMETHEUS_TOKEN }}
     metrics: 
     - ./metrics.yaml
-    indexer: 
+{{ if .OS_INDEXING }}
+    indexer:
+      type: opensearch
+      esServers: ["{{ .ES_SERVER }}"]
+      insecureSkipVerify: true
+      defaultIndex: kube-burner
+{{ else }}
+    indexer:
       type: local
       metricsDirectory: ./metrics
+{{ end }}
 global: 
   gc: true
 jobs: 
@@ -30,6 +38,10 @@ jobs:
       - objectTemplate: ./aws-credentials.yaml
         kind: Secret
         replicas: 1
+        inputVars:
+          KUADRANT_AWS_ACCESS_KEY_ID: "{{ .KUADRANT_AWS_ACCESS_KEY_ID }}"
+          KUADRANT_AWS_REGION: "{{ .KUADRANT_AWS_REGION }}"
+          KUADRANT_AWS_SECRET_ACCESS_KEY: "{{ .KUADRANT_AWS_SECRET_ACCESS_KEY }}"
   - name: scale-test-main
     jobIterations: 1
     qps: 1
@@ -43,6 +55,8 @@ jobs:
         waitOptions:
           forCondition: Programmed
           customStatusPath: ".conditions[].type"
+        inputVars:
+          KUADRANT_ZONE_ROOT_DOMAIN: "{{ .KUADRANT_ZONE_ROOT_DOMAIN }}"
       - objectTemplate: ./gw-tls-policy.yaml
         replicas: 1
         waitOptions:
@@ -68,6 +82,8 @@ jobs:
         waitOptions:
           forCondition: Accepted
           customStatusPath: ".conditions[].type"
+        inputVars:
+          KUADRANT_ZONE_ROOT_DOMAIN: "{{ .KUADRANT_ZONE_ROOT_DOMAIN }}"
       - objectTemplate: ./httproute-rlp.yaml
         replicas: 1
         waitOptions:

--- a/scale_test/config.yaml
+++ b/scale_test/config.yaml
@@ -1,0 +1,80 @@
+---
+metricsEndpoints: 
+  - endpoint: {{ .PROMETHEUS_URL }}
+    token: {{ .PROMETHEUS_TOKEN }}
+    metrics: 
+    - ./metrics.yaml
+    indexer: 
+      type: local
+      metricsDirectory: ./metrics
+global: 
+  gc: true
+jobs: 
+  - name: scale-test-preparations
+    jobIterations: 1
+    qps: 1
+    burst: 1
+    namespacedIterations: true
+    namespace: scale-test
+    waitWhenFinished: true
+    objects:
+      - objectTemplate: ./httpbin-deployment.yaml
+        kind: Deployment
+        replicas: 1
+        waitOptions:
+          forCondition: "Available"
+          customStatusPath: ".conditions[].type"
+      - objectTemplate: ./httpbin-service.yaml
+        kind: Service
+        replicas: 1
+      - objectTemplate: ./aws-credentials.yaml
+        kind: Secret
+        replicas: 1
+  - name: scale-test-main
+    jobIterations: 1
+    qps: 1
+    burst: 1
+    namespacedIterations: true
+    namespace: scale-test
+    waitWhenFinished: true
+    objects:
+      - objectTemplate: ./gw.yaml
+        replicas: 1
+        waitOptions:
+          forCondition: Programmed
+          customStatusPath: ".conditions[].type"
+      - objectTemplate: ./gw-tls-policy.yaml
+        replicas: 1
+        waitOptions:
+          forCondition: Enforced
+          customStatusPath: ".conditions[].type"
+      - objectTemplate: ./gw-dns-policy.yaml
+        replicas: 1
+        waitOptions:
+          forCondition: Enforced
+          customStatusPath: ".conditions[].type"
+      - objectTemplate: ./gw-rlp.yaml
+        replicas: 1
+        waitOptions:
+          forCondition: Enforced
+          customStatusPath: ".conditions[].type"
+      - objectTemplate: ./gw-auth-policy.yaml
+        replicas: 1
+        waitOptions:
+          forCondition: Enforced
+          customStatusPath: ".conditions[].type"
+      - objectTemplate: ./httproute.yaml
+        replicas: 1
+        waitOptions:
+          forCondition: Accepted
+          customStatusPath: ".conditions[].type"
+      - objectTemplate: ./httproute-rlp.yaml
+        replicas: 1
+        waitOptions:
+          forCondition: Enforced
+          customStatusPath: ".conditions[].type"
+      - objectTemplate: ./httproute-auth-policy.yaml
+        replicas: 1
+        waitOptions:
+          forCondition: Enforced
+          customStatusPath: ".conditions[].type"

--- a/scale_test/config.yaml
+++ b/scale_test/config.yaml
@@ -78,3 +78,13 @@ jobs:
         waitOptions:
           forCondition: Enforced
           customStatusPath: ".conditions[].type"
+  - name: scale-test-safe-dnspolicy-cleanup
+    jobType: delete
+    jobIterations: 1
+    namespacedIterations: true
+    namespace: scale-test
+    waitWhenFinished: true
+    objects:
+      - kind: DNSPolicy
+        apiVersion: kuadrant.io/v1alpha1
+        labelSelector: {kube-burner-job: scale-test-main}

--- a/scale_test/config.yaml
+++ b/scale_test/config.yaml
@@ -56,12 +56,12 @@ jobs:
       - objectTemplate: ./gw-rlp.yaml
         replicas: 1
         waitOptions:
-          forCondition: Enforced
+          forCondition: Accepted
           customStatusPath: ".conditions[].type"
       - objectTemplate: ./gw-auth-policy.yaml
         replicas: 1
         waitOptions:
-          forCondition: Enforced
+          forCondition: Accepted
           customStatusPath: ".conditions[].type"
       - objectTemplate: ./httproute.yaml
         replicas: 1

--- a/scale_test/gw-auth-policy.yaml
+++ b/scale_test/gw-auth-policy.yaml
@@ -1,0 +1,27 @@
+apiVersion: kuadrant.io/v1beta2
+kind: AuthPolicy
+metadata:
+  name: gw-auth-policy-{{.Iteration}}
+  labels: 
+    app: scale-test
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: scale-test-{{.Iteration}}
+  rules:
+    authorization:
+      deny-all:
+        opa:
+          rego: "allow = false"
+    response:
+      unauthorized:
+        headers:
+          "content-type":
+            value: application/json
+        body:
+          value: |
+            {
+              "error": "Forbidden",
+              "message": "Access denied by default by the gateway operator. If you are the administrator of the service, create a specific auth policy for the route."
+            }

--- a/scale_test/gw-dns-policy.yaml
+++ b/scale_test/gw-dns-policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: kuadrant.io/v1alpha1
+kind: DNSPolicy
+metadata:
+  name: gw-dns-policy-{{.Iteration}}
+  labels: 
+    app: scale-test
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: scale-test-{{.Iteration}}
+  providerRefs:
+  - name: aws-credentials

--- a/scale_test/gw-rlp.yaml
+++ b/scale_test/gw-rlp.yaml
@@ -1,0 +1,17 @@
+apiVersion: kuadrant.io/v1beta3
+kind: RateLimitPolicy
+metadata:
+  name: gw-rlp-{{.Iteration}}
+  labels: 
+    app: scale-test
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: scale-test-{{.Iteration}}
+  limits:
+    "global":
+      rates:
+      - limit: 5
+        duration: 10
+        unit: second

--- a/scale_test/gw-tls-policy.yaml
+++ b/scale_test/gw-tls-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: kuadrant.io/v1alpha1
+kind: TLSPolicy
+metadata:
+  name: gw-tls-policy-{{.Iteration}}
+  labels: 
+    app: scale-test
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: scale-test-{{.Iteration}}
+  issuerRef:
+    group: cert-manager.io
+    kind: ClusterIssuer
+    name: selfsigned-issuer

--- a/scale_test/gw.yaml
+++ b/scale_test/gw.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata: 
+  name: scale-test-{{.Iteration}}
+  labels: 
+    app: scale-test
+spec: 
+  gatewayClassName: istio
+  listeners: 
+  - allowedRoutes: 
+      namespaces: 
+        from: All
+    hostname: "*.scale-test-{{.Iteration}}.the.domain.iown"
+    name: api
+    port: 443
+    protocol: HTTPS
+    tls:
+      mode: Terminate
+      certificateRefs:
+        - name: scale-test-{{.Iteration}}
+          kind: Secret

--- a/scale_test/gw.yaml
+++ b/scale_test/gw.yaml
@@ -10,7 +10,7 @@ spec:
   - allowedRoutes: 
       namespaces: 
         from: All
-    hostname: "*.scale-test-{{.Iteration}}.the.domain.iown"
+    hostname: "*.scale-test-{{.Iteration}}.{{ .KUADRANT_ZONE_ROOT_DOMAIN }}"
     name: api
     port: 443
     protocol: HTTPS

--- a/scale_test/httpbin-deployment.yaml
+++ b/scale_test/httpbin-deployment.yaml
@@ -1,0 +1,24 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: httpbin
+  labels:
+    app: scale-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: scale-test
+  template:
+    metadata:
+      labels:
+        app: scale-test
+    spec:
+      containers:
+        - name: httpbin
+          image: 'quay.io/trepel/httpbin:jsmadis'
+          ports:
+            - name: api
+              containerPort: 8080
+              protocol: TCP

--- a/scale_test/httpbin-service.yaml
+++ b/scale_test/httpbin-service.yaml
@@ -1,0 +1,15 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: httpbin
+  labels:
+    app: scale-test
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: api
+  selector:
+    app: scale-test

--- a/scale_test/httproute-auth-policy.yaml
+++ b/scale_test/httproute-auth-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: kuadrant.io/v1beta2
+kind: AuthPolicy
+metadata:
+  name: httproute-auth-policy-{{.Iteration}}
+  labels: 
+    app: scale-test
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: scale-test-{{.Iteration}}
+  rules:
+    authorization:
+      allow-all:
+        opa:
+          rego: "allow = true"

--- a/scale_test/httproute-rlp.yaml
+++ b/scale_test/httproute-rlp.yaml
@@ -1,0 +1,17 @@
+apiVersion: kuadrant.io/v1beta3
+kind: RateLimitPolicy
+metadata:
+  name: httproute-rlp-{{.Iteration}}
+  labels: 
+    app: scale-test
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: scale-test-{{.Iteration}}
+  limits:
+    "httproute-level":
+      rates:
+      - limit: 10
+        duration: 10
+        unit: second

--- a/scale_test/httproute.yaml
+++ b/scale_test/httproute.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata: 
+  name: scale-test-{{.Iteration}}
+  labels: 
+    app: scale-test
+spec:
+  parentRefs:
+  - group: gateway.networking.k8s.io
+    kind: Gateway
+    name: scale-test-{{.Iteration}}
+  hostnames:
+  - "api-{{.Iteration}}.scale-test-{{.Iteration}}.the.domain.iown"
+  rules:
+  - backendRefs:
+    - group: ''
+      kind: Service
+      name: httpbin
+      port: 8080
+      weight: 1
+    matches:
+      - path:
+          type: PathPrefix
+          value: /

--- a/scale_test/httproute.yaml
+++ b/scale_test/httproute.yaml
@@ -10,7 +10,7 @@ spec:
     kind: Gateway
     name: scale-test-{{.Iteration}}
   hostnames:
-  - "api-{{.Iteration}}.scale-test-{{.Iteration}}.the.domain.iown"
+  - "api-{{.Iteration}}.scale-test-{{.Iteration}}.{{ .KUADRANT_ZONE_ROOT_DOMAIN }}"
   rules:
   - backendRefs:
     - group: ''

--- a/scale_test/metrics.yaml
+++ b/scale_test/metrics.yaml
@@ -1,0 +1,120 @@
+# API server
+- query: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb!~"WATCH", subresource!="log"}[2m])) by (verb,resource,subresource,instance,le)) > 0
+  metricName: API99thLatency
+
+- query: sum(irate(apiserver_request_total{apiserver="kube-apiserver",verb!="WATCH",subresource!="log"}[2m])) by (verb,instance,resource,code) > 0
+  metricName: APIRequestRate
+
+- query: sum(apiserver_current_inflight_requests{}) by (request_kind) > 0
+  metricName: APIInflightRequests
+
+# Containers & pod metrics
+- query: sum(irate(container_cpu_usage_seconds_total{name!="",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler|monitoring|logging|image-registry)"}[2m]) * 100) by (pod, namespace, node)
+  metricName: podCPU
+
+- query: sum(container_memory_rss{name!="",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler|monitoring|logging|image-registry)"}) by (pod, namespace, node)
+  metricName: podMemory
+
+- query: (sum(rate(container_fs_writes_bytes_total{container!="",device!~".+dm.+"}[5m])) by (device, container, node) and on (node) kube_node_role{role="master"}) > 0
+  metricName: containerDiskUsage
+
+# Kubelet & CRI-O metrics
+- query: sum(irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[2m]) * 100) by (node) and on (node) kube_node_role{role="worker"}
+  metricName: kubeletCPU
+
+- query: sum(process_resident_memory_bytes{service="kubelet",job="kubelet"}) by (node) and on (node) kube_node_role{role="worker"}
+  metricName: kubeletMemory
+
+- query: sum(irate(process_cpu_seconds_total{service="kubelet",job="crio"}[2m]) * 100) by (node) and on (node) kube_node_role{role="worker"}
+  metricName: crioCPU
+
+- query: sum(process_resident_memory_bytes{service="kubelet",job="crio"}) by (node) and on (node) kube_node_role{role="worker"}
+  metricName: crioMemory
+
+# Node metrics
+- query: sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) > 0
+  metricName: nodeCPU
+
+- query: avg(node_memory_MemAvailable_bytes) by (instance)
+  metricName: nodeMemoryAvailable
+
+- query: avg(node_memory_Active_bytes) by (instance)
+  metricName: nodeMemoryActive
+
+- query: avg(node_memory_Cached_bytes) by (instance) + avg(node_memory_Buffers_bytes) by (instance)
+  metricName: nodeMemoryCached+nodeMemoryBuffers
+
+- query: irate(node_network_receive_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m])
+  metricName: rxNetworkBytes
+
+- query: irate(node_network_transmit_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m])
+  metricName: txNetworkBytes
+
+- query: rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m])
+  metricName: nodeDiskWrittenBytes
+
+- query: rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m])
+  metricName: nodeDiskReadBytes
+
+- query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
+  metricName: etcdLeaderChangesRate
+
+# Etcd metrics
+- query: etcd_server_is_leader > 0
+  metricName: etcdServerIsLeader
+
+- query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))
+  metricName: 99thEtcdDiskBackendCommitDurationSeconds
+
+- query: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[2m]))
+  metricName: 99thEtcdDiskWalFsyncDurationSeconds
+
+- query: histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket[5m]))
+  metricName: 99thEtcdRoundTripTimeSeconds
+
+- query: etcd_mvcc_db_total_size_in_bytes
+  metricName: etcdDBPhysicalSizeBytes
+
+- query: etcd_mvcc_db_total_size_in_use_in_bytes
+  metricName: etcdDBLogicalSizeBytes
+
+- query: sum(rate(etcd_object_counts{}[5m])) by (resource) > 0
+  metricName: etcdObjectCount
+
+- query: sum by (cluster_version)(etcd_cluster_version)
+  metricName: etcdVersion
+  instant: true
+
+# Cluster metrics
+- query: sum(kube_namespace_status_phase) by (phase) > 0
+  metricName: namespaceCount
+
+- query: sum(kube_pod_status_phase{}) by (phase)
+  metricName: podStatusCount
+
+- query: count(kube_secret_info{})
+  metricName: secretCount
+
+- query: count(kube_deployment_labels{})
+  metricName: deploymentCount
+
+- query: count(kube_configmap_info{})
+  metricName: configmapCount
+
+- query: count(kube_service_info{})
+  metricName: serviceCount
+
+- query: count(openshift_route_created{})
+  metricName: routeCount
+  instant: true
+
+- query: kube_node_role
+  metricName: nodeRoles
+  instant: true
+
+- query: sum(kube_node_status_condition{status="true"}) by (condition)
+  metricName: nodeStatus
+
+- query: cluster_version{type="completed"}
+  metricName: clusterVersion
+  instant: true

--- a/scale_test/metrics/.gitignore
+++ b/scale_test/metrics/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/scale_test/readme.md
+++ b/scale_test/readme.md
@@ -62,13 +62,6 @@ Port forward to prometheus:
 kubectl -n monitoring port-forward svc/prometheus-k8s 9090:9090
 ```
 
-Set env vars for prometheus:
-
-```bash
-export PROMETHEUS_URL="http://127.0.0.1:9090"
-export PROMETHEUS_TOKEN=""
-```
-
 Run kube-burner:
 
 ```bash

--- a/scale_test/readme.md
+++ b/scale_test/readme.md
@@ -6,8 +6,18 @@ Control Plane scale testing via kube-burner utility
 
 This test assumes that Kuadrant together with all the dependencies (Gateway API, Istio, Certificate Manager etc) is installed. A ClusterIssuer (self-signed one is enough) is expected to exist too. Also make sure to port-forward Prometheus instance so that it is possible for kube-burner to query it.
 
-Provide the AWS credentials for DNS setup in `aws-credentials.yaml`
-Replace the `the.domain.iown` placeholder with the actual domain in `gw.yaml` and `httproute.yaml`.
+The following env vars will need to be set to run the tests:
+
+```
+export KUADRANT_AWS_SECRET_ACCESS_KEY=[key]
+export KUADRANT_AWS_ACCESS_KEY_ID=[id]
+export KUADRANT_ZONE_ROOT_DOMAIN=[domain]
+export KUADRANT_AWS_REGION=[region]
+export PROMETHEUS_URL=http://127.0.0.1:9090
+export PROMETHEUS_TOKEN=""
+export OS_INDEXING=true   # if sending metrics to opensearch/elasticsearch
+export ES_SERVER=https://[user]:[password]@[host]:[port]
+```
 
 Create an empty `./metrics` directory where the data returned from Prometheus are to be stored.
 

--- a/scale_test/readme.md
+++ b/scale_test/readme.md
@@ -19,8 +19,6 @@ export OS_INDEXING=true   # if sending metrics to opensearch/elasticsearch
 export ES_SERVER=https://[user]:[password]@[host]:[port]
 ```
 
-Create an empty `./metrics` directory where the data returned from Prometheus are to be stored.
-
 ## Execution
 
 `kube-burner init -c ./config.yaml --timeout 5m`

--- a/scale_test/readme.md
+++ b/scale_test/readme.md
@@ -1,0 +1,16 @@
+# Control Plane Scale Test
+
+Control Plane scale testing via kube-burner utility
+
+## Prerequisities
+
+This test assumes that Kuadrant together with all the dependencies (Gateway API, Istio, Certificate Manager etc) is installed. A ClusterIssuer (self-signed one is enough) is expected to exist too. Also make sure to port-forward Prometheus instance so that it is possible for kube-burner to query it.
+
+Provide the AWS credentials for DNS setup in `aws-credentials.yaml`
+Replace the `the.domain.iown` placeholder with the actual domain in `gw.yaml` and `httproute.yaml`.
+
+Create an empty `./metrics` directory where the data returned from Prometheus are to be stored.
+
+## Execution
+
+`kube-burner init -c ./config.yaml --timeout 5m`

--- a/scale_test/readme.md
+++ b/scale_test/readme.md
@@ -14,3 +14,53 @@ Create an empty `./metrics` directory where the data returned from Prometheus ar
 ## Execution
 
 `kube-burner init -c ./config.yaml --timeout 5m`
+
+## Setting up a local cluster for execution
+
+Follow the instructions in the Prerequisities section.
+
+Clone the [kuadrant-operator](https://github.com/Kuadrant/kuadrant-operator) repo:
+
+```bash
+CONTAINER_ENGINE=podman make local-setup
+```
+
+Deploy the observability stack, as per the instructions in https://github.com/Kuadrant/kuadrant-operator/blob/main/config/observability/README.md
+
+Create the Kuadrant resource:
+
+```bash
+kubectl create -f ./config/samples/kuadrant_v1beta1_kuadrant.yaml -n kuadrant-system
+```
+
+Create a ClusterIssuer:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned-issuer
+spec:
+  selfSigned: {}
+EOF
+```
+
+Port forward to prometheus:
+
+```bash
+kubectl -n monitoring port-forward svc/prometheus-k8s 9090:9090
+```
+
+Set env vars for prometheus:
+
+```bash
+export PROMETHEUS_URL="http://127.0.0.1:9090"
+export PROMETHEUS_TOKEN=""
+```
+
+Run kube-burner:
+
+```bash
+kube-burner init -c ./config.yaml --timeout 5m
+```


### PR DESCRIPTION
The config represents a scenario with:
- 1 Gateway & 1 HTTPRoute targeting the Gateway
- 1 TLSPolicy & 1 DNSPolicy targeting the Gateway
- 1 AuthPolicy & 1 RateLimitPolicy targeting the Gateway
- 1 AuthPolicy & 1 RateLimitPolicy targeting the HTTPRoute (thereby overwriting the 2 policies targeting the Gateway)
- a simple http app being exposed by the HTTPRoute

The kube-burner tool captures metrics from prometheus before and after the creation of these resources.
The resources are checked for specific status conditions before they are 'ready'.
After that, they are destroyed.
The metrics are then sent to an indexer (can be local flat files or elasticsearch/opensearch)

The readme has instructions for running the test against a local cluster with kuadrant installed, but can also be used against an ocp cluster. 