### PR TITLE
Add trlp metric tests

### DIFF
--- a/testsuite/tests/singlecluster/limitador/metrics/trlp_metrics/conftest.py
+++ b/testsuite/tests/singlecluster/limitador/metrics/trlp_metrics/conftest.py
@@ -1,0 +1,130 @@
+"""Conftest for TokenRateLimitPolicy metrics tests"""
+
+import pytest
+
+from testsuite.backend.llm_sim import LlmSim
+from testsuite.httpx.auth import HeaderApiKeyAuth
+from testsuite.kuadrant.extensions.telemetry_policy import TelemetryPolicy
+from testsuite.kuadrant.policy import CelExpression, CelPredicate
+from testsuite.kuadrant.policy.authorization import JsonResponse, ValueFrom
+from testsuite.kuadrant.policy.rate_limit import Limit
+from testsuite.kuadrant.policy.token_rate_limit import TokenRateLimitPolicy
+
+FREE_USER_LIMIT = Limit(limit=15, window="30s")
+PAID_USER_LIMIT = Limit(limit=30, window="60s")
+
+
+@pytest.fixture(scope="module")
+def backend(request, cluster, blame, label, testconfig):
+    """Deploys LlmSim backend"""
+    image = testconfig["llm_sim"]["image"]
+    llmsim = LlmSim(cluster, blame("llm-sim"), "meta-llama/Llama-3.1-8B-Instruct", label, image)
+    request.addfinalizer(llmsim.delete)
+    llmsim.commit()
+    return llmsim
+
+
+@pytest.fixture(scope="module")
+def user_label(blame):
+    """Creates a label prefixed as user"""
+    return blame("user")
+
+
+@pytest.fixture(scope="module")
+def free_user_api_key(create_api_key, user_label, blame):
+    """Creates API key Secret for a free user"""
+    annotations = {"kuadrant.io/groups": "free", "secret.kuadrant.io/user-id": blame("free-user")}
+    return create_api_key("api-key", user_label, "iamafreeuser", annotations=annotations)
+
+
+@pytest.fixture(scope="module")
+def paid_user_api_key(create_api_key, user_label, blame):
+    """Creates API key Secret for a paid user"""
+    annotations = {"kuadrant.io/groups": "paid", "secret.kuadrant.io/user-id": blame("paid-user")}
+    return create_api_key("api-key", user_label, "iamapaiduser", annotations=annotations)
+
+
+@pytest.fixture(scope="module")
+def free_user_auth(free_user_api_key):
+    """Valid API Key Auth for free user"""
+    return HeaderApiKeyAuth(free_user_api_key)
+
+
+@pytest.fixture(scope="module")
+def paid_user_auth(paid_user_api_key):
+    """Valid API Key Auth for paid user"""
+    return HeaderApiKeyAuth(paid_user_api_key)
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization, free_user_api_key):
+    """Sets AuthPolicy to validate the users API key, expose user ID/groups, and allow free/paid groups"""
+    authorization.identity.add_api_key("api-key", selector=free_user_api_key.selector)
+    authorization.responses.add_success_dynamic(
+        "identity",
+        JsonResponse(
+            {
+                "userid": ValueFrom("auth.identity.metadata.annotations.secret\\.kuadrant\\.io/user-id"),
+                "groups": ValueFrom("auth.identity.metadata.annotations.kuadrant\\.io/groups"),
+            }
+        ),
+    )
+    authorization.authorization.add_opa_policy(
+        "allow-groups",
+        """
+        groups := split(object.get(input.auth.identity.metadata.annotations, "kuadrant.io/groups", ""), ",")
+        allow { groups[_] == "free" }
+        allow { groups[_] == "paid" }
+        """,
+    )
+
+    return authorization
+
+
+@pytest.fixture(scope="module")
+def token_rate_limit(cluster, blame, module_label, route):
+    """Creates TokenRateLimitPolicy for free and paid users"""
+    policy = TokenRateLimitPolicy.create_instance(cluster, blame("trlp"), route, labels={"testRun": module_label})
+
+    policy.add_limit(
+        name="free",
+        limits=[FREE_USER_LIMIT],
+        when=[
+            CelPredicate('request.path == "/v1/chat/completions"'),
+            CelPredicate('auth.identity.groups.split(",").exists(g, g == "free")'),
+        ],
+        counters=[CelExpression("auth.identity.userid")],
+    )
+
+    policy.add_limit(
+        name="paid",
+        limits=[PAID_USER_LIMIT],
+        when=[
+            CelPredicate('request.path == "/v1/chat/completions"'),
+            CelPredicate('auth.identity.groups.split(",").exists(g, g == "paid")'),
+        ],
+        counters=[CelExpression("auth.identity.userid")],
+    )
+
+    return policy
+
+
+@pytest.fixture(scope="module")
+def telemetry_policy(cluster, blame, module_label, gateway):
+    """Add a telemetry policy to expose user and group labels in metrics"""
+    policy = TelemetryPolicy.create_instance(cluster, blame("user-group"), gateway, labels={"testRun": module_label})
+
+    policy.add_label("user", "auth.identity.userid")
+    policy.add_label("group", "auth.identity.groups")
+
+    return policy
+
+
+@pytest.fixture(scope="module", autouse=True)
+def commit(request, authorization, token_rate_limit, telemetry_policy):
+    """Commits policies"""
+    components = [authorization, token_rate_limit, telemetry_policy]
+    for component in components:
+        request.addfinalizer(component.delete)
+        component.commit()
+        component.wait_for_ready()

