### PR TITLE
Add re-raise for dinosaur tests

### DIFF
--- a/testsuite/tests/singlecluster/authorino/dinosaur/conftest.py
+++ b/testsuite/tests/singlecluster/authorino/dinosaur/conftest.py
@@ -47,6 +47,7 @@ def commit(request, authorization):
     except OpenShiftPythonException as exc:
         if "Too many" in exc.result.err():
             pytest.xfail("AuthPolicy max limit")
+        raise exc
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Description
Missing re-reaise will cause test fails in case AuthConfig/Policy was not created instead of error in creation.
<!--
Provide other information that might make life easier for the reviewer:
* Context - link to discussions,log snippet of failed test this will fix, etc
* If this PR is linked to an issue, mention it (e.g., Fixes #123)
* Verification Steps
-->
## Verification
Eye review is enough in my opinion. 

