### PR TITLE
Update ratelimitpolicy change_targetref test

### DIFF
--- a/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_ratelimitpolicy_target_ref.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_ratelimitpolicy_target_ref.py
@@ -18,9 +18,12 @@ def rate_limit(cluster, blame, module_label, gateway, route):  # pylint: disable
 
 
 def test_update_ratelimit_policy_target_ref(
-    route2, gateway2, rate_limit, client, client2, dns_policy, dns_policy2, change_target_ref
+    route2, gateway, gateway2, rate_limit, client, client2, dns_policy, dns_policy2, change_target_ref
 ):  # pylint: disable=unused-argument
     """Test updating the targetRef of a RateLimitPolicy from Gateway 1 to Gateway 2"""
+    assert gateway.wait_until(lambda obj: obj.is_affected_by(rate_limit))
+    assert gateway2.wait_until(lambda obj: not obj.is_affected_by(rate_limit))
+
     responses = client.get_many("/get", 2)
     responses.assert_all(status_code=200)
     assert client.get("/get").status_code == 429
@@ -29,6 +32,9 @@ def test_update_ratelimit_policy_target_ref(
     responses.assert_all(status_code=200)
 
     change_target_ref(rate_limit, gateway2)
+
+    assert gateway.wait_until(lambda obj: not obj.is_affected_by(rate_limit))
+    assert gateway2.wait_until(lambda obj: obj.is_affected_by(rate_limit))
 
     responses = client2.get_many("/get", 2)
     responses.assert_all(status_code=200)


### PR DESCRIPTION
**Description**

This PR aims to fix test `testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_ratelimitpolicy_target_ref.py` which has been failing intermittently on the nightly runs.


**Changes**

- Added wait_until(...) assertions to ensure Gateway resources reflect the expected RateLimitPolicy state before proceeding
