### PR TITLE
Fix kuadrantctl tests

### DIFF
--- a/testsuite/kuadrantctl.py
+++ b/testsuite/kuadrantctl.py
@@ -1,6 +1,5 @@
-# pylint: disable=line-too-long
 """
-Help as of 0.2.3
+kuadrantctl v0.5.0
 Kuadrant configuration command line utility
 
 Usage:
@@ -9,27 +8,15 @@ Usage:
 Available Commands:
   completion  Generate the autocompletion script for the specified shell
   generate    Commands related to kubernetes object generation
-    gatewayapi  Generate Gataway API resources
-        httproute   Generate Gateway API HTTPRoute from OpenAPI 3.0.X
-    kuadrant    Generate Kuadrant resources
-        authpolicy      Generate Kuadrant AuthPolicy from OpenAPI 3.0.X
-        ratelimitpolicy Generate Kuadrant Rate Limit Policy from OpenAPI 3.0.X
-
-
   help        Help about any command
+  topology    Export and visualize Kuadrant topology
   version     Print the version number of kuadrantctl
 
 Flags:
-  -h, --help                   help for httproute
-      --oas string             Path to OpenAPI spec file (in JSON or YAML format), URL, or '-' to read from standard input (required)
-  -o, --output-format string   Output format: 'yaml' or 'json'. (default "yaml")
-
-Global Flags:
+  -h, --help      help for kuadrantctl
   -v, --verbose   verbose output
 
-
 Use "kuadrantctl [command] --help" for more information about a command.
-
 """
 
 import subprocess

--- a/testsuite/tests/kuadrantctl/cli/test_basic_commands.py
+++ b/testsuite/tests/kuadrantctl/cli/test_basic_commands.py
@@ -3,10 +3,21 @@
 import pytest
 
 
-# https://github.com/Kuadrant/kuadrantctl/issues/90
 @pytest.mark.parametrize("command", ["help", "version"])
 def test_commands(kuadrantctl, command):
-    """Test that basic commands exists and returns anything"""
+    """Test that basic commands exist and return anything"""
     result = kuadrantctl.run(command)
+    assert not result.stderr, f"Command '{command}' returned an error: {result.stderr}"
+    assert result.stdout, f"Command '{command}' returned empty output"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [("completion", "bash"), ("completion", "zsh"), ("completion", "fish"), ("completion", "powershell")],
+    ids=["bash", "zsh", "fish", "powershell"],
+)
+def test_completion(kuadrantctl, command):
+    """Test that completion commands exist and return anything"""
+    result = kuadrantctl.run(*command)
     assert not result.stderr, f"Command '{command}' returned an error: {result.stderr}"
     assert result.stdout, f"Command '{command}' returned empty output"

--- a/testsuite/tests/kuadrantctl/conftest.py
+++ b/testsuite/tests/kuadrantctl/conftest.py
@@ -6,7 +6,10 @@ from importlib import resources
 import pytest
 import yaml
 
+from testsuite.backend.httpbin import Httpbin
+from testsuite.gateway.gateway_api.gateway import KuadrantGateway
 from testsuite.gateway.gateway_api.route import HTTPRoute
+from testsuite.gateway import Gateway, GatewayListener, Hostname
 from testsuite.kuadrantctl import KuadrantCTL
 from testsuite.oas import OASWrapper
 
@@ -22,12 +25,38 @@ def kuadrantctl(testconfig, skip_or_fail):
 
 @pytest.fixture(scope="module")
 def oas():
-    """
-    OpenAPISpecification definition
-    """
+    """OpenAPISpecification definition"""
     return OASWrapper(
         yaml.safe_load(resources.files("testsuite.resources.oas").joinpath("base_httpbin.yaml").read_text())
     )
+
+
+@pytest.fixture(scope="session")
+def backend(request, cluster, blame, label, testconfig):
+    """Deploys Httpbin backend"""
+    image = testconfig["httpbin"]["image"]
+    httpbin = Httpbin(cluster, blame("httpbin"), label, image)
+    request.addfinalizer(httpbin.delete)
+    httpbin.commit()
+    return httpbin
+
+
+@pytest.fixture(scope="session")
+def gateway(request, cluster, blame, label, wildcard_domain) -> Gateway:
+    """Deploys Gateway that wires up the Backend behind the reverse-proxy and Authorino instance"""
+    gw = KuadrantGateway.create_instance(cluster, blame("gw"), {"app": label})
+    gw.add_listener(GatewayListener(hostname=wildcard_domain))
+    request.addfinalizer(gw.delete)
+    gw.commit()
+    gw.wait_for_ready()
+    return gw
+
+
+@pytest.fixture(scope="module")
+def hostname(gateway, exposer, blame) -> Hostname:
+    """Exposed Hostname object"""
+    hostname = exposer.expose_hostname(blame("hostname"), gateway)
+    return hostname
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
Fix kuadrantctl tests. Added new test for shell completions.

Closes #514 

### Verification steps

Don't need to verify, it generates policies with old manifests. kuadrantctl is not being developed or updated currently. 

Basic commands and route generation tests still work though.
