### PR TITLE
Added apikey Auth and v1 updates to scale test policies

### DIFF
--- a/scale_test/config.yaml
+++ b/scale_test/config.yaml
@@ -17,8 +17,12 @@ metricsEndpoints:
       type: local
       metricsDirectory: ./metrics
 {{ end }}
-global: 
+global:
+{{ if .SKIP_CLEANUP }}
+  gc: false
+{{ else }}
   gc: true
+{{ end }}
 jobs: 
   - name: scale-test-preparations
     jobIterations: 1
@@ -44,6 +48,16 @@ jobs:
           KUADRANT_AWS_ACCESS_KEY_ID: "{{ .KUADRANT_AWS_ACCESS_KEY_ID }}"
           KUADRANT_AWS_REGION: "{{ .KUADRANT_AWS_REGION }}"
           KUADRANT_AWS_SECRET_ACCESS_KEY: "{{ .KUADRANT_AWS_SECRET_ACCESS_KEY }}"
+      - objectTemplate: ./person-secret.yaml
+        kind: Secret
+        replicas: 1
+        inputVars:
+          person: "alice"
+      - objectTemplate: ./person-secret.yaml
+        kind: Secret
+        replicas: 1
+        inputVars:
+          person: "bob"
   - name: scale-test-main
     jobIterations: 1
     qps: 1
@@ -122,6 +136,9 @@ jobs:
           LISTENER_NUM: "{{$LISTENER_NUM}}"
   {{- end }}
 {{- end }}
+{{ if .SKIP_CLEANUP }}
+# nothing to do if cleanup is skipped
+{{ else }}
   - name: scale-test-safe-dnspolicy-cleanup
     jobType: delete
     jobIterations: 1
@@ -132,3 +149,4 @@ jobs:
       - kind: DNSPolicy
         apiVersion: kuadrant.io/v1alpha1
         labelSelector: {kube-burner-job: scale-test-main}
+{{ end }}

--- a/scale_test/gw-auth-policy.yaml
+++ b/scale_test/gw-auth-policy.yaml
@@ -1,5 +1,5 @@
 {{- $GW_NUM := .GW_NUM }}
-apiVersion: kuadrant.io/v1beta3
+apiVersion: kuadrant.io/v1
 kind: AuthPolicy
 metadata:
   name: auth-policy-gw{{$GW_NUM}}-i{{ .Iteration }}

--- a/scale_test/gw-dns-policy.yaml
+++ b/scale_test/gw-dns-policy.yaml
@@ -1,5 +1,5 @@
 {{- $GW_NUM := .GW_NUM }}
-apiVersion: kuadrant.io/v1alpha1
+apiVersion: kuadrant.io/v1
 kind: DNSPolicy
 metadata:
   name: dns-policy-gw{{$GW_NUM}}-i{{ .Iteration }}

--- a/scale_test/gw-rlp.yaml
+++ b/scale_test/gw-rlp.yaml
@@ -1,5 +1,5 @@
 {{- $GW_NUM := .GW_NUM }}
-apiVersion: kuadrant.io/v1beta3
+apiVersion: kuadrant.io/v1
 kind: RateLimitPolicy
 metadata:
   name: rlp-gw{{$GW_NUM}}-i{{ .Iteration }}
@@ -13,6 +13,5 @@ spec:
   limits:
     "global":
       rates:
-      - limit: 5
-        duration: 10
-        unit: second
+      - limit: 3
+        window: "10s"

--- a/scale_test/gw-tls-policy.yaml
+++ b/scale_test/gw-tls-policy.yaml
@@ -1,5 +1,5 @@
 {{- $GW_NUM := .GW_NUM }}
-apiVersion: kuadrant.io/v1alpha1
+apiVersion: kuadrant.io/v1
 kind: TLSPolicy
 metadata:
   name: tls-policy-gw{{$GW_NUM}}-i{{ .Iteration }}

--- a/scale_test/gw.yaml
+++ b/scale_test/gw.yaml
@@ -16,7 +16,7 @@ spec:
   - allowedRoutes: 
       namespaces: 
         from: All
