### PR TITLE
Fix invalid issuer test

### DIFF
--- a/testsuite/kubernetes/client.py
+++ b/testsuite/kubernetes/client.py
@@ -93,10 +93,10 @@ class KubernetesClient:
         with self.context:
             return oc.selector("route", field_selectors={"spec.to.name": service_name}).objects(cls=OpenshiftRoute)
 
-    def do_action(self, verb: str, *args, auto_raise: bool = True, parse_output: bool = False):
+    def do_action(self, verb: str, *args, stdin_str=None, auto_raise: bool = True, parse_output: bool = False):
         """Run an oc command."""
         with self.context:
-            result = oc.invoke(verb, args, auto_raise=auto_raise)
+            result = oc.invoke(verb, args, stdin_str=stdin_str, auto_raise=auto_raise)
             if parse_output:
                 return oc.APIObject(string_to_model=result.out())
             return result


### PR DESCRIPTION
## Description
https://github.com/Kuadrant/kuadrant-operator/pull/1393 changed message returned if an invalid issuer kind has been set (like 'Gateway' in this test). Validation also was moved to the object creation

## Verification steps
`pytest /home/averevki/work/testsuite/testsuite/tests/singlecluster/gateway/reconciliation/test_invalid_issuer_reference.py`
