### PR TITLE
Fix/refactor authorino metadata tests

### DIFF
--- a/testsuite/tests/singlecluster/authorino/caching/metadata/test_caching.py
+++ b/testsuite/tests/singlecluster/authorino/caching/metadata/test_caching.py
@@ -22,12 +22,15 @@ def test_cached(client, auth, module_label, mockserver):
         - both requests return the same result
         - only single external value evaluation occurs. The second response contains cached (in-memory) value
     """
-    response = client.get("/get", auth=auth)
-    data = extract_response(response)[module_label]["uuid"] % None
-    response = client.get("/get", auth=auth)
-    cached_data = extract_response(response)[module_label]["uuid"] % None
-
-    assert cached_data is not None
+    response1 = client.get("/get", auth=auth)
+    assert response1.status_code == 200
+    data = extract_response(response1)[module_label]["uuid"] % None
     assert data is not None
+
+    response2 = client.get("/get", auth=auth)
+    assert response2.status_code == 200
+    cached_data = extract_response(response2)[module_label]["uuid"] % None
+    assert cached_data is not None
+
     assert data == cached_data
     assert len(mockserver.retrieve_requests(module_label)) == 1

--- a/testsuite/tests/singlecluster/authorino/caching/metadata/test_not_cached.py
+++ b/testsuite/tests/singlecluster/authorino/caching/metadata/test_not_cached.py
@@ -17,12 +17,14 @@ def authorization(authorization, module_label, expectation_path):
 def test_no_caching(client, auth, module_label, mockserver):
     """Tests value is not cached for metadata without caching feature"""
     response1 = client.get("/get", auth=auth)
+    assert response1.status_code == 200
     data = extract_response(response1)[module_label]["uuid"] % None
+    assert data is not None
 
     response2 = client.get("/get", auth=auth)
+    assert response2.status_code == 200
     cached_data = extract_response(response2)[module_label]["uuid"] % None
-
     assert cached_data is not None
-    assert data is not None
+
     assert cached_data != data
     assert len(mockserver.retrieve_requests(module_label)) == 2

--- a/testsuite/tests/singlecluster/authorino/caching/metadata/test_ttl.py
+++ b/testsuite/tests/singlecluster/authorino/caching/metadata/test_ttl.py
@@ -9,30 +9,28 @@ from testsuite.utils import extract_response
 
 pytestmark = [pytest.mark.authorino]
 
-
-@pytest.fixture(scope="module")
-def cache_ttl():
-    """Returns TTL in seconds for Cached Metadata"""
-    return 5
+CACHE_TTL = 5
 
 
 @pytest.fixture(scope="module")
-def authorization(authorization, module_label, expectation_path, cache_ttl):
+def authorization(authorization, module_label, expectation_path):
     """Adds Cached Metadata to the AuthConfig"""
-    meta_cache = Cache(cache_ttl, ValueFrom("context.request.http.path"))
+    meta_cache = Cache(CACHE_TTL, ValueFrom("context.request.http.path"))
     authorization.metadata.add_http(module_label, expectation_path, "GET", cache=meta_cache)
     return authorization
 
 
-def test_cached_ttl(client, auth, module_label, cache_ttl, mockserver):
+def test_cached_ttl(client, auth, module_label, mockserver):
     """Tests that cached value expires after ttl"""
     response = client.get("/get", auth=auth)
     data = extract_response(response)[module_label]["uuid"] % None
-    sleep(cache_ttl)
+    assert data is not None
+
+    sleep(CACHE_TTL)
+
     response = client.get("/get", auth=auth)
     cached_data = extract_response(response)[module_label]["uuid"] % None
-
     assert cached_data is not None
-    assert data is not None
+
     assert data != cached_data
     assert len(mockserver.retrieve_requests(module_label)) == 2

--- a/testsuite/utils.py
+++ b/testsuite/utils.py
@@ -125,7 +125,7 @@ def extract_response(response, header="Simple", key="data"):
 
     # Returning None if content is empty, this typically happens for non-200 responses
     if len(response.content) == 0:
-        return weakget(None)
+        return weakget({})
 
     return weakget(json.loads(response.json()["headers"][header]))[key]
 


### PR DESCRIPTION
These changes aimed to improve nightlies execution of cached authorino tests. 
- Refactor authorino metadata test to verify 200 response code
- Fix response extract utility function to return valid weakget object

### Verification steps

```sh
make testsuite/tests/singlecluster/authorino/caching/metadata/
```