### PR TITLE
Collision tests for policies.

### DIFF
--- a/testsuite/tests/singlecluster/authorino/collisions/auth_policy/test_collisions.py
+++ b/testsuite/tests/singlecluster/authorino/collisions/auth_policy/test_collisions.py
@@ -1,13 +1,17 @@
+"""Test auth policies collisions when attached to the same target"""
+
 import pytest
 
 from testsuite.httpx.auth import HeaderApiKeyAuth
 from testsuite.kuadrant.policy import has_condition
 from testsuite.kuadrant.policy.authorization.auth_policy import AuthPolicy
 
+
 @pytest.fixture(scope="module")
 def api_key(create_api_key, module_label):
     """Creates API key Secret."""
     return create_api_key("api-key", module_label, "api_key_value")
+
 
 # pylint: disable = unused-argument
 @pytest.fixture(scope="module")
@@ -19,6 +23,7 @@ def authorization(request, cluster, blame, module_label, route, label, oidc_prov
     auth.identity.add_oidc("first", oidc_provider.well_known["issuer"])
     return auth
 
+
 @pytest.fixture(scope="module")
 def authorization2(request, cluster, blame, module_label, route, label, api_key):
     """Create a RateLimitPolicy with a basic limit with target coming from test parameter"""
@@ -27,6 +32,7 @@ def authorization2(request, cluster, blame, module_label, route, label, api_key)
     auth = AuthPolicy.create_instance(cluster, blame("sp"), target_ref, labels={"testRun": label})
     auth.identity.add_api_key("second", selector=api_key.selector)
     return auth
+
 
 @pytest.fixture(scope="module")
 def auth2(api_key):
@@ -42,16 +48,10 @@ def commit(request, authorization, authorization2):
         policy.commit()
         policy.wait_for_ready()
 
+
 @pytest.mark.parametrize("authorization", ["gateway", "route"], indirect=True)
-def test_collision(client, authorization, authorization2, auth, auth2):
+def test_collision_auth_policy(client, authorization, authorization2, auth, auth2):
     """Test first policy is being overridden when another policy with the same target is created."""
-    assert authorization.wait_until(
-        has_condition(
-            "Enforced",
-            "False",
-            "Overridden",
-            "AuthPolicy is overridden"
-        )
-    )
+    assert authorization.wait_until(has_condition("Enforced", "False", "Overridden", "AuthPolicy is overridden"))
     assert client.get("/get", auth=auth).status_code == 401
     assert client.get("/get", auth=auth2).status_code == 200

--- a/testsuite/tests/singlecluster/authorino/collisions/auth_policy/test_collisions.py
+++ b/testsuite/tests/singlecluster/authorino/collisions/auth_policy/test_collisions.py
@@ -1,0 +1,57 @@
+import pytest
+
+from testsuite.httpx.auth import HeaderApiKeyAuth
+from testsuite.kuadrant.policy import has_condition
+from testsuite.kuadrant.policy.authorization.auth_policy import AuthPolicy
+
+@pytest.fixture(scope="module")
+def api_key(create_api_key, module_label):
+    """Creates API key Secret."""
+    return create_api_key("api-key", module_label, "api_key_value")
+
+# pylint: disable = unused-argument
+@pytest.fixture(scope="module")
+def authorization(request, cluster, blame, module_label, route, label, oidc_provider):
+    """Create a RateLimitPolicy with a basic limit with target coming from test parameter"""
+    target_ref = request.getfixturevalue(getattr(request, "param", "route"))
+
+    auth = AuthPolicy.create_instance(cluster, blame("fp"), target_ref, labels={"testRun": label})
+    auth.identity.add_oidc("first", oidc_provider.well_known["issuer"])
+    return auth
+
+@pytest.fixture(scope="module")
+def authorization2(request, cluster, blame, module_label, route, label, api_key):
+    """Create a RateLimitPolicy with a basic limit with target coming from test parameter"""
+    target_ref = request.getfixturevalue(getattr(request, "param", "route"))
+
+    auth = AuthPolicy.create_instance(cluster, blame("sp"), target_ref, labels={"testRun": label})
+    auth.identity.add_api_key("second", selector=api_key.selector)
+    return auth
+
+@pytest.fixture(scope="module")
+def auth2(api_key):
+    """API key Auth"""
+    return HeaderApiKeyAuth(api_key)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def commit(request, authorization, authorization2):
+    """Commits AuthPolicy after the target is created"""
+    for policy in [authorization, authorization2]:  # Forcing order of creation.
+        request.addfinalizer(policy.delete)
+        policy.commit()
+        policy.wait_for_ready()
+
+@pytest.mark.parametrize("authorization", ["gateway", "route"], indirect=True)
+def test_collision(client, authorization, authorization2, auth, auth2):
+    """Test first policy is being overridden when another policy with the same target is created."""
+    assert authorization.wait_until(
+        has_condition(
+            "Enforced",
+            "False",
+            "Overridden",
+            "AuthPolicy is overridden"
+        )
+    )
+    assert client.get("/get", auth=auth).status_code == 401
+    assert client.get("/get", auth=auth2).status_code == 200

--- a/testsuite/tests/singlecluster/authorino/collisions/rate_limit/test_collisions.py
+++ b/testsuite/tests/singlecluster/authorino/collisions/rate_limit/test_collisions.py
@@ -1,12 +1,13 @@
+"""Test rate limit policies collisions when attached to the same target"""
+
 import pytest
 
-from testsuite.httpx.auth import HeaderApiKeyAuth
 from testsuite.kuadrant.policy import has_condition, CelPredicate
-from testsuite.kuadrant.policy.authorization.auth_policy import AuthPolicy
 from testsuite.kuadrant.policy.rate_limit import Limit, RateLimitPolicy
 
 FIRST_LIMIT = Limit(3, "5s")
 SECOND_LIMIT = Limit(6, "5s")
+
 
 # pylint: disable = unused-argument
 @pytest.fixture(scope="module")
@@ -17,6 +18,7 @@ def rate_limit(request, cluster, blame, module_label, route, label):
     rate_limit = RateLimitPolicy.create_instance(cluster, blame("fp"), target_ref, labels={"testRun": module_label})
     rate_limit.add_limit("first", [FIRST_LIMIT], when=[CelPredicate("request.path == '/get'")])
     return rate_limit
+
 
 @pytest.fixture(scope="module")
 def rate_limit2(request, cluster, blame, module_label, route, label):
@@ -36,17 +38,11 @@ def commit(request, rate_limit, rate_limit2):
         policy.commit()
         policy.wait_for_ready()
 
+
 @pytest.mark.parametrize("rate_limit", ["gateway", "route"], indirect=True)
-def test_collision(client, rate_limit, rate_limit2):
+def test_collision_rate_limit(client, rate_limit, rate_limit2):
     """Test first policy is being overridden when another policy with the same target is created."""
-    assert rate_limit.wait_until(
-        has_condition(
-            "Enforced",
-            "False",
-            "Overridden",
-            "RateLimitPolicy is overridden"
-        )
-    )
+    assert rate_limit.wait_until(has_condition("Enforced", "False", "Overridden", "RateLimitPolicy is overridden"))
     responses = client.get_many("/get", FIRST_LIMIT.limit)
     responses.assert_all(status_code=200)
     assert client.get("/get").status_code == 200

--- a/testsuite/tests/singlecluster/authorino/collisions/rate_limit/test_collisions.py
+++ b/testsuite/tests/singlecluster/authorino/collisions/rate_limit/test_collisions.py
@@ -1,0 +1,56 @@
+import pytest
+
+from testsuite.httpx.auth import HeaderApiKeyAuth
+from testsuite.kuadrant.policy import has_condition, CelPredicate
+from testsuite.kuadrant.policy.authorization.auth_policy import AuthPolicy
+from testsuite.kuadrant.policy.rate_limit import Limit, RateLimitPolicy
+
+FIRST_LIMIT = Limit(3, "5s")
+SECOND_LIMIT = Limit(6, "5s")
+
+# pylint: disable = unused-argument
+@pytest.fixture(scope="module")
+def rate_limit(request, cluster, blame, module_label, route, label):
+    """Create a RateLimitPolicy with a basic limit with target coming from test parameter"""
+    target_ref = request.getfixturevalue(getattr(request, "param", "route"))
+
+    rate_limit = RateLimitPolicy.create_instance(cluster, blame("fp"), target_ref, labels={"testRun": module_label})
+    rate_limit.add_limit("first", [FIRST_LIMIT], when=[CelPredicate("request.path == '/get'")])
+    return rate_limit
+
+@pytest.fixture(scope="module")
+def rate_limit2(request, cluster, blame, module_label, route, label):
+    """Create a RateLimitPolicy with a basic limit with target coming from test parameter"""
+    target_ref = request.getfixturevalue(getattr(request, "param", "route"))
+
+    rate_limit = RateLimitPolicy.create_instance(cluster, blame("sp"), target_ref, labels={"testRun": module_label})
+    rate_limit.add_limit("second", [SECOND_LIMIT], when=[CelPredicate("request.path == '/anything'")])
+    return rate_limit
+
+
+@pytest.fixture(scope="module", autouse=True)
+def commit(request, rate_limit, rate_limit2):
+    """Commits RateLimitPolicy after the target is created"""
+    for policy in [rate_limit, rate_limit2]:  # Forcing order of creation.
+        request.addfinalizer(policy.delete)
+        policy.commit()
+        policy.wait_for_ready()
+
+@pytest.mark.parametrize("rate_limit", ["gateway", "route"], indirect=True)
+def test_collision(client, rate_limit, rate_limit2):
+    """Test first policy is being overridden when another policy with the same target is created."""
+    assert rate_limit.wait_until(
+        has_condition(
+            "Enforced",
+            "False",
+            "Overridden",
+            "RateLimitPolicy is overridden"
+        )
+    )
+    responses = client.get_many("/get", FIRST_LIMIT.limit)
+    responses.assert_all(status_code=200)
+    assert client.get("/get").status_code == 200
+
+    responses = client.get_many("/anything", SECOND_LIMIT.limit)
+    responses.assert_all(status_code=200)
+    assert client.get("/anything").status_code == 429

--- a/testsuite/tests/singlecluster/authorino/collisions/test_collisions.py
+++ b/testsuite/tests/singlecluster/authorino/collisions/test_collisions.py
@@ -6,6 +6,8 @@ from testsuite.httpx.auth import HeaderApiKeyAuth
 from testsuite.kuadrant.policy import has_condition
 from testsuite.kuadrant.policy.authorization.auth_policy import AuthPolicy
 
+pytestmark = [pytest.mark.authorino]
+
 
 @pytest.fixture(scope="module")
 def api_key(create_api_key, module_label):
@@ -48,10 +50,11 @@ def commit(request, authorization, authorization2):
         policy.wait_for_ready()
 
 
-@pytest.mark.parametrize("authorization, authorization2", [
-    pytest.param("gateway", "gateway", id="gateway"),
-    pytest.param("route", "route", id="route")
-], indirect=True)
+@pytest.mark.parametrize(
+    "authorization, authorization2",
+    [pytest.param("gateway", "gateway", id="gateway"), pytest.param("route", "route", id="route")],
+    indirect=True,
+)
 def test_collision_auth_policy(client, authorization, authorization2, auth, auth2):
     """Test first policy is being overridden when another policy with the same target is created."""
     assert authorization.wait_until(has_condition("Enforced", "False", "Overridden", "AuthPolicy is overridden"))

--- a/testsuite/tests/singlecluster/authorino/collisions/test_collisions.py
+++ b/testsuite/tests/singlecluster/authorino/collisions/test_collisions.py
@@ -16,7 +16,7 @@ def api_key(create_api_key, module_label):
 
 
 @pytest.fixture(scope="module")
-def authorization(request, cluster, blame, module_label, route, label, oidc_provider):
+def authorization(request, cluster, blame, route, label, oidc_provider):  # pylint: disable=unused-argument
     """Create a AuthPolicy with route as target reference"""
     target_ref = request.getfixturevalue(getattr(request, "param", "route"))
 
@@ -26,7 +26,7 @@ def authorization(request, cluster, blame, module_label, route, label, oidc_prov
 
 
 @pytest.fixture(scope="module")
-def authorization2(request, cluster, blame, module_label, route, label, api_key):
+def authorization2(request, cluster, blame, route, label, api_key):  # pylint: disable=unused-argument
     """Create a AuthPolicy with route as target reference"""
     target_ref = request.getfixturevalue(getattr(request, "param", "route"))
 
@@ -55,7 +55,7 @@ def commit(request, authorization, authorization2):
     [pytest.param("gateway", "gateway", id="gateway"), pytest.param("route", "route", id="route")],
     indirect=True,
 )
-def test_collision_auth_policy(client, authorization, authorization2, auth, auth2):
+def test_collision_auth_policy(client, authorization, auth, auth2):
     """Test first policy is being overridden when another policy with the same target is created."""
     assert authorization.wait_until(has_condition("Enforced", "False", "Overridden", "AuthPolicy is overridden"))
     assert client.get("/get", auth=auth).status_code == 401

--- a/testsuite/tests/singlecluster/authorino/collisions/test_collisions.py
+++ b/testsuite/tests/singlecluster/authorino/collisions/test_collisions.py
@@ -22,7 +22,9 @@ def target(request):
 
 
 @pytest.fixture(scope="module")
-def authorization(request, cluster, blame, target, label, oidc_provider):  # pylint: disable=unused-argument
+def authorization(
+    request, gateway, route, cluster, blame, target, label, oidc_provider
+):  # pylint: disable=unused-argument
     """Create an AuthPolicy with either gateway or route as target reference"""
     auth = AuthPolicy.create_instance(cluster, blame("fp"), target, labels={"testRun": label})
     auth.identity.add_oidc("first", oidc_provider.well_known["issuer"])

--- a/testsuite/tests/singlecluster/authorino/collisions/test_collisions.py
+++ b/testsuite/tests/singlecluster/authorino/collisions/test_collisions.py
@@ -17,7 +17,7 @@ def api_key(create_api_key, module_label):
 
 @pytest.fixture(scope="module")
 def authorization(request, cluster, blame, route, label, oidc_provider):  # pylint: disable=unused-argument
-    """Create a AuthPolicy with route as target reference"""
+    """Create an AuthPolicy with route as target reference"""
     target_ref = request.getfixturevalue(getattr(request, "param", "route"))
 
     auth = AuthPolicy.create_instance(cluster, blame("fp"), target_ref, labels={"testRun": label})
@@ -27,7 +27,7 @@ def authorization(request, cluster, blame, route, label, oidc_provider):  # pyli
 
 @pytest.fixture(scope="module")
 def authorization2(request, cluster, blame, route, label, api_key):  # pylint: disable=unused-argument
-    """Create a AuthPolicy with route as target reference"""
+    """Create an AuthPolicy with route as target reference"""
     target_ref = request.getfixturevalue(getattr(request, "param", "route"))
 
     auth = AuthPolicy.create_instance(cluster, blame("sp"), target_ref, labels={"testRun": label})
@@ -43,7 +43,7 @@ def auth2(api_key):
 
 @pytest.fixture(scope="module", autouse=True)
 def commit(request, authorization, authorization2):
-    """Commits AuthPolicy after the target is created"""
+    """Commits both AuthPolicies after the target is created"""
     for policy in [authorization, authorization2]:  # Forcing order of creation.
         request.addfinalizer(policy.delete)
         policy.commit()

--- a/testsuite/tests/singlecluster/limitador/collisions/test_collisions.py
+++ b/testsuite/tests/singlecluster/limitador/collisions/test_collisions.py
@@ -39,7 +39,10 @@ def commit(request, rate_limit, rate_limit2):
         policy.wait_for_ready()
 
 
-@pytest.mark.parametrize("rate_limit", ["gateway", "route"], indirect=True)
+@pytest.mark.parametrize("rate_limit, rate_limit2", [
+    pytest.param("gateway", "gateway", id="gateway"),
+    pytest.param("route", "route", id="route")
+], indirect=True)
 def test_collision_rate_limit(client, rate_limit, rate_limit2):
     """Test first policy is being overridden when another policy with the same target is created."""
     assert rate_limit.wait_until(has_condition("Enforced", "False", "Overridden", "RateLimitPolicy is overridden"))

--- a/testsuite/tests/singlecluster/limitador/collisions/test_collisions.py
+++ b/testsuite/tests/singlecluster/limitador/collisions/test_collisions.py
@@ -35,7 +35,7 @@ def rate_limit2(request, cluster, blame, module_label, route, label):
 
 @pytest.fixture(scope="module", autouse=True)
 def commit(request, rate_limit, rate_limit2):
-    """Commits RateLimitPolicy after the target is created"""
+    """Commits RateLimitPolicies after the target is created"""
     for policy in [rate_limit, rate_limit2]:  # Forcing order of creation.
         request.addfinalizer(policy.delete)
         policy.commit()

--- a/testsuite/tests/singlecluster/limitador/collisions/test_collisions.py
+++ b/testsuite/tests/singlecluster/limitador/collisions/test_collisions.py
@@ -5,8 +5,11 @@ import pytest
 from testsuite.kuadrant.policy import has_condition, CelPredicate
 from testsuite.kuadrant.policy.rate_limit import Limit, RateLimitPolicy
 
+
 FIRST_LIMIT = Limit(3, "5s")
 SECOND_LIMIT = Limit(6, "5s")
+
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.limitador]
 
 
 # pylint: disable = unused-argument
