### PR TITLE
Update failing change_targetref tests

### DIFF
--- a/testsuite/httpx/__init__.py
+++ b/testsuite/httpx/__init__.py
@@ -65,6 +65,10 @@ class Result:
             or self.has_error("No address associated with hostname")
         )
 
+    def has_tls_error(self):
+        """True, if the result failed due to TLS failure"""
+        return self.has_error("SSL: UNEXPECTED_EOF_WHILE_READING") or self.has_error("Connection refused")
+
     def has_cert_verify_error(self):
         """True, if the result failed due to TLS certificate verification failure"""
         return self.has_error("SSL: CERTIFICATE_VERIFY_FAILED")

--- a/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_authpolicy_target_ref.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_authpolicy_target_ref.py
@@ -2,6 +2,8 @@
 Test for changing targetRef field in AuthPolicy
 """
 
+import time
+
 import pytest
 
 from testsuite.kuadrant.policy.authorization.auth_policy import AuthPolicy
@@ -31,6 +33,8 @@ def test_update_auth_policy_target_ref(
     assert response.status_code == 200
 
     change_target_ref(authorization, gateway2)
+
+    time.sleep(10)  # Allow extra time for AuthPolicy enforcement to propagate
 
     response = client2.get("/get", auth=auth)
     assert response.status_code == 200

--- a/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_tlspolicy_target_ref.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_tlspolicy_target_ref.py
@@ -2,6 +2,8 @@
 Test for changing targetRef field in TLSPolicy
 """
 
+import time
+
 import pytest
 
 from testsuite.gateway import TLSGatewayListener
@@ -68,7 +70,7 @@ def test_update_tls_policy_target_ref(
     assert response.status_code == 200
 
     response = KuadrantClient(base_url=f"https://{hostname2.hostname}", verify=False).get("/get")
-    assert response.has_error("[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol")
+    assert response.has_tls_error()
 
     change_target_ref(tls_policy, gateway2)
 
@@ -82,6 +84,7 @@ def test_update_tls_policy_target_ref(
     # Delete TLS secret to verify gateway1 no longer serves valid TLS traffic
     tls_secret = gateway.get_tls_secret(hostname.hostname)
     tls_secret.delete()
+    time.sleep(10)  # Allow extra time for secret deletion to propagate
 
     response = KuadrantClient(base_url=f"https://{hostname.hostname}", verify=False).get("/get")
-    assert response.has_error("[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol")
+    assert response.has_tls_error()


### PR DESCRIPTION
## Description

This PR updates the failing `change_targetref` tests as described in issue #664.

**Changes:**
- Solution for now is to add `time.sleep(10)` to both tests, comments in code explain reasoning. In the future, when issue #660 is addressed, there could be a better solution in place of this.

- Added `has_tls_error() `method to `testsuite/httpx/__init__.py`

- Updated assertions in `testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_tlspolicy_target_ref.py` to use `assert response.has_tls_error()` instead of directly checking for a specific SSL error message via `response.has_error("[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol")`.
