### PR TITLE
Fix missing existance check in CEL predicate

### DIFF
--- a/testsuite/tests/singlecluster/authorino/conditions/test_top_level_condition.py
+++ b/testsuite/tests/singlecluster/authorino/conditions/test_top_level_condition.py
@@ -10,7 +10,7 @@ pytestmark = [pytest.mark.authorino]
 @pytest.fixture(scope="module")
 def authorization(authorization, module_label):
     """Add rule to the AuthConfig to skip entire authn/authz with certain request header"""
-    authorization.add_rule([CelPredicate(f"request.headers.key != '{module_label}'")])
+    authorization.add_rule([CelPredicate(f"!(has(request.headers.key) && request.headers.key == '{module_label}')")])
     return authorization
 
 


### PR DESCRIPTION
## Description
Probably when CEL predicate was introduced to AuthConfig the way non-existing values were handled changed. Before if predicate did not find the value it would return false, now it returns true. To fix the test I added `has()` test which checks if the value is present.

This fixes one the common fail defined in #626

## Verification
Run affected test:
```sh
flags=--standalone make testsuite/tests/singlecluster/authorino/conditions/test_top_level_condition.py
```
<!-- Provide a brief description of the changes in this pull request -->
<!--
Provide other information that might make life easier for the reviewer:
* Context - link to discussions,log snippet of failed test this will fix, etc
* If this PR is linked to an issue, mention it (e.g., Fixes #123)
* Verification Steps
-->

