### PR TITLE
Revert fixture move; add 5s sleep to test if it resolves status code …

### DIFF
--- a/testsuite/tests/singlecluster/authorino/identity/plain/conftest.py
+++ b/testsuite/tests/singlecluster/authorino/identity/plain/conftest.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from testsuite.httpx.auth import HttpxOidcClientAuth
+
 
 @pytest.fixture(scope="module")
 def realm_role(keycloak, blame):
@@ -17,3 +19,9 @@ def user_with_role(keycloak, realm_role, blame):
     user = keycloak.realm.create_user(username, password)
     user.assign_realm_role(realm_role)
     return user
+
+
+@pytest.fixture(scope="module")
+def auth2(user_with_role, keycloak):
+    """Creates user with role and returns its authentication object for HTTPX"""
+    return HttpxOidcClientAuth.from_user(keycloak.get_token, user_with_role, "authorization")

--- a/testsuite/tests/singlecluster/authorino/identity/plain/test_jwt_plain_identity.py
+++ b/testsuite/tests/singlecluster/authorino/identity/plain/test_jwt_plain_identity.py
@@ -7,16 +7,9 @@ import pytest
 
 from testsuite.utils import extract_response
 from testsuite.gateway.envoy.jwt_plain_identity import JwtEnvoy
-from testsuite.httpx.auth import HttpxOidcClientAuth
 
 
 pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
-
-
-@pytest.fixture(scope="module")
-def auth2(user_with_role, keycloak):
-    """Creates user with role and returns its authentication object for HTTPX"""
-    return HttpxOidcClientAuth.from_user(keycloak.get_token, user_with_role, "authorization")
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/singlecluster/authorino/identity/plain/test_jwt_user_story.py
+++ b/testsuite/tests/singlecluster/authorino/identity/plain/test_jwt_user_story.py
@@ -3,20 +3,14 @@ Test for JWT plain identity implementing user story from :
 https://github.com/Kuadrant/authorino/blob/main/docs/user-guides/envoy-jwt-authn-and-authorino.md
 """
 
+import time
 import pytest
 
 from testsuite.kuadrant.policy.authorization import Pattern, ValueFrom, DenyResponse
 from testsuite.gateway.envoy.jwt_plain_identity import JwtEnvoy
-from testsuite.httpx.auth import HttpxOidcClientAuth
 
 
 pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
-
-
-@pytest.fixture(scope="module")
-def auth2(user_with_role, keycloak):
-    """Creates user with role and returns its authentication object for HTTPX"""
-    return HttpxOidcClientAuth.from_user(keycloak.get_token, user_with_role, "authorization")
 
 
 @pytest.fixture(scope="module")
@@ -106,6 +100,7 @@ def route(route, backend):
         },
     }
     route.add_custom_routes_match(match=route_dictionary)
+    time.sleep(5)
     return route
 
 


### PR DESCRIPTION
## Description
This PR reverts the previous change where the fixture was moved closer to the test and instead introduces a 5-second sleep in the test execution. The goal is to investigate whether adding a delay resolves the response status code issue.

Changes:

- Reverted fixture relocation.
- Added a 5-second sleep before running the test assertion.

Purpose:

- To test if the response status code 500 issue is caused by timing/race conditions.

