### PR TITLE
Update of default images

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -10,15 +10,15 @@ default:
       username: "testUser"
       password: "testPassword"
   httpbin:
-    image: "quay.io/trepel/httpbin:jsmadis"
+    image: "quay.io/rhn_support_azgabur/httpbin:latest"
   mockserver:
-    image: "quay.io/mganisin/mockserver:latest"
+    image: "quay.io/rhn_support_azgabur/mockserver:latest"
   service_protection:
     system_project: "kuadrant-system"
     project: "kuadrant"
     project2: "kuadrant2"
     envoy:
-      image: "quay.io/trepel/envoy:v1.31.0"
+      image: "quay.io/trepel/envoy:v1.35-latest"
     gateway:
        project: "istio-system"
        name: "istio-ingressgateway"


### PR DESCRIPTION
## Description

Update of default images used by testsuite in `config/settings.yaml`
- all three are multiarch manifests now
- envoy updated to v1.35

### Verification steps

Make sure you are not overriding these in `config/settings.local.yaml`, then execute both kuadrant tests and authorino standalone tests against amd64 (standard architecture) cluster:
`flags="-vvv" make test`
`flags="-vvv --standalone" make authorino-standalone`

However, it is probably ok to run just one test of each instead of whole test suite.

You can also pull all the images for ARM64 to validate that these are indeed multiarch manifests:
```
podman pull --platform linux/arm64 quay.io/rhn_support_azgabur/httpbin:latest
podman pull --platform linux/arm64 quay.io/rhn_support_azgabur/mockserver:latest
podman pull --platform linux/arm64 quay.io/trepel/envoy:v1.35-latest
```

