### PR TITLE
Move fixture closer to test to check response status code issue

### DIFF
--- a/testsuite/tests/singlecluster/authorino/identity/plain/conftest.py
+++ b/testsuite/tests/singlecluster/authorino/identity/plain/conftest.py
@@ -2,8 +2,6 @@
 
 import pytest
 
-from testsuite.httpx.auth import HttpxOidcClientAuth
-
 
 @pytest.fixture(scope="module")
 def realm_role(keycloak, blame):
@@ -19,9 +17,3 @@ def user_with_role(keycloak, realm_role, blame):
     user = keycloak.realm.create_user(username, password)
     user.assign_realm_role(realm_role)
     return user
-
-
-@pytest.fixture(scope="module")
-def auth2(user_with_role, keycloak):
-    """Creates user with role and returns its authentication object for HTTPX"""
-    return HttpxOidcClientAuth.from_user(keycloak.get_token, user_with_role, "authorization")

--- a/testsuite/tests/singlecluster/authorino/identity/plain/test_jwt_plain_identity.py
+++ b/testsuite/tests/singlecluster/authorino/identity/plain/test_jwt_plain_identity.py
@@ -7,9 +7,16 @@ import pytest
 
 from testsuite.utils import extract_response
 from testsuite.gateway.envoy.jwt_plain_identity import JwtEnvoy
+from testsuite.httpx.auth import HttpxOidcClientAuth
 
 
 pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
+
+
+@pytest.fixture(scope="module")
+def auth2(user_with_role, keycloak):
+    """Creates user with role and returns its authentication object for HTTPX"""
+    return HttpxOidcClientAuth.from_user(keycloak.get_token, user_with_role, "authorization")
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Description
This PR moves a fixture from conftest.py directly into the test file to investigate and resolve an issue with the response status code 500.

Changes:

- Relocated the fixture closer to the test that uses it.
- No changes to test logic, only fixture location.

Purpose:

- To determine if the response status code issue is related to the fixture being defined globally in conftest.py.
