### PR TITLE
Fix metadata tests

### DIFF
--- a/testsuite/tests/singlecluster/authorino/metadata/conftest.py
+++ b/testsuite/tests/singlecluster/authorino/metadata/conftest.py
@@ -6,16 +6,14 @@ from testsuite.kubernetes import KubernetesObject
 
 
 @pytest.fixture(scope="module")
-def create_client_secret(request, cluster):
+def create_client_secret(request, cluster, authorino):
     """Creates Client Secret, used by Authorino to start the authentication with the UMA registry"""
 
     def _create_secret(name, client_id, client_secret):
         model = {
             "apiVersion": "v1",
             "kind": "Secret",
-            "metadata": {
-                "name": name,
-            },
+            "metadata": {"name": name, "namespace": authorino.namespace()},
             "stringData": {"clientID": client_id, "clientSecret": client_secret},
             "type": "Opaque",
         }


### PR DESCRIPTION
AuthConfig is automatically created in the namespace of Authorino. So the secret needs to be created there as well.