### PR TITLE
Fix reworded status in DNS/TLSPolicy

### DIFF
--- a/testsuite/tests/singlecluster/gateway/reconciliation/test_invalid_issuer_reference.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/test_invalid_issuer_reference.py
@@ -36,7 +36,7 @@ def test_wrong_issuer_type(request, gateway, blame, module_label):
         has_condition(
             "Accepted",
             "False",
-            "Unknown",
+            "Invalid",
             'invalid value "Gateway" for issuerRef.kind. Must be empty, "Issuer" or "ClusterIssuer"',
         ),
         timelimit=20,
@@ -61,6 +61,6 @@ def test_non_existing_issuer(request, gateway, cluster, blame, module_label):
     policy.commit()
 
     assert policy.wait_until(
-        has_condition("Accepted", "False", "Unknown", 'ClusterIssuer.cert-manager.io "does-not-exist" not found'),
+        has_condition("Accepted", "False", "Invalid", 'unable to find issuer'),
         timelimit=20,
     ), f"Policy did not reach expected status, instead it was: {policy.refresh().model.status.conditions}"


### PR DESCRIPTION
Fix failing tests due to changed wording of conditions.

To review run:
```
make testsuite/tests/singlecluster/gateway/reconciliation/test_invalid_issuer_reference.py
```