### PR TITLE
Add tests for changing targetRef field in policies

### DIFF
--- a/testsuite/httpx/__init__.py
+++ b/testsuite/httpx/__init__.py
@@ -59,7 +59,11 @@ class Result:
 
     def has_dns_error(self):
         """True, if the result failed due to DNS failure"""
-        return self.has_error("Name or service not known") or self.has_error("No address associated with hostname")
+        return (
+            self.has_error("nodename nor servname provided, or not known")
+            or self.has_error("Name or service not known")
+            or self.has_error("No address associated with hostname")
+        )
 
     def has_cert_verify_error(self):
         """True, if the result failed due to TLS certificate verification failure"""

--- a/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_authpolicy_target_ref.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_authpolicy_target_ref.py
@@ -4,11 +4,21 @@ Test for changing targetRef field in AuthPolicy
 
 import pytest
 
-pytestmark = [pytest.mark.kuadrant_only, pytest.mark.dnspolicy]
+from testsuite.kuadrant.policy.authorization.auth_policy import AuthPolicy
+
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.authorino, pytest.mark.dnspolicy]
+
+
+@pytest.fixture(scope="module")
+def authorization(oidc_provider, gateway, cluster, blame, module_label, route):  # pylint: disable=unused-argument
+    """Overwrite the authorization fixture and attach it to the gateway"""
+    policy = AuthPolicy.create_instance(cluster, blame("authz"), gateway, labels={"testRun": module_label})
+    policy.identity.add_oidc("default", oidc_provider.well_known["issuer"])
+    return policy
 
 
 def test_update_auth_policy_target_ref(
-    gateway2, authorization, client, client2, auth, dns_policy, dns_policy2, change_target_ref
+    route2, gateway2, authorization, client, client2, auth, dns_policy, dns_policy2, change_target_ref
 ):  # pylint: disable=unused-argument
     """Test updating the targetRef of an AuthPolicy from Gateway 1 to Gateway 2"""
     response = client.get("/get", auth=auth)
@@ -27,3 +37,6 @@ def test_update_auth_policy_target_ref(
 
     response = client2.get("/get")
     assert response.status_code == 401
+
+    response = client.get("/get")
+    assert response.status_code == 200

--- a/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_dnspolicy_target_ref.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_dnspolicy_target_ref.py
@@ -1,0 +1,42 @@
+"""
+Test for changing targetRef field in DNSPolicy
+"""
+
+from time import sleep
+import pytest
+
+from testsuite.gateway import GatewayListener
+
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.dnspolicy]
+
+
+def test_update_dns_policy_target_ref(
+    gateway, gateway2, client, client2, dns_policy, change_target_ref
+):  # pylint: disable=unused-argument
+    """Test updating the targetRef of DNSPolicy from Gateway 1 to Gateway 2"""
+    assert gateway.refresh().is_affected_by(dns_policy)
+    assert not gateway2.refresh().is_affected_by(dns_policy)
+
+    response = client.get("/get")
+    assert not response.has_dns_error()
+    assert response.status_code == 200
+
+    response = client2.get("/get")
+    assert response.has_dns_error()
+
+    dns_ttl = gateway.get_listener_dns_ttl(GatewayListener.name)
+
+    change_target_ref(dns_policy, gateway2)
+
+    # Wait for records deletion/ttl expiration from the previous request
+    sleep(dns_ttl)
+
+    assert not gateway.refresh().is_affected_by(dns_policy)
+    assert gateway2.refresh().is_affected_by(dns_policy)
+
+    response = client2.get("/get")
+    assert not response.has_dns_error()
+    assert response.status_code == 200
+
+    response = client.get("/get")
+    assert response.has_dns_error()

--- a/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_ratelimitpolicy_target_ref.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_ratelimitpolicy_target_ref.py
@@ -6,16 +6,7 @@ import pytest
 
 from testsuite.kuadrant.policy.rate_limit import Limit, RateLimitPolicy
 
-pytestmark = [pytest.mark.kuadrant_only, pytest.mark.dnspolicy]
-
-
-@pytest.fixture(scope="module")
-def authorization():
-    """
-    Override the authorization fixture to prevent the creation of an AuthPolicy.
-    This ensures no authentication is enforced during the test
-    """
-    return None
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.dnspolicy, pytest.mark.limitador]
 
 
 @pytest.fixture(scope="module")
@@ -27,7 +18,7 @@ def rate_limit(cluster, blame, module_label, gateway, route):  # pylint: disable
 
 
 def test_update_ratelimit_policy_target_ref(
-    gateway2, rate_limit, client, client2, dns_policy, dns_policy2, change_target_ref
+    route2, gateway2, rate_limit, client, client2, dns_policy, dns_policy2, change_target_ref
 ):  # pylint: disable=unused-argument
     """Test updating the targetRef of a RateLimitPolicy from Gateway 1 to Gateway 2"""
     responses = client.get_many("/get", 2)
