### PR TITLE
Improve wait on health-check tests

### DIFF
--- a/testsuite/kuadrant/policy/dns.py
+++ b/testsuite/kuadrant/policy/dns.py
@@ -56,14 +56,14 @@ class HealthCheck:  # pylint: disable=invalid-name
 class DNSHealthCheckProbe(KubernetesObject):
     """DNSHealthCheckProbe object"""
 
-    def _status_ready(self):
-        """Returns True if DNSHealthCheckProbe status.healthy field has appeared"""
-        return self.wait_until(lambda obj: obj.model.status.healthy is not oc.Missing)
-
     def is_healthy(self) -> bool:
         """Returns True if DNSHealthCheckProbe endpoint is healthy"""
-        assert self._status_ready(), "DNSHealthCheckProbe status wasn't ready in time"
-        return self.refresh().model.status.healthy
+        return self.model.status.healthy
+
+    def wait_for_ready(self):
+        """Returns True if DNSHealthCheckProbe status.healthy field has appeared"""
+        success = self.wait_until(lambda obj: obj.model.status.healthy is not oc.Missing)
+        assert success, "DNSHealthCheckProbe status wasn't ready in time"
 
 
 class DNSPolicy(Policy):

--- a/testsuite/tests/singlecluster/gateway/dnspolicy/health_check/conftest.py
+++ b/testsuite/tests/singlecluster/gateway/dnspolicy/health_check/conftest.py
@@ -44,7 +44,9 @@ def dns_policy(dns_policy, health_check):
 @pytest.fixture(scope="module")
 def dns_health_probe(dns_policy):
     """Return DNSHealthCheckProbe object for created DNSPolicy"""
-    return dns_policy.get_dns_health_probe()
+    dns_health_probe = dns_policy.get_dns_health_probe()
+    dns_health_probe.wait_for_ready()
+    return dns_health_probe
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/testsuite/tests/singlecluster/gateway/dnspolicy/health_check/test_remove_endpoint.py
+++ b/testsuite/tests/singlecluster/gateway/dnspolicy/health_check/test_remove_endpoint.py
@@ -31,13 +31,13 @@ def test_remove_endpoint(backend, dns_policy, dns_health_probe, client, auth):
         has_record_condition("Healthy", "False", "HealthChecksFailed", "Not healthy addresses:")
     )
 
-    assert not dns_health_probe.is_healthy()
+    assert dns_health_probe.wait_until(lambda obj: not obj.is_healthy())
     response = client.get("/get", auth=auth)
     assert response.status_code == 503
 
     backend.deployment.self_selector().scale(1)
     assert dns_policy.wait_until(has_condition("SubResourcesHealthy", "True"), timelimit=120)
 
-    assert dns_health_probe.is_healthy()
+    assert dns_health_probe.wait_until(lambda obj: obj.is_healthy())
     response = client.get("/get", auth=auth)
     assert response.status_code == 200


### PR DESCRIPTION
## Description
`.is_healthy()` was failing inside the test so I fix it
## Verification Steps
`make testsuite/tests/singlecluster/gateway/dnspolicy/health_check/`

