### PR TITLE
Add JWT test implementing user story from user-guides

### DIFF
--- a/testsuite/gateway/envoy/config.py
+++ b/testsuite/gateway/envoy/config.py
@@ -114,7 +114,7 @@ class EnvoyConfig(ConfigMap):
             "route_config"
         ]["virtual_hosts"][0]["routes"]
         for host in virtual_hosts:
-            if host["match"]["prefix"] == prefix and host["route"]["cluster"] == backend.url:
+            if host["match"].get("prefix") == prefix and host["route"]["cluster"] == backend.url:
                 return True
         return False
 
@@ -139,4 +139,13 @@ class EnvoyConfig(ConfigMap):
         config["static_resources"]["listeners"][0]["filter_chains"][0]["filters"][0]["typed_config"]["route_config"][
             "virtual_hosts"
         ][0]["routes"] = {}
+        self["envoy.yaml"] = yaml.dump(config)
+
+    @modify
+    def add_custom_routes_match(self, match: dict, position: int = 0):
+        """Add specific routes match which will be specified through dictionary data into fixture."""
+        config = yaml.safe_load(self["envoy.yaml"])
+        config["static_resources"]["listeners"][0]["filter_chains"][0]["filters"][0]["typed_config"]["route_config"][
+            "virtual_hosts"
+        ][0]["routes"].insert(position, match)
         self["envoy.yaml"] = yaml.dump(config)

--- a/testsuite/gateway/envoy/jwt_plain_identity.py
+++ b/testsuite/gateway/envoy/jwt_plain_identity.py
@@ -7,15 +7,21 @@ from testsuite.gateway.envoy import Envoy, EnvoyConfig
 
 
 class JwtEnvoy(Envoy):
-    """Envoy configuration with JWT plain identity test setup"""
+    """Envoy configuration with JWT tests setup"""
 
     def __init__(
-        self, cluster, gw_name, authorino, envoy_image, tools, keycloak_realm, keycloak_url, labels: dict[str, str]
+        self,
+        cluster,
+        gw_name,
+        authorino,
+        envoy_image,
+        keycloak_realm,
+        keycloak_url,
+        labels: dict[str, str],
     ):
         super().__init__(cluster, gw_name, authorino, envoy_image, labels)
         self.server_url = keycloak_url
         self.realm = keycloak_realm
-        self.tools = tools
 
     @property
     def config(self):

--- a/testsuite/gateway/envoy/route.py
+++ b/testsuite/gateway/envoy/route.py
@@ -33,6 +33,11 @@ class EnvoyVirtualRoute(GatewayRoute):
             self.gateway.config.add_backend(backend, prefix)
             self.gateway.rollout()
 
+    def add_custom_routes_match(self, match: dict, position: int = 0):
+        """Add specific routes match which will be specified through dictionary data into fixture."""
+        self.gateway.config.add_custom_routes_match(position=position, match=match)
+        self.gateway.rollout()
+
     def remove_all_backend(self):
         self.gateway.config.remove_all_backends()
         self.gateway.rollout()

--- a/testsuite/mockserver.py
+++ b/testsuite/mockserver.py
@@ -1,6 +1,6 @@
 """Module for Mockserver integration"""
 
-from typing import Union
+from typing import Union, Literal
 
 from apyproxy import ApyProxy
 from httpx import Client
@@ -55,12 +55,14 @@ class Mockserver:
         json_data = {"httpResponse": {"headers": {"Content-Type": [str(content_type)]}, "body": body}}
         return self._expectation(expectation_id, json_data)
 
-    def create_template_expectation(self, expectation_id, template):
+    def create_template_expectation(
+        self, expectation_id, template, template_type: Literal["MUSTACHE", "VELOCITY"] = "MUSTACHE"
+    ):
         """
-        Creates template expectation in Mustache format.
+        Creates template expectation in Mustache or Velocity format.
         https://www.mock-server.com/mock_server/response_templates.html
         """
-        json_data = {"httpResponseTemplate": {"templateType": "MUSTACHE", "template": template}}
+        json_data = {"httpResponseTemplate": {"templateType": template_type, "template": template}}
         return self._expectation(expectation_id, json_data)
 
     def clear_expectation(self, expectation_id):

