### PR TITLE
Add tests for mTLS configuration and functional behavior

### DIFF
--- a/testsuite/tests/singlecluster/mtls/conftest.py
+++ b/testsuite/tests/singlecluster/mtls/conftest.py
@@ -1,0 +1,31 @@
+"""Conftest for mTLS tests"""
+
+import time
+import pytest
+
+from testsuite.kuadrant.policy.rate_limit import RateLimitPolicy, Limit
+
+
+@pytest.fixture(scope="module")
+def authorization():
+    """Disable AuthPolicy creation during these tests"""
+    return None
+
+
+@pytest.fixture(scope="module")
+def rate_limit(cluster, blame, module_label, gateway, route):  # pylint: disable=unused-argument
+    """RateLimitPolicy for testing"""
+    policy = RateLimitPolicy.create_instance(cluster, blame("limit"), gateway, labels={"testRun": module_label})
+    policy.add_limit("basic", [Limit(2, "10s")])
+    return policy
+
+
+def wait_for_mtls_status(kuadrant, expected: bool):
+    """Wait until Kuadrant CR status.mtls matches the expected value"""
+    for _ in range(10):
+        kuadrant.refresh()
+        if kuadrant.model.status.get("mtls") == expected:
+            return
+        time.sleep(2)
+
+    raise TimeoutError("mTLS status did not reach expected value")

--- a/testsuite/tests/singlecluster/mtls/test_mtls_configuration.py
+++ b/testsuite/tests/singlecluster/mtls/test_mtls_configuration.py
@@ -1,0 +1,86 @@
+"""
+Tests mTLS configuration and readiness after Kuadrant CR changes
+"""
+
+import time
+import pytest
+
+from openshift_client import selector
+from testsuite.tests.singlecluster.mtls.conftest import wait_for_mtls_status
+
+pytestmark = [pytest.mark.kuadrant_only]
+
+
+def test_peer_authentication_resource_applied(kuadrant, cluster, rate_limit):  # pylint: disable=unused-argument
+    """Verify PeerAuthentication with STRICT mode is created when mTLS is enabled"""
+    kuadrant.refresh()
+    kuadrant.model.spec.mtls.enable = True
+    kuadrant.apply()
+    wait_for_mtls_status(kuadrant, expected=True)
+
+    project = cluster.change_project("kuadrant-system")
+    with project.context:
+        peer_auths = selector("peerauthentication").objects()
+    assert peer_auths, "No PeerAuthentication resources found"
+
+    strict = [pa.name() for pa in peer_auths if pa.model.spec.mtls.mode == "STRICT"]
+    assert strict, "No PeerAuthentication with mtls.mode == 'STRICT'"
+
+    # Reset mTLS
+    kuadrant.refresh()
+    kuadrant.model.spec.mtls.enable = False
+    kuadrant.apply()
+    wait_for_mtls_status(kuadrant, expected=False)
+
+
+def test_limitador_pods_have_istio_sidecar_and_labels(kuadrant, cluster, rate_limit):  # pylint: disable=unused-argument
+    """Verify Limitador pods have istio-proxy sidecar and required labels after enabling mTLS"""
+    kuadrant.refresh()
+    kuadrant.model.spec.mtls.enable = True
+    kuadrant.apply()
+    wait_for_mtls_status(kuadrant, expected=True)
+
+    time.sleep(15)  # Wait for sidecar injection to take effect
+
+    project = cluster.change_project("kuadrant-system")
+    with project.context:
+        pods = selector("pods", labels={"app": "limitador"}).objects()
+    assert pods, "No Limitador pods found in kuadrant-system"
+
+    for pod in pods:
+        pod_name = pod.name()
+        pod_labels = pod.model.metadata.labels
+        container_names = [c.name for c in pod.model.spec.containers]
+
+        assert (
+            pod_labels["sidecar.istio.io/inject"] == "true"
+        ), f"{pod_name} missing label 'sidecar.istio.io/inject: true'"
+
+        assert pod_labels["kuadrant.io/managed"] == "true", f"{pod_name} missing label 'kuadrant.io/managed: true'"
+
+        assert "istio-proxy" in container_names, f"{pod_name} does not have 'istio-proxy' sidecar container"
+
+    # Reset mTLS
+    kuadrant.refresh()
+    kuadrant.model.spec.mtls.enable = False
+    kuadrant.apply()
+    wait_for_mtls_status(kuadrant, expected=False)
+
+
+def test_kuadrant_cr_reaches_ready_status(kuadrant, rate_limit):  # pylint: disable=unused-argument
+    """Verify Kuadrant CR reaches Ready status after enabling mTLS"""
+    kuadrant.refresh()
+    kuadrant.model.spec.mtls.enable = True
+    kuadrant.apply()
+    wait_for_mtls_status(kuadrant, expected=True)
+
+    ready = kuadrant.wait_until(
+        lambda obj: any(c.type == "Ready" and c.status == "True" for c in obj.model.status.conditions)
+    )
+    assert ready, "Kuadrant CR did not reach Ready=True in time"
+
+    # Reset mTLS
+    kuadrant.refresh()
+    kuadrant.model.spec.mtls.enable = False
+    kuadrant.apply()
+    wait_for_mtls_status(kuadrant, expected=False)

