### PR TITLE
Change the location of CatalogSource with Kuadrant

### DIFF
--- a/testsuite/capabilities.py
+++ b/testsuite/capabilities.py
@@ -34,7 +34,7 @@ def kuadrant_version():
         clusters.append(cluster2)
     versions = []
     for cluster in clusters:
-        project = cluster.change_project("openshift-marketplace")
+        project = cluster.change_project(settings["service_protection"]["system_project"])
         if not project.connected:
             break
         with project.context:


### PR DESCRIPTION
LOW PRIORITY

In the helm deployment of Kuadrant, the secret containing login credentials to Keycloack is located under different name and key.

To verify run some keycloack test on cluster witch has Kuadrant deployed with Helm:
```
make testsuite/tests/singlecluster/authorino/identity/auth/
```

Additionally the location of CatalogSource containing information about Kuadrant version has been moved https://github.com/Kuadrant/testsuite/pull/558/commits/6ea72cb85a05cf1d6bc3be78b3f343ddfb3f3392 reflects that now.