--- a/testsuite/tests/singlecluster/limitador/metrics/trlp_metrics/test_trlp_metrics.py
+++ b/testsuite/tests/singlecluster/limitador/metrics/trlp_metrics/test_trlp_metrics.py
@@ -1,0 +1,130 @@
+"""
+Tests for TokenRateLimitPolicy metrics with TelemetryPolicy
+
+User Guide:
+https://github.com/Kuadrant/kuadrant-operator/blob/a1ad64a2fb9230985230b57695fface04c3b8d3c/doc/user-guides/observability/token-metrics.md
+"""
+
+import pytest
+
+
+basic_request = {
+    "model": "meta-llama/Llama-3.1-8B-Instruct",
+    "messages": [{"role": "user", "content": "What is Kubernetes?"}],
+    "stream": False,  # disable streaming (default)
+    "usage": True,  # ensures `usage.total_tokens` is returned in the response
+    "max_tokens": 50,
+}
+
+
+@pytest.fixture(scope="module")
+def token_usage(prometheus, pod_monitor, client, free_user_auth, paid_user_auth):
+    """Send requests to generate metrics, trigger rate limiting and return token usage"""
+    # Free user requests
+    free_tokens = 0
+    for _ in range(10):
+        response = client.post("/v1/chat/completions", auth=free_user_auth, json={**basic_request})
+        if response.status_code == 200:
+            free_tokens += response.json().get("usage", {}).get("total_tokens", 0)
+        elif response.status_code == 429:
+            break  # stop once free user is rate-limited
+
+    # Paid user requests
+    paid_tokens = 0
+    for _ in range(10):
+        response = client.post("/v1/chat/completions", auth=paid_user_auth, json={**basic_request})
+        if response.status_code == 200:
+            paid_tokens += response.json().get("usage", {}).get("total_tokens", 0)
+        elif response.status_code == 429:
+            break  # stop once paid user is rate-limited
+
+    # Wait for metrics to propagate
+    prometheus.wait_for_scrape(pod_monitor, "/metrics")
+
+    return {
+        "free_total_tokens": free_tokens,
+        "paid_total_tokens": paid_tokens,
+    }
+
+
+def test_authorized_hits_metric_exists_and_increments_free_user(
+    prometheus, limitador, route, pod_monitor, free_user_api_key, token_usage
+):
+    """Verify `authorized_hits` metric is emitted and accumulates tokens consumed for free user/group"""
+    metrics = prometheus.get_metrics(
+        labels={
+            "pod": limitador.pod.name(),
+            "limitador_namespace": f"{route.namespace()}/{route.name()}",
+            "job": f"{pod_monitor.namespace()}/{pod_monitor.name()}",
+            "user": free_user_api_key.model.metadata.annotations["secret.kuadrant.io/user-id"],
+            "group": "free",
+        }
+    )
+
+    # Ensure `authorized_hits` metric exists for this user/group
+    authorized_hits = metrics.filter(lambda x: x["metric"]["__name__"] == "authorized_hits")
+    assert len(authorized_hits.metrics) == 1
+
+    # Verify the metric is accumulating tokens
+    actual_hits = authorized_hits.values[0]
+    expected_tokens = token_usage["free_total_tokens"]
+    assert actual_hits > 0, f"authorized_hits must be > 0, got {actual_hits}"
+
+    # Verify the token metric value remains within the range of total tokens consumed
+    # Token values will vary slightly due to timing of Prometheus scrapes, hence why exact matching is not asserted
+    assert (
+        actual_hits <= expected_tokens
+    ), f"authorized_hits ({actual_hits}) should not exceed tokens consumed ({expected_tokens}) for free user"
+
+
+def test_authorized_hits_metric_exists_and_increments_paid_user(
+    prometheus, limitador, route, pod_monitor, paid_user_api_key, token_usage
+):
+    """Verify `authorized_hits` metric is emitted and accumulates tokens consumed for paid user/group"""
+    metrics = prometheus.get_metrics(
+        labels={
+            "pod": limitador.pod.name(),
+            "limitador_namespace": f"{route.namespace()}/{route.name()}",
+            "job": f"{pod_monitor.namespace()}/{pod_monitor.name()}",
+            "user": paid_user_api_key.model.metadata.annotations["secret.kuadrant.io/user-id"],
+            "group": "paid",
+        }
+    )
+
+    authorized_hits = metrics.filter(lambda x: x["metric"]["__name__"] == "authorized_hits")
+    assert len(authorized_hits.metrics) == 1
+
+    actual_hits = authorized_hits.values[0]
+    expected_tokens = token_usage["paid_total_tokens"]
+    assert actual_hits > 0, f"authorized_hits must be > 0, got {actual_hits}"
+    assert (
+        actual_hits <= expected_tokens
+    ), f"authorized_hits ({actual_hits}) should not exceed tokens consumed ({expected_tokens}) for paid user"
+
+
+def test_metrics_reported_per_user_and_group(
+    prometheus, limitador, route, pod_monitor, free_user_api_key, paid_user_api_key, token_usage
+):  # pylint: disable=unused-argument
+    """Ensure 'authorized_hits', 'authorized_calls', and 'limited_calls' are reported separately per user/group"""
+    metrics = prometheus.get_metrics(
+        labels={
+            "pod": limitador.pod.name(),
+            "limitador_namespace": f"{route.namespace()}/{route.name()}",
+            "job": f"{pod_monitor.namespace()}/{pod_monitor.name()}",
+        }
+    )
+
+    for metric_name in ("authorized_hits", "authorized_calls", "limited_calls"):
+        free_metrics = metrics.filter(
+            lambda x, mn=metric_name: x["metric"]["__name__"] == mn
+            and x["metric"]["group"] == "free"
+            and x["metric"]["user"] == free_user_api_key.model.metadata.annotations["secret.kuadrant.io/user-id"]
+        )
+        paid_metrics = metrics.filter(
+            lambda x, mn=metric_name: x["metric"]["__name__"] == mn
+            and x["metric"]["group"] == "paid"
+            and x["metric"]["user"] == paid_user_api_key.model.metadata.annotations["secret.kuadrant.io/user-id"]
+        )
+
+        assert len(free_metrics.metrics) == 1, f"{metric_name} metric not found with free user/group labels"
+        assert len(paid_metrics.metrics) == 1, f"{metric_name} metric not found with paid user/group labels"


### PR DESCRIPTION
### Description

This PR adds tests for TokenRateLimitPolicy metrics to verify that Limitador exposes token usage metrics, correctly labeled with `user` and `group` from the TelemetryPolicy. The tests validate that the expected metrics (`authorized_hits`, `authorized_calls`, and `limited_calls`) are emitted, accumulate as requests are made, and are correctly separated by user and group labels.

These tests cover the cases defined in https://github.com/Kuadrant/kuadrant-operator/issues/1515.

### Related Items

- Issue: https://github.com/Kuadrant/kuadrant-operator/issues/1460  
- Jira: [CONNLINK-484](https://issues.redhat.com/browse/CONNLINK-484)  
- User Guide: [Token Metrics Monitoring Guide](https://github.com/Kuadrant/kuadrant-operator/blob/a1ad64a2fb9230985230b57695fface04c3b8d3c/doc/user-guides/observability/token-metrics.md)

Closes https://github.com/Kuadrant/kuadrant-operator/issues/1515