### PR TITLE
Add class for TelemetryPolicy

### DIFF
--- a/testsuite/kuadrant/extensions/telemetry_policy.py
+++ b/testsuite/kuadrant/extensions/telemetry_policy.py
@@ -1,0 +1,50 @@
+"""Module containing classes related to TelemetryPolicy"""
+
+from typing import Dict
+
+from testsuite.gateway import Referencable
+from testsuite.kubernetes import modify
+from testsuite.kubernetes.client import KubernetesClient
+from testsuite.kuadrant.policy import Policy
+
+
+class TelemetryPolicy(Policy):
+    """TelemetryPolicy for configuring telemetry metrics labels"""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def create_instance(
+        cls,
+        cluster: KubernetesClient,
+        name: str,
+        target: Referencable,
+        labels: Dict[str, str] = None,
+        section_name: str = None,
+    ):
+        """Creates base instance"""
+        model: Dict = {
+            "apiVersion": "extensions.kuadrant.io/v1alpha1",
+            "kind": "TelemetryPolicy",
+            "metadata": {"name": name, "namespace": cluster.project, "labels": labels},
+            "spec": {
+                "targetRef": target.reference,
+            },
+        }
+        if section_name:
+            model["spec"]["targetRef"]["sectionName"] = section_name
+
+        return cls(model, context=cluster.context)
+
+    @modify
+    def add_label(self, label_name, label_path):
+        """Add a label to the TelemetryPolicy"""
+        metrics = self.model.spec.setdefault("metrics", {})
+        default = metrics.setdefault("default", {})
+        labels = default.setdefault("labels", {})
+        labels[label_name] = label_path
+
+    def wait_for_ready(self):
+        # TODO: Delete this method when TelemetryPolicy status is fixed.
+        pass


### PR DESCRIPTION
## Description
Adds TelemetryPolicy class into testsuite that allows configuring telemetry metrics labels on Gateway resources.

Known Issues
- TODO: Delete wait_for_ready(self) method when TelemetryPolicy status is fixed.

