### PR TITLE
Added brackets around the policy name

### DIFF
--- a/testsuite/gateway/gateway_api/gateway.py
+++ b/testsuite/gateway/gateway_api/gateway.py
@@ -78,7 +78,7 @@ class KuadrantGateway(KubernetesObject, Gateway):
                 f"kuadrant.io/{policy.kind(lowercase=False)}Affected",
                 "True",
                 "Accepted",
-                f"Object affected by {policy.kind(lowercase=False)} {policy.namespace()}/{policy.name()}",
+                f"Object affected by {policy.kind(lowercase=False)} [{policy.namespace()}/{policy.name()}]",
             ):
                 return True
         return False

--- a/testsuite/gateway/gateway_api/route.py
+++ b/testsuite/gateway/gateway_api/route.py
@@ -54,7 +54,7 @@ class HTTPRoute(KubernetesObject, GatewayRoute):
                         f"kuadrant.io/{policy.kind(lowercase=False)}Affected",
                         "True",
                         "Accepted",
-                        f"Object affected by {policy.kind(lowercase=False)} {policy.namespace()}/{policy.name()}",
+                        f"Object affected by {policy.kind(lowercase=False)} [{policy.namespace()}/{policy.name()}]",
                     ):
                         return True
         return False


### PR DESCRIPTION
Fixes multiple tests in D&O along with `testsuite/tests/singlecluster/gateway/reconciliation/test_affected_by.py`