--- a/testsuite/tests/singlecluster/authorino/identity/plain/conftest.py
+++ b/testsuite/tests/singlecluster/authorino/identity/plain/conftest.py
@@ -1,0 +1,27 @@
+"""Conftest for JWT plain identity tests"""
+
+import pytest
+
+from testsuite.httpx.auth import HttpxOidcClientAuth
+
+
+@pytest.fixture(scope="module")
+def realm_role(keycloak, blame):
+    """Creates new realm role"""
+    return keycloak.realm.create_realm_role(blame("role"))
+
+
+@pytest.fixture(scope="module")
+def user_with_role(keycloak, realm_role, blame):
+    """Creates new user and adds him into realm_role"""
+    username = blame("someuser")
+    password = blame("password")
+    user = keycloak.realm.create_user(username, password)
+    user.assign_realm_role(realm_role)
+    return user
+
+
+@pytest.fixture(scope="module")
+def auth2(user_with_role, keycloak):
+    """Creates user with role and returns its authentication object for HTTPX"""
+    return HttpxOidcClientAuth.from_user(keycloak.get_token, user_with_role, "authorization")

--- a/testsuite/tests/singlecluster/authorino/identity/plain/test_jwt_plain_identity.py
+++ b/testsuite/tests/singlecluster/authorino/identity/plain/test_jwt_plain_identity.py
@@ -1,33 +1,15 @@
 """
 Plain identity test with automation handled by Envoy leveraging the Envoy JWT Authentication filter
 (decoded JWT injected as 'metadata_context' into the response).
-https://github.com/Kuadrant/authorino/blob/main/docs/user-guides/envoy-jwt-authn-and-authorino.md
 """
 
 import pytest
 
-from testsuite.httpx.auth import HttpxOidcClientAuth
-from testsuite.gateway.envoy.jwt_plain_identity import JwtEnvoy
 from testsuite.utils import extract_response
+from testsuite.gateway.envoy.jwt_plain_identity import JwtEnvoy
 
 
 pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
-
-
-@pytest.fixture(scope="module")
-def realm_role(keycloak, blame):
-    """Creates new realm role"""
-    return keycloak.realm.create_realm_role(blame("role"))
-
-
-@pytest.fixture(scope="module")
-def user_with_role(keycloak, realm_role, blame):
-    """Creates new user and adds him into realm_role"""
-    username = blame("someuser")
-    password = blame("password")
-    user = keycloak.realm.create_user(username, password)
-    user.assign_realm_role(realm_role)
-    return user
 
 
 @pytest.fixture(scope="module")
@@ -39,8 +21,8 @@ def authorization(authorization, realm_role, blame):
     authorization.identity.add_plain(
         "plain", "context.metadata_context.filter_metadata.envoy\\.filters\\.http\\.jwt_authn|verified_jwt"
     )
-    authorization.responses.add_simple("context.metadata_context.filter_metadata")
     authorization.authorization.add_role_rule(blame("rule"), realm_role["name"], "^/get")
+    authorization.responses.add_simple("context.metadata_context.filter_metadata")
     return authorization
 
 
