### PR TITLE
Use sectionName in scale test

### DIFF
--- a/scale_test/config.yaml
+++ b/scale_test/config.yaml
@@ -62,7 +62,7 @@ jobs:
     jobIterations: 1
     qps: 1
     burst: 1
-    jobPause: 2m
+    jobPause: 3m
     namespacedIterations: true
     namespace: scale-test
     waitWhenFinished: true
@@ -144,6 +144,7 @@ jobs:
     jobIterations: 1
     namespacedIterations: true
     namespace: scale-test
+    jobPause: 2m # to allow DNSRecords to be removed
     waitWhenFinished: true
     objects:
       - kind: DNSPolicy

--- a/scale_test/httproute.yaml
+++ b/scale_test/httproute.yaml
@@ -13,6 +13,7 @@ spec:
   - group: gateway.networking.k8s.io
     kind: Gateway
     name: gw{{$GW_NUM}}-i{{ .Iteration }}
+    sectionName: api-{{$LISTENER_NUM}}
   hostnames:
   - "api.scale-test-gw{{$GW_NUM}}-l{{$LISTENER_NUM}}-i{{$Iteration}}.{{$KUADRANT_ZONE_ROOT_DOMAIN}}"
   rules:


### PR DESCRIPTION
Use sectionName in scale test so that there are not "invalid path" log entries in kuadrant operator log. Also slightly increased pause to wait after everything was done. And added pause to allow for DNSRecords to get properly removed.

## Verification Steps

Run the scale test as described in readme. You can skip the cleanup to inspect manually that it works.