### PR TITLE
Add support for OCP Ingress and standalone OSSMv3 configurations

### DIFF
--- a/scale_test/control-plane-config.yaml
+++ b/scale_test/control-plane-config.yaml
@@ -1,5 +1,10 @@
 {{- $KUADRANT_ZONE_ROOT_DOMAIN := .KUADRANT_ZONE_ROOT_DOMAIN }}
 {{- $NUM_LISTENERS := .NUM_LISTENERS }}
+{{- $USE_STANDALONE_MESH := .USE_STANDALONE_MESH }}
+{{- $GATEWAY_CONTROLLER_NAME := "openshift.io/gateway-controller/v1" }}
+{{- if eq $USE_STANDALONE_MESH "true" }}
+  {{- $GATEWAY_CONTROLLER_NAME = "istio.io/gateway-controller" }}
+{{- end }}
 ---
 metricsEndpoints: 
   - endpoint: {{ .PROMETHEUS_URL }}
@@ -81,6 +86,7 @@ jobs:
           KUADRANT_ZONE_ROOT_DOMAIN: "{{$KUADRANT_ZONE_ROOT_DOMAIN}}"
           NUM_LISTENERS: "{{$NUM_LISTENERS}}"
           GW_NUM: "{{$GW_NUM}}"
+          USE_STANDALONE_MESH: "{{$USE_STANDALONE_MESH}}"
       - objectTemplate: templates/gw-tls-policy.yaml
         replicas: 1
         waitOptions:
@@ -119,7 +125,7 @@ jobs:
         replicas: 1
         waitOptions:
           customStatusPaths:
-            - key: '(.parents[] | select(.controllerName == "istio.io/gateway-controller")).conditions[] | select(.type == "Accepted").status'
+            - key: '(.parents[] | select(.controllerName == "{{$GATEWAY_CONTROLLER_NAME}}")).conditions[] | select(.type == "Accepted").status'
               value: "True"
         inputVars:
           KUADRANT_ZONE_ROOT_DOMAIN: "{{$KUADRANT_ZONE_ROOT_DOMAIN}}"

--- a/scale_test/control-plane.md
+++ b/scale_test/control-plane.md
@@ -15,6 +15,7 @@ export KUADRANT_ZONE_ROOT_DOMAIN=[domain]
 export KUADRANT_AWS_REGION=[region]
 export PROMETHEUS_URL=http://127.0.0.1:9090
 export PROMETHEUS_TOKEN=""
+export USE_STANDALONE_MESH=false # false indicates that Openshift Ingress is used
 export OS_INDEXING=true   # if sending metrics to opensearch/elasticsearch
 export ES_SERVER=https://[user]:[password]@[host]:[port]
 
@@ -29,9 +30,14 @@ export OS_INDEXING= # to disable indexing
 export ES_SERVER= # to disable indexing
 ```
 
+If you installed OSSMv3 yourself (IE you are not using Openshift Ingress feature available since OCP v4.19):
+```
+export USE_STANDALONE_MESH=true
+```
+
 ## Execution
 
-`kube-burner init -c ./control-plane-config.yaml --timeout 5m --uuid scale-test-$(openssl rand -hex 3)`
+`kube-burner init -c ./control-plane-config.yaml --timeout 15m --uuid scale-test-$(openssl rand -hex 3)`
 
 Don't forget to increase the timeout if a larger number of CRs are to be created. You might also modify policy templates based on your needs, e.g. increase limits in RateLimitPolicy CR templates etc.
 
@@ -46,7 +52,7 @@ export SKIP_CLEANUP=true
 If so then note the UUID of your scale test run so that you can perform manual cleanup. The DNSPolicy CR needs to be removed manually first. That triggers corresponding DNSRecord CR removal. It is not handled gracefully by Kube Burner cleanup so better to remove it manually beforehand:
 
 ```
