### PR TITLE
Change simple dns strategy test case in more DNS way

### DIFF
--- a/testsuite/tests/multicluster/test_simple_strategy.py
+++ b/testsuite/tests/multicluster/test_simple_strategy.py
@@ -16,7 +16,7 @@ def test_simple_strategy(client, hostname, gateway, gateway2):
     """
     Test simple load-balancing strategy across multiple clusters
     - Checks that request to the hostname works
-    - Checks that DNS resolution return IPs in a round-robin fashion
+    - Checks that DNS resolution returns both IP addresses in A record set
     """
     result = client.get("/get")
     assert not result.has_dns_error(), result.error
@@ -26,15 +26,5 @@ def test_simple_strategy(client, hostname, gateway, gateway2):
     gw1_ip, gw2_ip = gateway.external_ip().split(":")[0], gateway2.external_ip().split(":")[0]
     assert gw1_ip != gw2_ip
 
-    gw1_ip_resolved = dns.resolver.resolve(hostname.hostname)[0].address
-    gw2_ip_resolved = dns.resolver.resolve(hostname.hostname)[0].address
-    assert gw1_ip_resolved != gw2_ip_resolved, "Simple routing strategy should return IPs in a round-robin fashion"
-    assert {gw1_ip_resolved, gw2_ip_resolved} == {gw1_ip, gw2_ip}
-
-    for i in range(10):
-        assert (
-            dns.resolver.resolve(hostname.hostname)[0].address == gw1_ip_resolved
-        ), f"Simple routing strategy should return IPs in a round-robin fashion (iteration {i + 1})"
-        assert (
-            dns.resolver.resolve(hostname.hostname)[0].address == gw2_ip_resolved
-        ), f"Simple routing strategy should return IPs in a round-robin fashion (iteration {i + 1})"
+    dns_ips = {ip.address for ip in dns.resolver.resolve(hostname.hostname)}
+    assert {gw1_ip, gw2_ip} == dns_ips, "Simple routing strategy should return both IP addresses in A record set"


### PR DESCRIPTION
To test "Simple strategy" we do not really need to check the round-robin way of returned DNS responses. In the description of [AWS route 53 Simple strategy](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-simple.html) it is stated that they return the responses at random. The standard DNS behavior when multiple A records exist for single name is to return the order in round-robin or random fashion. In ideal world how this test is currently written we would want to expect this behavior. But due to caching, recursive resolver different implementation, system dns implementation or the randomness we cant always guarantee this behavior to be exact.

Checking that in the response are all A records that are expected and not bothering with their orders seems to me as better and more durable testing scenario with less false fails while trusting that the DNS provider or recursive resolver provider or any other places where it makes a difference, to return the order of records at random.