### PR TITLE
Change unsupported jwt library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ pytest-html = "*"
 dynaconf = "*"
 dnspython = "*"
 python-keycloak = ">=3.6"
-python-jose = "*"
+PyJWT = "*"
 lxml = "*"
 cryptography = "*"
 backoff = "*"
@@ -29,7 +29,6 @@ weakget = "*"
 mypy = "*"
 pylint = "*"
 types-PyYAML = "*"
-types-python-jose = "*"
 black = {version = "*", extras = ["d"]}
 
 


### PR DESCRIPTION
`python-jose` is no longer supported. Switch to `PyJWT` library. Also removes time-aware zone deprecation message.