### PR TITLE
Change the listener hostname directly - fix test_change_listener test

### DIFF
--- a/testsuite/tests/singlecluster/gateway/reconciliation/listeners/test_gateway_listeners_dns.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/listeners/test_gateway_listeners_dns.py
@@ -21,11 +21,9 @@ def test_change_listener(custom_client, check_ok_https, gateway, route, second_d
     check_ok_https(wildcard_domain)
     wildcard_domain_ttl = gateway.get_listener_dns_ttl(DEFAULT_LISTENER_NAME)
 
-    gateway.remove_listener(DEFAULT_LISTENER_NAME)
+    gateway.refresh().model.spec.listeners[0].hostname = second_domain
+    gateway.apply()
     route.remove_hostname(wildcard_domain)
-    gateway.add_listener(
-        TLSGatewayListener(hostname=second_domain, gateway_name=gateway.name(), name=DEFAULT_LISTENER_NAME)
-    )
     route.add_hostname(second_domain)
 
     sleep(wildcard_domain_ttl)


### PR DESCRIPTION
## Description
Gateway cant have 0 listeners. This change wont change the test case as this is what I wanted to test in the first place. ie. Changing the hostname of the single listener.
<!-- Provide a brief description of the changes in this pull request -->
<!--
Provide other information that might make life easier for the reviewer:
* Context - link to discussions,log snippet of failed test this will fix, etc
* If this PR is linked to an issue, mention it (e.g., Fixes #123)
* Verification Steps
-->
## Verification steps
Run the test
```sh
make testsuite/tests/singlecluster/gateway/reconciliation/listeners/test_gateway_listeners_dns.py
```
