### PR TITLE
Added marker on collision tests for kuadrant only.

### DIFF
--- a/testsuite/tests/singlecluster/authorino/collisions/test_collisions.py
+++ b/testsuite/tests/singlecluster/authorino/collisions/test_collisions.py
@@ -6,7 +6,7 @@ from testsuite.httpx.auth import HeaderApiKeyAuth
 from testsuite.kuadrant.policy import has_condition
 from testsuite.kuadrant.policy.authorization.auth_policy import AuthPolicy
 
-pytestmark = [pytest.mark.authorino]
+pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this pull request -->
<!--
Provide other information that might make life easier for the reviewer:
* Context - link to discussions,log snippet of failed test this will fix, etc
* If this PR is linked to an issue, mention it (e.g., Fixes #123)
* Verification Steps
-->

Added marker on authorization policy collisions tests for kuadrant only as it is not supported in standalone mode.