@@ -39,10 +42,11 @@ def commit(request, rate_limit, rate_limit2):
         policy.wait_for_ready()
 
 
-@pytest.mark.parametrize("rate_limit, rate_limit2", [
-    pytest.param("gateway", "gateway", id="gateway"),
-    pytest.param("route", "route", id="route")
-], indirect=True)
+@pytest.mark.parametrize(
+    "rate_limit, rate_limit2",
+    [pytest.param("gateway", "gateway", id="gateway"), pytest.param("route", "route", id="route")],
+    indirect=True,
+)
 def test_collision_rate_limit(client, rate_limit, rate_limit2):
     """Test first policy is being overridden when another policy with the same target is created."""
     assert rate_limit.wait_until(has_condition("Enforced", "False", "Overridden", "RateLimitPolicy is overridden"))

--- a/testsuite/tests/singlecluster/limitador/collisions/test_collisions.py
+++ b/testsuite/tests/singlecluster/limitador/collisions/test_collisions.py
@@ -36,7 +36,7 @@ def rate_limit2(request, cluster, blame, module_label, target, label):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def commit(request, rate_limit, rate_limit2):
+def commit(request, route, rate_limit, rate_limit2):
     """Commits RateLimitPolicies after the target is created"""
     for policy in [rate_limit, rate_limit2]:  # Forcing order of creation.
         request.addfinalizer(policy.delete)


### PR DESCRIPTION
This PR aims to fix issue: #571 

Added collision test for both auth policies and rate limits when attached to the same target.