### PR TITLE
Update change_target_ref function and improve consistency

### DIFF
--- a/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/conftest.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/conftest.py
@@ -119,6 +119,7 @@ def change_target_ref():
     """Function that changes targetRef of given policy"""
 
     def _change_targetref(policy, gateway):
+        policy.refresh()
         policy.model.spec.targetRef = gateway.reference
         policy.apply()
         policy.wait_for_ready()

--- a/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_dnspolicy_target_ref.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_dnspolicy_target_ref.py
@@ -14,8 +14,8 @@ def test_update_dns_policy_target_ref(
     gateway, gateway2, client, client2, dns_policy, change_target_ref
 ):  # pylint: disable=unused-argument
     """Test updating the targetRef of DNSPolicy from Gateway 1 to Gateway 2"""
-    assert gateway.refresh().is_affected_by(dns_policy)
-    assert not gateway2.refresh().is_affected_by(dns_policy)
+    assert gateway.wait_until(lambda obj: obj.is_affected_by(dns_policy))
+    assert gateway2.wait_until(lambda obj: not obj.is_affected_by(dns_policy))
 
     response = client.get("/get")
     assert not response.has_dns_error()
@@ -31,8 +31,8 @@ def test_update_dns_policy_target_ref(
     # Wait for records deletion/ttl expiration from the previous request
     sleep(dns_ttl)
 
-    assert not gateway.refresh().is_affected_by(dns_policy)
-    assert gateway2.refresh().is_affected_by(dns_policy)
+    assert gateway.wait_until(lambda obj: not obj.is_affected_by(dns_policy))
+    assert gateway2.wait_until(lambda obj: obj.is_affected_by(dns_policy))
 
     response = client2.get("/get")
     assert not response.has_dns_error()


### PR DESCRIPTION
### PR Description

change_targetref DNSPolicy test is failing almost every night for the last few weeks (and sometimes rate limit tests too). Adding a refresh has made these tests stable again.

**Summary of changes:** 
* Added`policy.refresh()` before updating `targetRef`
* Switched DNSPolicy and AuthPolicy test to use `wait_until` for gateway assertions for consistency with the other two tests