### PR TITLE
Refactor to use poetry sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,11 +81,11 @@ poetry.lock: pyproject.toml
 	poetry lock
 
 .make-poetry-sync: poetry.lock
-	@if [ -z "$(poetry env list)" -o -n "${force}" ]; then poetry install --sync; fi
+	@if [ -z "$(poetry env list)" -o -n "${force}" ]; then poetry sync; fi
 	@ touch .make-poetry-sync .make-poetry-sync-no-dev
 
 .make-poetry-sync-no-dev: poetry.lock
-	@if [ -z "$(poetry env list)" -o -n "${force}" ]; then poetry install --sync --without dev; fi
+	@if [ -z "$(poetry env list)" -o -n "${force}" ]; then poetry sync --without dev; fi
 	@ touch .make-poetry-sync-no-dev
 
 


### PR DESCRIPTION
```
The `--sync` option is deprecated and slated for removal in the next minor release after June 2025, use the `poetry sync` command instead.
```
https://github.com/python-poetry/poetry/pull/9801

