### PR TITLE
Run multicluster tests with -n2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ kuadrant-only: poetry-no-dev
 
 multicluster: ## Run Multicluster only tests
 multicluster: poetry-no-dev
-	$(PYTEST) -m 'multicluster' --dist loadfile --enforce $(flags) testsuite
+	$(PYTEST) -n2 -m 'multicluster' --dist loadfile --enforce $(flags) testsuite
 
 dnstls: ## Run DNS and TLS tests
 dnstls: poetry-no-dev


### PR DESCRIPTION
## Description
Run multicluster tests with -n2 instead of sequentially in Makefile
## Verification Steps
`make multicluster`

