### PR TITLE
Scale test: cleanup condition fix and httpbin image update

### DIFF
--- a/scale_test/control-plane-config.yaml
+++ b/scale_test/control-plane-config.yaml
@@ -145,7 +145,7 @@ jobs:
           LISTENER_NUM: "{{$LISTENER_NUM}}"
   {{- end }}
 {{- end }}
-{{- if not .SKIP_CLEANUP }}
+{{- if ne .SKIP_CLEANUP "true" }}
   - name: scale-test-safe-dnspolicy-cleanup
     jobType: delete
     jobIterations: 1

--- a/scale_test/max-gateway-listeners/templates/httpbin-deployment.yaml
+++ b/scale_test/max-gateway-listeners/templates/httpbin-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: httpbin
-          image: 'quay.io/trepel/httpbin:jsmadis'
+          image: 'quay.io/rhn_support_azgabur/httpbin:latest'
           ports:
             - name: api
               containerPort: 8080

--- a/scale_test/templates/httpbin-deployment.yaml
+++ b/scale_test/templates/httpbin-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: httpbin
-          image: 'quay.io/trepel/httpbin:jsmadis'
+          image: 'quay.io/rhn_support_azgabur/httpbin:latest'
           ports:
             - name: api
               containerPort: 8080


### PR DESCRIPTION
## Description

Cleanup condition fix and httpbin image update in scale test.

### Verification Steps

Eye review probably suffice. The cleanup condition is relatively trivial and the httpbin image had been validated as part of review of https://github.com/Kuadrant/testsuite/pull/729

If you want to be thorough you can run the scale test as described in scale-test/control-plane.md several times with various values for SKIP_CLEANUP env var:
- have it undefined (`unset SKIP_CLEANUP`) -> error saying that you need to define it
- have it empty (`SKIP_CLEANUP= # empty`) -> success with cleanup
- have it set to true (`SKIP_CLEANUP=true`) -> success without cleanup
- have it set to false (`SKIP_CLEANUP=false`) -> success with cleanup