-kubectl delete dnspolicy [:dns_policy_name] -n scale-test-0
+kubectl delete dnspolicy --all -n scale-test-0
 kube-burner destroy --uuid [:uuid]
 ```
 

--- a/scale_test/max-gateway-listeners/README.md
+++ b/scale_test/max-gateway-listeners/README.md
@@ -11,6 +11,11 @@ export PROMETHEUS_URL=https://thanos-querier-openshift-monitoring.your.thanos.ro
 export OS_INDEXING=  # set as empty string if don't want indexing
 export ES_SERVER=  # format: https://username:password@your.opensearch.instance.com
 export SKIP_CLEANUP=true  # No automatic way to test the enforced policies, so generally set to true
+export USE_STANDALONE_MESH=false # false indicates that Openshift Ingress is used
+```
+If you installed OSSMv3 yourself (IE you are not using Openshift Ingress feature available since OCP v4.19):
+```
+export USE_STANDALONE_MESH=true
 ```
 
 #### Cloud configuration (One of the following)
@@ -37,4 +42,16 @@ export AZURE_CONFIG_JSON='{\"tenantId\":\"abcd-4320\",\"subscriptionId\":\"321-2
 ### Test created dns records
 ```shell
 ./test.sh <KUBE_BURNER_RUN_UUID>
+```
+
+### Cleanup
+
+Manually remove DNSPolicies
+```shell
+kubectl delete dnspolicy --all -n max-gateway-listeners-scale-test-0
+```
+
+Wait for all the DNSRecords to get removed, it might take a while. Then proceed with
+```shell
+kube-burner destroy --uuid <KUBE_BURNER_RUN_UUID>
 ```

--- a/scale_test/max-gateway-listeners/config.yaml
+++ b/scale_test/max-gateway-listeners/config.yaml
@@ -1,6 +1,11 @@
 {{ if not (has .DNS_PROVIDER (list "aws" "gcp" "azure")) }}
   {{ fail "DNS_PROVIDER must be aws, gcp, or azure" }}
 {{ end }}
+{{- $USE_STANDALONE_MESH := .USE_STANDALONE_MESH }}
+{{- $GATEWAY_CONTROLLER_NAME := "openshift.io/gateway-controller/v1" }}
+{{- if eq $USE_STANDALONE_MESH "true" }}
+  {{- $GATEWAY_CONTROLLER_NAME = "istio.io/gateway-controller" }}
+{{- end }}
 metricsEndpoints:
   - endpoint: {{ .PROMETHEUS_URL }}
     token: {{ .PROMETHEUS_TOKEN }}
@@ -78,6 +83,7 @@ jobs:
         inputVars:
           KUADRANT_ZONE_ROOT_DOMAIN: "{{.KUADRANT_ZONE_ROOT_DOMAIN}}"
           GW_NUM: 1
+          USE_STANDALONE_MESH: "{{$USE_STANDALONE_MESH}}"
       - objectTemplate: templates/gateway.yaml
         replicas: 1
         waitOptions:
@@ -87,11 +93,12 @@ jobs:
         inputVars:
           KUADRANT_ZONE_ROOT_DOMAIN: "{{.KUADRANT_ZONE_ROOT_DOMAIN}}"
           GW_NUM: 2
+          USE_STANDALONE_MESH: "{{$USE_STANDALONE_MESH}}"
       - objectTemplate: templates/httproute.yaml
         replicas: 1
         waitOptions:
           customStatusPaths:
-            - key: '(.parents[] | select(.controllerName == "istio.io/gateway-controller")).conditions[] | select(.type == "Accepted").status'
+            - key: '(.parents[] | select(.controllerName == "{{$GATEWAY_CONTROLLER_NAME}}")).conditions[] | select(.type == "Accepted").status'
               value: "True"
             - key: '(.parents[] | select(.controllerName == "kuadrant.io/policy-controller")).conditions[] | select(.type == "kuadrant.io/DNSPolicyAffected").status'
               value: "True"
@@ -102,7 +109,7 @@ jobs:
         replicas: 1
         waitOptions:
           customStatusPaths:
-            - key: '(.parents[] | select(.controllerName == "istio.io/gateway-controller")).conditions[] | select(.type == "Accepted").status'
+            - key: '(.parents[] | select(.controllerName == "{{$GATEWAY_CONTROLLER_NAME}}")).conditions[] | select(.type == "Accepted").status'
               value: "True"
             - key: '(.parents[] | select(.controllerName == "kuadrant.io/policy-controller")).conditions[] | select(.type == "kuadrant.io/DNSPolicyAffected").status'
               value: "True"