-    hostname: "*.scale-test-gw{{$GW_NUM}}-l{{ $LISTENER_NUM }}-i{{$Iteration}}.{{ $KUADRANT_ZONE_ROOT_DOMAIN }}"
+    hostname: "api.scale-test-gw{{$GW_NUM}}-l{{$LISTENER_NUM}}-i{{$Iteration}}.{{$KUADRANT_ZONE_ROOT_DOMAIN}}"
     name: api-{{ $LISTENER_NUM }}
     port: 443
     protocol: HTTPS

--- a/scale_test/httproute-auth-policy.yaml
+++ b/scale_test/httproute-auth-policy.yaml
@@ -1,6 +1,6 @@
 {{- $GW_NUM := .GW_NUM }}
 {{- $LISTENER_NUM := .LISTENER_NUM }}
-apiVersion: kuadrant.io/v1beta3
+apiVersion: kuadrant.io/v1
 kind: AuthPolicy
 metadata:
   name: httproute-auth-policy-gw{{$GW_NUM}}-l{{$LISTENER_NUM}}-i{{ .Iteration }}
@@ -16,3 +16,21 @@ spec:
       allow-all:
         opa:
           rego: "allow = true"
+    authentication:
+      "api-key-users":
+        apiKey:
+          allNamespaces: true
+          selector:
+            matchLabels:
+              app: scale-test
+        credentials:
+          authorizationHeader:
+            prefix: APIKEY
+    response:
+      success:
+        filters:
+          "identity":
+            json:
+              properties:
+                "userid":
+                  selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id

--- a/scale_test/httproute-rlp.yaml
+++ b/scale_test/httproute-rlp.yaml
@@ -1,6 +1,6 @@
 {{- $GW_NUM := .GW_NUM }}
 {{- $LISTENER_NUM := .LISTENER_NUM }}
-apiVersion: kuadrant.io/v1beta3
+apiVersion: kuadrant.io/v1
 kind: RateLimitPolicy
 metadata:
   name: httproute-rlp-gw{{$GW_NUM}}-l{{$LISTENER_NUM}}-i{{ .Iteration }}
@@ -14,6 +14,5 @@ spec:
   limits:
     "httproute-level":
       rates:
-      - limit: 10
-        duration: 10
-        unit: second
+      - limit: 5
+        window: "10s"

--- a/scale_test/httproute.yaml
+++ b/scale_test/httproute.yaml
@@ -1,3 +1,5 @@
+{{- $Iteration := .Iteration }}
+{{- $KUADRANT_ZONE_ROOT_DOMAIN := .KUADRANT_ZONE_ROOT_DOMAIN }}
 {{- $GW_NUM := .GW_NUM }}
 {{- $LISTENER_NUM := .LISTENER_NUM }}
 apiVersion: gateway.networking.k8s.io/v1
@@ -12,7 +14,7 @@ spec:
     kind: Gateway
     name: gw{{$GW_NUM}}-i{{ .Iteration }}
   hostnames:
-  - "api.scale-test-gw{{$GW_NUM}}-l{{$LISTENER_NUM}}-i{{.Iteration}}.{{ .KUADRANT_ZONE_ROOT_DOMAIN }}"
+  - "api.scale-test-gw{{$GW_NUM}}-l{{$LISTENER_NUM}}-i{{$Iteration}}.{{$KUADRANT_ZONE_ROOT_DOMAIN}}"
   rules:
   - backendRefs:
     - group: ''

--- a/scale_test/person-secret.yaml
+++ b/scale_test/person-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{.person}}-key
+  labels:
+    authorino.kuadrant.io/managed-by: authorino
+    app: scale-test
+  annotations:
+    secret.kuadrant.io/user-id: {{.person}}
+stringData:
+  api_key: iam{{.person}}
+type: Opaque


### PR DESCRIPTION
## Overview

- SKIP_CLEANUP env var to skip cleanup and update readme accordingly
- Using APIKEY Auth in HTTPRoute AuthPolicies
- Necessary policy template updates required to support v1 - there were breaking changes there since v0.11
- Small change to hostname as a prep for potential addition of DNS health check - it does not support wildcards (asterisk)


## Verification Steps

Follow the readme, skip cleanup and try the curl commands as described. Then delete DNSPolcies and delete the remaining stuff via kube-burner destroy command.

Note: this only works with nightly build (November 15 and later), does not work with v1 rc4 due to https://github.com/Kuadrant/kuadrant-operator/issues/990