--- a/testsuite/tests/singlecluster/mtls/test_mtls_functional_behavior.py
+++ b/testsuite/tests/singlecluster/mtls/test_mtls_functional_behavior.py
@@ -1,0 +1,60 @@
+"""
+Tests the enabling and disabling of mTLS configuration via the Kuadrant CR
+"""
+
+import time
+import pytest
+
+from testsuite.tests.singlecluster.mtls.conftest import wait_for_mtls_status
+
+pytestmark = [pytest.mark.kuadrant_only]
+
+
+def test_requests_succeed_when_mtls_disabled(kuadrant, client, rate_limit):  # pylint: disable=unused-argument
+    """Tests that requests succeed when mTLS is disabled"""
+    kuadrant.refresh()
+    kuadrant.model.spec.mtls.enable = False
+    kuadrant.apply()
+
+    assert kuadrant.model.spec.mtls.enable is False
+    assert kuadrant.model.status.mtls is False
+
+    responses = client.get_many("/get", 2)
+    responses.assert_all(status_code=200)
+    assert client.get("/get").status_code == 429
+
+
+def test_requests_succeed_when_mtls_enabled(kuadrant, client, rate_limit):  # pylint: disable=unused-argument
+    """Tests that requests succeed when mTLS is enabled"""
+    kuadrant.refresh()
+    kuadrant.model.spec.mtls.enable = True
+    kuadrant.apply()
+    wait_for_mtls_status(kuadrant, expected=True)
+
+    assert kuadrant.model.spec.mtls.enable is True
+    assert kuadrant.model.status.mtls is True
+
+    time.sleep(15)  # Delay to ensure system finishes applying mTLS changes before sending requests
+
+    responses = client.get_many("/get", 2)
+    responses.assert_all(status_code=200)
+    assert client.get("/get").status_code == 429
+
+
+def test_requests_still_succeed_after_mtls_disabled_again(
+    kuadrant, client, rate_limit
+):  # pylint: disable=unused-argument
+    """Tests that requests succeed after disabling mTLS again"""
+    kuadrant.refresh()
+    kuadrant.model.spec.mtls.enable = False
+    kuadrant.apply()
+    wait_for_mtls_status(kuadrant, expected=False)
+
+    assert kuadrant.model.spec.mtls.enable is False
+    assert kuadrant.model.status.mtls is False
+
+    time.sleep(15)  # Delay to ensure system finishes applying mTLS changes before sending requests
+
+    responses = client.get_many("/get", 2)
+    responses.assert_all(status_code=200)
+    assert client.get("/get").status_code == 429


### PR DESCRIPTION
#### **Description:**

This PR introduces tests to verify the functionality and configuration of mTLS in Kuadrant. It includes two key sets of tests:

1. **mTLS Configuration Tests** (`test_mtls_configuration.py`):
    * Verifies that PeerAuthentication with STRICT mode is created when mTLS is enabled
    * Confirms that Limitador pods have the necessary Istio sidecar and labels after mTLS is enabled
    * Ensures Kuadrant CR reaches Ready status after enabling mTLS

2. **mTLS Functional Behavior Tests** (`test_mtls_functional_behavior.py`):
    * Ensures that requests succeed when mTLS is disabled
    * Verifies that requests continue to succeed when mTLS is enabled
    * Confirms that requests still succeed after mTLS is disabled again