### PR TITLE
Update .gitignore to ignore .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 logs/*
 !logs/.gitkeep
+
+# macOS system files
+.DS_Store


### PR DESCRIPTION
This PR updates the .gitignore file to exclude .DS_Store files, which are macOS-specific metadata files that are not needed in the repository. 