@@ -42,3 +33,6 @@ def test_update_ratelimit_policy_target_ref(
     responses = client2.get_many("/get", 2)
     responses.assert_all(status_code=200)
     assert client2.get("/get").status_code == 429
+
+    responses = client.get_many("/get", 3)
+    responses.assert_all(status_code=200)

--- a/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_tlspolicy_target_ref.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_tlspolicy_target_ref.py
@@ -1,0 +1,87 @@
+"""
+Test for changing targetRef field in TLSPolicy
+"""
+
+import pytest
+
+from testsuite.gateway import TLSGatewayListener
+from testsuite.gateway.gateway_api.gateway import KuadrantGateway
+from testsuite.gateway.gateway_api.hostname import StaticHostname
+from testsuite.httpx import KuadrantClient
+
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.dnspolicy, pytest.mark.tlspolicy]
+
+
+@pytest.fixture(scope="module")
+def gateway(request, cluster, blame, wildcard_domain, module_label):
+    """Create Gateway 1 with TLSGatewayListener"""
+    gateway_name = blame("gw")
+    gw = KuadrantGateway.create_instance(
+        cluster,
+        gateway_name,
+        {"app": module_label},
+    )
+    gw.add_listener(TLSGatewayListener(hostname=wildcard_domain, gateway_name=gateway_name))
+    request.addfinalizer(gw.delete)
+    gw.commit()
+    gw.wait_for_ready()
+    return gw
+
+
+@pytest.fixture(scope="module")
+def gateway2(request, cluster, blame, wildcard_domain2, module_label):
+    """Create Gateway 2 with TLSGatewayListener"""
+    gateway_name = blame("gw2")
+    gw = KuadrantGateway.create_instance(
+        cluster,
+        gateway_name,
+        {"app": module_label},
+    )
+    gw.add_listener(TLSGatewayListener(hostname=wildcard_domain2, gateway_name=gateway_name))
+    request.addfinalizer(gw.delete)
+    gw.commit()
+    gw.wait_for_ready()
+    return gw
+
+
+@pytest.fixture(scope="module")
+def custom_client():
+    """
+    Provides a client for both gateway's to avoid secret and cert errors
+    """
+
+    def _client_new(hostname: str, gateway_instance: KuadrantGateway):
+        return StaticHostname(hostname, gateway_instance.get_tls_cert).client()
+
+    return _client_new
+
+
+def test_update_tls_policy_target_ref(
+    tls_policy, gateway, gateway2, dns_policy, dns_policy2, change_target_ref, custom_client, hostname, hostname2
+):  # pylint: disable=unused-argument
+    """Test updating the targetRef of TLSPolicy from Gateway 1 to Gateway 2"""
+    assert gateway.refresh().is_affected_by(tls_policy)
+    assert not gateway2.refresh().is_affected_by(tls_policy)
+
+    response = custom_client(hostname.hostname, gateway).get("/get")
+    assert not response.has_cert_verify_error()
+    assert response.status_code == 200
+
+    response = KuadrantClient(base_url=f"https://{hostname2.hostname}", verify=False).get("/get")
+    assert response.has_error("[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol")
+
+    change_target_ref(tls_policy, gateway2)
+
+    assert not gateway.refresh().is_affected_by(tls_policy)
+    assert gateway2.refresh().is_affected_by(tls_policy)
+
+    response = custom_client(hostname2.hostname, gateway2).get("/get")
+    assert not response.has_cert_verify_error()
+    assert response.status_code == 200
+
+    # Delete TLS secret to verify gateway1 no longer serves valid TLS traffic
+    tls_secret = gateway.get_tls_secret(hostname.hostname)
+    tls_secret.delete()
+
+    response = KuadrantClient(base_url=f"https://{hostname.hostname}", verify=False).get("/get")
+    assert response.has_error("[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol")


### PR DESCRIPTION
**Summary**
This PR adds reconciliation tests focusing on targetRef updates across different policies. 

**Test Cases Covered**
* DNSPolicy: Verifies DNS records are updated accordingly when changing `targetRef` from Gateway 1 (hostname 1) to Gateway 2 (hostname 2).
* TLSPolicy: Verifies TLS records are updated accordingly when changing `targetRef` from Gateway 1 (hostname 1) to Gateway 2 (hostname 2).
* AuthPolicy and RateLimitPolicy were covered in PR #622), but were slightly modified in this PR.

**Related Issue**
Closes [#307](https://github.com/Kuadrant/testsuite/issues/307)