--- a/scale_test/max-gateway-listeners/templates/gateway.yaml
+++ b/scale_test/max-gateway-listeners/templates/gateway.yaml
@@ -1,3 +1,8 @@
+{{- $USE_STANDALONE_MESH := .USE_STANDALONE_MESH }}
+{{- $GATEWAY_CLASS_NAME := "openshift-default" }}
+{{- if eq $USE_STANDALONE_MESH "true" }}
+  {{- $GATEWAY_CLASS_NAME = "istio" }}
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata: 
@@ -5,7 +10,7 @@ metadata:
   labels: 
     app: max-gateway-listeners-scale-test
 spec: 
-  gatewayClassName: istio
+  gatewayClassName: {{$GATEWAY_CLASS_NAME}}
   listeners:
 {{- $context := . -}}
 {{- range $index := until 64 }}

--- a/scale_test/max-gateway-listeners/test.sh
+++ b/scale_test/max-gateway-listeners/test.sh
@@ -5,7 +5,7 @@ UUID="$1"
 
 for gw in 1 2; do
   for listener in {1..64}; do
-    url="http://gw${gw}-api${listener}.${UUID}.{$KUADRANT_ZONE_ROOT_DOMAIN}/get"
+    url="http://gw${gw}-api${listener}.${UUID}.${KUADRANT_ZONE_ROOT_DOMAIN}/get"
     if ! curl -sf -o /dev/null "$url"; then
       echo "Failed: $url" >&2
       exit 1

