### PR TITLE
JWT plain identity test

### DIFF
--- a/testsuite/gateway/envoy/jwt_plain_identity.py
+++ b/testsuite/gateway/envoy/jwt_plain_identity.py
@@ -1,0 +1,82 @@
+"""JWT plain identity test Envoy"""
+
+from urllib.parse import urlparse
+import yaml
+
+from testsuite.gateway.envoy import Envoy, EnvoyConfig
+
+
+class JwtEnvoy(Envoy):
+    """Envoy configuration with JWT plain identity test setup"""
+
+    def __init__(
+        self, cluster, gw_name, authorino, envoy_image, tools, keycloak_realm, keycloak_url, labels: dict[str, str]
+    ):
+        super().__init__(cluster, gw_name, authorino, envoy_image, labels)
+        self.server_url = keycloak_url
+        self.realm = keycloak_realm
+        self.tools = tools
+
+    @property
+    def config(self):
+        if not self._config:
+            self._config = EnvoyConfig.create_instance(self.cluster, self.name, self.authorino, self.labels)
+            config = yaml.safe_load(self._config["envoy.yaml"])
+            config["static_resources"]["clusters"].append(
+                {
+                    "name": "keycloak",
+                    "connect_timeout": "0.25s",
+                    "type": "logical_dns",
+                    "lb_policy": "round_robin",
+                    "load_assignment": {
+                        "cluster_name": "keycloak",
+                        "endpoints": [
+                            {
+                                "lb_endpoints": [
+                                    {
+                                        "endpoint": {
+                                            "address": {
+                                                "socket_address": {
+                                                    "address": urlparse(self.server_url).hostname,
+                                                    "port_value": urlparse(self.server_url).port,
+                                                }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        ],
+                    },
+                }
+            )
+            config["static_resources"]["listeners"][0]["filter_chains"][0]["filters"][0]["typed_config"][
+                "http_filters"
+            ].insert(
+                0,
+                {
+                    "name": "envoy.filters.http.jwt_authn",
+                    "typed_config": {
+                        "@type": "type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication",
+                        "providers": {
+                            "keycloak": {
+                                "issuer": f"{self.server_url}/realms/{self.realm}",
+                                "remote_jwks": {
+                                    "http_uri": {
+                                        "uri": f"{self.server_url}/realms/{self.realm}/protocol/openid-connect/certs",
+                                        "cluster": "keycloak",
+                                        "timeout": "5s",
+                                    },
+                                    "cache_duration": {"seconds": 300},
+                                },
+                                "payload_in_metadata": "verified_jwt",
+                            }
+                        },
+                        "rules": [{"match": {"prefix": "/"}, "requires": {"provider_name": "keycloak"}}],
+                    },
+                },
+            )
+            config["static_resources"]["listeners"][0]["filter_chains"][0]["filters"][0]["typed_config"][
+                "http_filters"
+            ][1]["typed_config"]["metadata_context_namespaces"] = ["envoy.filters.http.jwt_authn"]
+            self._config["envoy.yaml"] = yaml.dump(config)
+        return self._config

--- a/testsuite/tests/singlecluster/authorino/identity/plain/test_jwt_plain_identity.py
+++ b/testsuite/tests/singlecluster/authorino/identity/plain/test_jwt_plain_identity.py
@@ -1,0 +1,91 @@
+"""
+Plain identity test with automation handled by Envoy leveraging the Envoy JWT Authentication filter
+(decoded JWT injected as 'metadata_context' into the response).
+https://github.com/Kuadrant/authorino/blob/main/docs/user-guides/envoy-jwt-authn-and-authorino.md
+"""
+
+import pytest
+
+from testsuite.httpx.auth import HttpxOidcClientAuth
+from testsuite.gateway.envoy.jwt_plain_identity import JwtEnvoy
+from testsuite.utils import extract_response
+
+
+pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
+
+
+@pytest.fixture(scope="module")
+def realm_role(keycloak, blame):
+    """Creates new realm role"""
+    return keycloak.realm.create_realm_role(blame("role"))
+
+
+@pytest.fixture(scope="module")
+def user_with_role(keycloak, realm_role, blame):
+    """Creates new user and adds him into realm_role"""
+    username = blame("someuser")
+    password = blame("password")
+    user = keycloak.realm.create_user(username, password)
+    user.assign_realm_role(realm_role)
+    return user
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization, realm_role, blame):
+    """
+    Setup AuthConfig to retrieve identity from given path.
+    Adds rule, that requires user to be part of realm_role to be allowed access.
+    """
+    authorization.identity.add_plain(
+        "plain", "context.metadata_context.filter_metadata.envoy\\.filters\\.http\\.jwt_authn|verified_jwt"
+    )
+    authorization.responses.add_simple("context.metadata_context.filter_metadata")
+    authorization.authorization.add_role_rule(blame("rule"), realm_role["name"], "^/get")
+    return authorization
+
+
+@pytest.fixture(scope="module")
+def gateway(request, authorino, cluster, blame, module_label, testconfig, keycloak):
+    """Deploys Envoy with additional JWT plain identity test setup"""
+    envoy = JwtEnvoy(
+        cluster,
+        blame("gw"),
+        authorino,
+        testconfig["service_protection"]["envoy"]["image"],
+        testconfig["tools"].project,
+        keycloak.realm_name,
+        keycloak.server_url,
+        labels={"app": module_label},
+    )
+    request.addfinalizer(envoy.delete)
+    envoy.commit()
+    return envoy
+
+
+@pytest.fixture(scope="module")
+def auth2(user_with_role, keycloak):
+    """Creates user with role and returns its authentication object for HTTPX"""
+    return HttpxOidcClientAuth.from_user(keycloak.get_token, user_with_role, "authorization")
+
+
+def test_jwt_plain_identity(client, auth2, auth, keycloak):
+    """
+    Test assertions for corresponding status codes:
+    - user has assigned role and valid token is passed through
+    - user doesn't have assigned role
+    - invalid token
+    """
+
+    response = client.get("/get", auth=auth2)
+    assert response is not None
+    assert response.status_code == 200
+    extracted_iss = (extract_response(response) % None)["envoy.filters.http.jwt_authn"]["verified_jwt"]["iss"]
+    assert extracted_iss == f"{keycloak.server_url}/realms/{keycloak.realm_name}"
+
+    response = client.get("/get", auth=auth)
+    assert response is not None
+    assert response.status_code == 403
+
+    response = client.get("/get", headers={"Authorization": "Bearer invalid-token123"})
+    assert response is not None
+    assert response.status_code == 401


### PR DESCRIPTION
## Description
This PR addresses part of issue #673. It tests two cases of authentication in Envoy using the Envoy JWT authentication filter. The first case is when the user has a role assigned, and the second case is when the user does not have a role assigned.

