### PR TITLE
Update .gitignore to ignore Google Drive upload temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,7 @@ logs/*
 
 # macOS system files
 .DS_Store
+
+# Ignore temporary Drive upload files
+*.tmp.driveupload
+


### PR DESCRIPTION
This PR updates .gitignore to ignore Google Drive upload temp files.