--- a/scale_test/namespaced-dns-operator-deployments-config.yaml
+++ b/scale_test/namespaced-dns-operator-deployments-config.yaml
@@ -1,4 +1,9 @@
 {{ $DNS_OPERATOR_GITHUB_URL := https://raw.githubusercontent.com/{{.DNS_OPERATOR_GITHUB_ORG}}/dns-operator/refs/heads/{{.DNS_OPERATOR_GITREF}} }}
+{{- $USE_STANDALONE_MESH := .USE_STANDALONE_MESH }}
+{{- $GATEWAY_CONTROLLER_NAME := "openshift.io/gateway-controller/v1" }}
+{{- if eq .USE_STANDALONE_MESH "true" }}
+  {{- $GATEWAY_CONTROLLER_NAME = "istio.io/gateway-controller" }}
+{{- end }}
 
 metricsEndpoints:
   - endpoint: {{ .PROMETHEUS_URL }}
@@ -121,6 +126,7 @@ jobs:
           KUADRANT_ZONE_ROOT_DOMAIN: '{{ $.KUADRANT_ZONE_ROOT_DOMAIN }}'
           NUM_LISTENERS: '{{ $.NUM_LISTENERS }}'
           GW_NUM: '{{ $gwNum }}'
+          USE_STANDALONE_MESH: "{{$USE_STANDALONE_MESH}}"
       - objectTemplate: templates/gw-dnspolicy-loadbalanced.yaml
         kind: DNSPolicy
         replicas: 1
@@ -139,7 +145,7 @@ jobs:
         replicas: 1
         waitOptions:
           customStatusPaths:
-            - key: '(.parents[] | select(.controllerName == "istio.io/gateway-controller")).conditions[] | select(.type == "Accepted").status'
+            - key: '(.parents[] | select(.controllerName == "{{$GATEWAY_CONTROLLER_NAME}}")).conditions[] | select(.type == "Accepted").status'
               value: "True"
         inputVars:
           KUADRANT_ZONE_ROOT_DOMAIN: '{{ $.KUADRANT_ZONE_ROOT_DOMAIN }}'

--- a/scale_test/namespaced-dns-operator-deployments.md
+++ b/scale_test/namespaced-dns-operator-deployments.md
@@ -10,7 +10,7 @@ In the kuadrant-operator directory, run the following to create a local kind clu
 ```shell
 make local-setup SUBNET_OFFSET=1 CIDR=26 NUM_IPS=64
 ```
-Note: In order to test at scale, metallb must be configured with enough ip address to assign one to each gateway to be created.  
+Note: In order to test at scale, metallb must be configured with enough ip address to assign one to each gateway to be created.
 
 ## Pre-test setup
 
@@ -22,7 +22,7 @@ Note: This is required for the default kubeburner workload (namespaced-dns-opera
 
 Deploy the observability stack:
 ```shell
-kubectl apply --server-side -k github.com/kuadrant/dns-operator/config/observability?ref=main # Run twice if it fails the first time dut o CRDs i.e. "ensure CRDs are installed first"
+kubectl apply --server-side -k github.com/kuadrant/dns-operator/config/observability?ref=main # Run twice if it fails the first time du to CRDs i.e. "ensure CRDs are installed first"
 ```
 Note: This should be in the kuadrant-operator repo instead of the dns operator
 
@@ -33,7 +33,7 @@ kubectl -n monitoring port-forward service/thanos-query 9090:9090
 
 ## Run test 
 
-The `test-scale-dnspolicy` make target can be used without input to run the default test workload with the default configuration:  
+The `test-scale-dnspolicy` make target can be used without input to run the default test workload with the default configuration:
 
 ```shell
 make test-scale-dnspolicy
@@ -60,7 +60,7 @@ Note: DNSPolices are deleted as part of the run as `SKIP_CLEANUP` defaults to fa
 
 Alternatively it can be executed passing in values as required. Please refer to the `test-scale-dnspolicy` make target for possible variables and their default values.
 ```shell
-make test-scale-dnspolicy JOB_ITERATIONS=1 NUM_GWS=1 NUM_LISTENERS=1 SKIP_CLEANUP=true DNS_PROVIDER=aws KUADRANT_ZONE_ROOT_DOMAIN=my.domain.com
+make test-scale-dnspolicy JOB_ITERATIONS=1 NUM_GWS=1 NUM_LISTENERS=1 SKIP_CLEANUP=true DNS_PROVIDER=aws KUADRANT_ZONE_ROOT_DOMAIN=my.domain.com USE_STANDALONE_MESH=false
 ```
 
 ## Workloads
@@ -81,7 +81,7 @@ In each test namespace a dns provider credential is created, the type created is
 Create a shared recordset in AWS (DNS_PROVIDER=aws) for a single host with four distinct A record values, owned by four DNSRecord resources, created by four gateway/dnspolices (JOB_ITERATIONS * NUM_GWS) processed by two dns operators(JOB_ITERATIONS). 
 
 ```shell
-make test-scale-dnspolicy JOB_ITERATIONS=2 NUM_GWS=2 NUM_LISTENERS=1 DNS_PROVIDER=aws KUADRANT_AWS_ACCESS_KEY_ID=<my aws access key> KUADRANT_AWS_SECRET_ACCESS_KEY=<my aws secret id>. KUADRANT_AWS_REGION='' KUADRANT_ZONE_ROOT_DOMAIN=mn.hcpapps.net SKIP_CLEANUP=true
+make test-scale-dnspolicy JOB_ITERATIONS=2 NUM_GWS=2 NUM_LISTENERS=1 DNS_PROVIDER=aws KUADRANT_AWS_ACCESS_KEY_ID=<my aws access key> KUADRANT_AWS_SECRET_ACCESS_KEY=<my aws secret id>. KUADRANT_AWS_REGION='' KUADRANT_ZONE_ROOT_DOMAIN=mn.hcpapps.net SKIP_CLEANUP=true USE_STANDALONE_MESH=false
 ...
 time="2025-01-13 10:19:27" level=info msg="Finished execution with UUID: 469d4b4e-6c41-4433-8c4b-2c48ea4973bc" file="job.go:247"
 time="2025-01-13 10:19:27" level=info msg="👋 Exiting kube-burner 469d4b4e-6c41-4433-8c4b-2c48ea4973bc" file="kube-burner.go:85"

--- a/scale_test/templates/gw-tls.yaml
+++ b/scale_test/templates/gw-tls.yaml
@@ -1,6 +1,11 @@
 {{- $Iteration := .Iteration }}
 {{- $KUADRANT_ZONE_ROOT_DOMAIN := .KUADRANT_ZONE_ROOT_DOMAIN }}
 {{- $GW_NUM := .GW_NUM }}
+{{- $USE_STANDALONE_MESH := .USE_STANDALONE_MESH }}
+{{- $GATEWAY_CLASS_NAME := "openshift-default" }}
+{{- if eq $USE_STANDALONE_MESH "true" }}
+  {{- $GATEWAY_CLASS_NAME = "istio" }}
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata: 
@@ -8,7 +13,7 @@ metadata:
   labels: 
     app: scale-test
 spec: 
-  gatewayClassName: istio
+  gatewayClassName: {{$GATEWAY_CLASS_NAME}}
   listeners: 
 {{- $numListeners := .NUM_LISTENERS | atoi }}
 {{- range $index := until $numListeners }}

--- a/scale_test/templates/gw.yaml
+++ b/scale_test/templates/gw.yaml
@@ -1,3 +1,8 @@
+{{- $USE_STANDALONE_MESH := .USE_STANDALONE_MESH }}
+{{- $GATEWAY_CONTROLLER_NAME := "openshift.io/gateway-controller/v1" }}
+{{- if eq $USE_STANDALONE_MESH "true" }}
+  {{- $GATEWAY_CONTROLLER_NAME = "istio.io/gateway-controller" }}
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata: 
@@ -5,7 +10,7 @@ metadata:
   labels: 
     app: scale-test
 spec: 
-  gatewayClassName: istio
+  gatewayClassName: {{$GATEWAY_CLASS_NAME}}
   listeners:
 {{- $numListeners := .NUM_LISTENERS | atoi }}
 {{- range $index := until $numListeners }}

--- a/scale_test/templates/httpbin-service.yaml
+++ b/scale_test/templates/httpbin-service.yaml
@@ -2,7 +2,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: httpbin
+  name: httpbin-service
   labels:
     app: scale-test
 spec:

--- a/scale_test/templates/httproute-listener.yaml
+++ b/scale_test/templates/httproute-listener.yaml
@@ -20,7 +20,7 @@ spec:
   - backendRefs:
     - group: ''
       kind: Service
-      name: httpbin
+      name: httpbin-service
       port: 8080
       weight: 1
     matches:

--- a/scale_test/templates/httproute.yaml
+++ b/scale_test/templates/httproute.yaml
@@ -15,7 +15,7 @@ spec:
   - backendRefs:
     - group: ''
       kind: Service
-      name: httpbin
+      name: httpbin-service
       port: 8080
       weight: 1
     matches:


### PR DESCRIPTION
## Description
This PR adds support for both OpenShift Ingress (available in OCP 4.19+) and standalone OSSM v3 configurations in scale tests, making the test compatible with different OSSMv3 deployment scenarios.

Closes https://github.com/Kuadrant/testsuite/issues/712

### Key Changes
- Introduce USE_STANDALONE_MESH environment variable to toggle between OpenShift Ingress (OCP 4.19+) and standalone OSSM v3
- Set appropriate gateway class names: `openshift-default` vs `istio`
- Configure correct gateway controller names: `openshift.io/gateway-controller/v1` vs `istio.io/gateway-controller`
- Update documentation with new configuration options and cleanup procedures

### Additional Small Changes
- Increase default timeout from 5m to 15m for scale tests
- Fix variable expansion in max-gateway-listeners test script
- Service renaming: `httpbin` -> `httpbin-service` in HTTPRoute templates. Reason was that `<SERVICE_NAME>_PORT` env var is auto-injected by Kubernetes/OpenShift for every Service in the namespace (in this particular case it is `HTTPBIN_PORT` and the injected value is `tcp://<some-ip>:8080`) and the httpbin app (from `quay.io/rhn_support_azgabur/httpbin:latest`) uses `HTTPBIN_PORT` env var for determining the port and it expects numerical value there. This leads to `Error: 'tcp' is not a valid port number.`

## Verification Steps

Eye review.
Ideal would be to execute both control plane scale test and max gateway listeners test twice - against Kuadrant on OCP v4.19 installed using Openshift Ingress and against Kuadrant on OCP v4.18 or before using standalone OSSMv3. You can just follow the control-plane.md and max-gateway-listeners/README.md files. No need to run the DNS Operator scale test - it is not really used at the moment.
