### PR TITLE
Add assertions to apply() and modify_and_apply() methods

### DIFF
--- a/testsuite/kubernetes/__init__.py
+++ b/testsuite/kubernetes/__init__.py
@@ -34,6 +34,23 @@ class KubernetesObject(APIObject, LifecycleObject):
         self._committed = True
         return self.refresh()
 
+    def apply(self, *args, **kwargs):
+        """
+        Overrides apply() to fail with assertion error if unsuccessful
+        """
+        result = super().apply(*args, **kwargs)
+        assert result.status() == 0, f"Apply returned non-zero exit code for {self.kind()} {self.name()}"
+        return result
+
+    def modify_and_apply(self, *args, **kwargs):
+        """
+        Overrides modify_and_apply() to fail with assertion error if unsuccessful
+        """
+        result, applied_change = super().modify_and_apply(*args, **kwargs)
+        assert applied_change, f"Modify and apply failed for {self.kind()} {self.name()} with result: {result}"
+        assert result.status() == 0, f"Modify and apply returned non-zero exit code for {self.kind()} {self.name()}"
+        return result, applied_change
+
     def delete(self, ignore_not_found=True, cmd_args=None):
         """Deletes the resource, by default ignored not found"""
         with timeout(30):


### PR DESCRIPTION
**Summary**
This PR adds assertions to the `.apply()` and `.modify_and_apply()` methods to ensure errors are raised when resource updates fail, preventing silent failures.

**Description of changes**
Following solution (b) from issue #631, the `.apply()` and `.modify_and_apply()` methods have been overridden in `KubernetesObject` to raise an assertion error when:

- A change was expected but not applied (i.e. no modification occurred)
- The apply command itself failed (returned a non-zero exit code)

**Related Issue**
Closes [#631](https://github.com/Kuadrant/testsuite/issues/631)