@@ -52,7 +34,6 @@ def gateway(request, authorino, cluster, blame, module_label, testconfig, keyclo
         blame("gw"),
         authorino,
         testconfig["service_protection"]["envoy"]["image"],
-        testconfig["tools"].project,
         keycloak.realm_name,
         keycloak.server_url,
         labels={"app": module_label},
@@ -60,12 +41,6 @@ def gateway(request, authorino, cluster, blame, module_label, testconfig, keyclo
     request.addfinalizer(envoy.delete)
     envoy.commit()
     return envoy
-
-
-@pytest.fixture(scope="module")
-def auth2(user_with_role, keycloak):
-    """Creates user with role and returns its authentication object for HTTPX"""
-    return HttpxOidcClientAuth.from_user(keycloak.get_token, user_with_role, "authorization")
 
 
 def test_jwt_plain_identity(client, auth2, auth, keycloak):

--- a/testsuite/tests/singlecluster/authorino/identity/plain/test_jwt_user_story.py
+++ b/testsuite/tests/singlecluster/authorino/identity/plain/test_jwt_user_story.py
@@ -1,0 +1,136 @@
+"""
+Test for JWT plain identity implementing user story from :
+https://github.com/Kuadrant/authorino/blob/main/docs/user-guides/envoy-jwt-authn-and-authorino.md
+"""
+
+import pytest
+
+from testsuite.kuadrant.policy.authorization import Pattern, ValueFrom, DenyResponse
+from testsuite.gateway.envoy.jwt_plain_identity import JwtEnvoy
+
+
+pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
+
+
+@pytest.fixture(scope="module")
+def mockserver_expectation(request, mockserver, module_label):
+    """Creates a MockServer expectation with a VELOCITY template that responds with
+    different mock JSON responses based on the 'country' query parameter."""
+
+    velocity_template = """
+    #set($country = $request.queryStringParameters['country'][0])
+    #if($country == "GB")
+    {
+      "statusCode": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "body": "{ \\"country_iso_code\\": \\"GB\\", \\"country_name\\": \\"Great Britain\\" }"
+    }
+    #elseif($country == "IT")
+    {
+      "statusCode": 200,
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "body": "{ \\"country_iso_code\\": \\"IT\\", \\"country_name\\": \\"Italy\\" }"
+    }
+    #end
+    """
+    request.addfinalizer(lambda: mockserver.clear_expectation(module_label))
+    expectation = mockserver.create_template_expectation(module_label, velocity_template, template_type="VELOCITY")
+    return expectation + "?country={context.request.http.headers.x-country}"
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization, realm_role, mockserver_expectation):
+    """
+    Add to the AuthConfig:
+        - retrieve identity from the specified path
+        - add HTTP metadata from the MockServer
+        - define an authorization rule to enable geofence when the user doesn't have the assigned realm role
+        - set a custom deny message for unauthorized responses
+    """
+    authorization.identity.add_plain(
+        "plain", "context.metadata_context.filter_metadata.envoy\\.filters\\.http\\.jwt_authn|verified_jwt"
+    )
+    authorization.metadata.add_http("geoinfo", mockserver_expectation, "GET")
+    authorization.authorization.add_auth_rules(
+        "geofence",
+        [Pattern("auth.metadata.geoinfo.country_iso_code", "eq", "GB")],
+        when=[Pattern("auth.identity.realm_access.roles", "excl", realm_role["name"])],
+    )
+    authorization.responses.set_unauthorized(
+        DenyResponse(
+            message=ValueFrom("The requested resource is not available in " + "{auth.metadata.geoinfo.country_name}"),
+        )
+    )
+    return authorization
+
+
+@pytest.fixture(scope="module")
+def gateway(request, authorino, cluster, blame, module_label, testconfig, keycloak):
+    """Deploys Envoy with additional JWT plain identity test setup."""
+    envoy = JwtEnvoy(
+        cluster,
+        blame("gw"),
+        authorino,
+        testconfig["service_protection"]["envoy"]["image"],
+        keycloak.realm_name,
+        keycloak.server_url,
+        labels={"app": module_label},
+    )
+    request.addfinalizer(envoy.delete)
+    envoy.commit()
+    return envoy
+
+
+@pytest.fixture(scope="module")
+def route(route, backend):
+    """Add specific route match for JWT test into EnvoyConfig."""
+    route_dictionary = {
+        "match": {"path_separated_prefix": "/anything/global"},
+        "route": {"cluster": backend.url},
+        "typed_per_filter_config": {
+            "envoy.filters.http.ext_authz": {
+                "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+                "disabled": True,
+            }
+        },
+    }
+    route.add_custom_routes_match(match=route_dictionary)
+    return route
+
+
+def test_jwt_user_story(client, auth, auth2):
+    """
+    A user without an assigned realm role can access only with the allowed country parameter
+    or when accessing from global path parameter, that doesn't trigger external authorization.
+    User with assigned role can access all paths, regardless of the country parameter.
+    """
+
+    response = client.get("/get", auth=auth2, headers={"x-country": "GB"})
+    assert response is not None
+    assert response.status_code == 200
+
+    response = client.get("/get", auth=auth2, headers={"x-country": "IT"})
+    assert response is not None
+    assert response.status_code == 200
+
+    response = client.get("/anything/global", auth=auth2)
+    assert response is not None
+    assert response.status_code == 200
+
+    response = client.get("/get", auth=auth, headers={"x-country": "GB"})
+    assert response is not None
+    assert response.status_code == 200
+
+    response = client.get("/get", auth=auth, headers={"x-country": "IT"})
+    assert response is not None
+    assert response.status_code == 403
+    deny_message = response.headers.get("x-ext-auth-reason")
+    assert deny_message == "The requested resource is not available in Italy"
+
+    response = client.get("/anything/global", auth=auth)
+    assert response is not None
+    assert response.status_code == 200


### PR DESCRIPTION
## Description
This PR implements the user story from issue #689 into the testsuite.
As a user you can access from anywhere if you have a realm role assigned. But if user does not have assigned realm role than the user can access only from allowed path parameter "/anythig/SK/" or when accessing through "/anything/global" path parameter that does not trigger external authorization by Envoy.
