### PR TITLE
Make API Key auth look for all namespaces

### DIFF
--- a/testsuite/kuadrant/policy/authorization/sections.py
+++ b/testsuite/kuadrant/policy/authorization/sections.py
@@ -138,7 +138,7 @@ class IdentitySection(Section):
         name,
         selector: Selector,
         *,
-        all_namespaces: bool = False,
+        all_namespaces: bool = True,
         credentials: Credentials = None,
         **common_features,
     ):


### PR DESCRIPTION
For reason see: https://github.com/Kuadrant/testsuite/issues/579