### PR TITLE
Update AuthPolicy to use filters instead of dynamicMetadata

### DIFF
--- a/testsuite/kuadrant/policy/authorization/auth_config.py
+++ b/testsuite/kuadrant/policy/authorization/auth_config.py
@@ -36,7 +36,7 @@ class AuthConfig(KubernetesObject):
     @cached_property
     def responses(self) -> ResponseSection:
         """Gives access to response settings"""
-        return ResponseSection(self, "response")
+        return ResponseSection(self, "response", "dynamicMetadata")
 
     @classmethod
     def create_instance(

--- a/testsuite/kuadrant/policy/authorization/auth_policy.py
+++ b/testsuite/kuadrant/policy/authorization/auth_policy.py
@@ -1,5 +1,6 @@
 """Module containing classes related to AuthPolicy"""
 
+from functools import cached_property
 from typing import Dict, TYPE_CHECKING
 
 from testsuite.gateway import Referencable
@@ -7,6 +8,7 @@ from testsuite.kubernetes import modify
 from testsuite.kubernetes.client import KubernetesClient
 from testsuite.utils import asdict
 from .auth_config import AuthConfig
+from .sections import ResponseSection
 from .. import Policy
 from . import Pattern
 
@@ -55,6 +57,11 @@ class AuthPolicy(Policy, AuthConfig):
         spec_section = self.spec_section
         self.spec_section = None
         return spec_section.setdefault("rules", {})
+
+    @cached_property
+    def responses(self) -> ResponseSection:
+        """Gives access to response settings"""
+        return ResponseSection(self, "response", "filters")
 
     @property
     def defaults(self):

--- a/testsuite/kuadrant/policy/authorization/sections.py
+++ b/testsuite/kuadrant/policy/authorization/sections.py
@@ -208,6 +208,10 @@ class ResponseSection(Section):
 
     SUCCESS_RESPONSE = Union[JsonResponse, PlainResponse, WristbandResponse]
 
+    def __init__(self, obj: "AuthConfig", section_name, data_key: Literal["filters", "dynamicMetadata"]):
+        super().__init__(obj, section_name)
+        self.data_key = data_key
+
     def add_simple(self, auth_json: str, name="simple", key="data", **common_features):
         """
         Add simple response to AuthConfig, used for configuring response for debugging purposes,
@@ -232,7 +236,7 @@ class ResponseSection(Section):
         This section is for items wrapped as Envoy Dynamic Metadata.
         """
 
-        success_dynamic_metadata = self.section.setdefault("success", {}).setdefault("filters", {})
+        success_dynamic_metadata = self.section.setdefault("success", {}).setdefault(self.data_key, {})
         asdict_value = asdict(value)
         add_common_features(asdict_value, **common_features)
         success_dynamic_metadata.update({name: asdict_value})


### PR DESCRIPTION
In https://github.com/Kuadrant/kuadrant-operator/pull/952 some renaming was done: `spec.rules.response.success.dynamicMetadata → spec.rules.response.success.filters`. This applies only for AuthPolicy, not for AuthConfigt