### PR TITLE
Update httproute-delete test

### DIFF
--- a/testsuite/tests/singlecluster/reconciliation/test_httproute_delete.py
+++ b/testsuite/tests/singlecluster/reconciliation/test_httproute_delete.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from testsuite.kuadrant.policy import has_condition
+
 pytestmark = [pytest.mark.kuadrant_only]
 
 
@@ -19,13 +21,13 @@ def test_delete(client, route, hostname, authorization):
     response = client.get("/get")
     assert response.status_code == 200
 
+    deleted_route_name = route.name()
     route.delete()
 
     with hostname.client(retry_codes={200}) as failing_client:
         response = failing_client.get("/get")
         assert response.status_code == 404, "Removing HTTPRoute was not reconciled"
 
-    authorization.refresh()
-    condition = authorization.model.status.conditions[0]
-    assert condition.status == "False"
-    assert "not found" in condition.message
+    assert authorization.refresh().wait_until(
+        has_condition("Accepted", "False", "TargetNotFound", f"AuthPolicy target {deleted_route_name} was not found")
+    ), f"AuthPolicy did not reach expected record status, instead it was: {authorization.model.status.condition}"


### PR DESCRIPTION
## Description
Update old httproute-delete test to see why exactly it's failing in nightly runs

## Verification Steps
```sh
make testsuite/tests/singlecluster/reconciliation/test_httproute_delete.py
```

