### PR TITLE
Add CoreDNS metrics tests

### DIFF
--- a/testsuite/prometheus.py
+++ b/testsuite/prometheus.py
@@ -19,6 +19,15 @@ def _params(key: str = "", labels: dict[str, str] = None) -> dict[str, str]:
     return {"query": "%s{%s}" % (key, ",".join(f"{k}='{v}'" for k, v in labels.items()))}
 
 
+def has_label(label_name: str, label_value: str):
+    """Returns function, that returns True if given metric has specific label with specific value"""
+
+    def _has_label(metric):
+        return metric["metric"].get(label_name) == label_value
+
+    return _has_label
+
+
 class Metrics:
     """Interface to the returned Prometheus metrics"""
 

--- a/testsuite/tests/multicluster/coredns/two_clusters/metrics/conftest.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/metrics/conftest.py
@@ -1,0 +1,45 @@
+"""Conftest for DNS Operator metrics tests"""
+
+import pytest
+
+from testsuite.kubernetes.secret import Secret
+from testsuite.kubernetes.monitoring import MetricsEndpoint
+from testsuite.kubernetes.monitoring.service_monitor import ServiceMonitor
+
+pytestmark = [pytest.mark.multicluster, pytest.mark.disruptive]
+
+
+@pytest.fixture(scope="module")
+def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
+    """Creates Opaque secrets containing kubeconfig for the secondary cluster2 on primary cluster"""
+    tools2 = cluster2.change_project("tools")
+    coredns_sa2 = tools2.get_service_account("coredns")
+    kubeconfig2 = coredns_sa2.get_kubeconfig(blame("ctx"), blame("usr"), blame("clstr"), api_url=tools2.api_url)
+
+    return [
+        Secret.create_instance(
+            cluster.change_project(testconfig["service_protection"]["system_project"]),
+            blame("kubecfg"),
+            {"kubeconfig": kubeconfig2},
+            secret_type="Opaque",
+            labels={"app": module_label, "kuadrant.io/multicluster-kubeconfig": "true"},
+        )
+    ]
+
+
+@pytest.fixture(scope="package")
+def service_monitor(cluster, request, testconfig, blame):
+    """Create ServiceMonitor object to follow DNS Operator controller /metrics endpoint"""
+    system_project = cluster.change_project(testconfig["service_protection"]["system_project"])
+    endpoints = [MetricsEndpoint("/metrics", "metrics")]
+    match_labels = {"control-plane": "dns-operator-controller-manager"}
+    monitor = ServiceMonitor.create_instance(system_project, blame("sm"), endpoints, match_labels=match_labels)
+    request.addfinalizer(monitor.delete)
+    monitor.commit()
+    return monitor
+
+
+@pytest.fixture(scope="package", autouse=True)
+def wait_for_active_targets(prometheus, service_monitor):
+    """Waits for all endpoints in Service Monitor to become active targets"""
+    assert prometheus.is_reconciled(service_monitor), "Service Monitor didn't get reconciled in time"

--- a/testsuite/tests/multicluster/coredns/two_clusters/metrics/test_metrics.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/metrics/test_metrics.py
@@ -1,0 +1,76 @@
+"""Test multi-cluster CoreDNS metrics exposed by the DNS Operator on /metrics endpoint"""
+
+import pytest
+
+from testsuite.prometheus import has_label
+
+pytestmark = [pytest.mark.multicluster, pytest.mark.disruptive]
+
+
+@pytest.fixture(scope="module")
+def dns_metrics(prometheus, service_monitor):
+    """Return all metrics from the DNS Operator controller /metrics endpoint"""
+    prometheus.wait_for_scrape(service_monitor, "/metrics")
+    return prometheus.get_metrics(labels={"service": "dns-operator-controller-manager-metrics-service"})
+
+
+def test_authoritative_record_metrics(testconfig, dns_metrics, dnsrecord1):
+    """Test metrics for the authoritative DNSRecord on the primary cluster"""
+    authoritative_record_metrics = dns_metrics.filter(has_label("dns_record_name", dnsrecord1.model.status.zoneID))
+
+    authoritative_record = authoritative_record_metrics.filter(
+        has_label("__name__", "dns_provider_record_ready") and has_label("dns_record_is_delegating", "false")
+    )
+    assert len(authoritative_record.metrics) == 1
+    assert (
+        authoritative_record.metrics[0]["metric"]["dns_record_root_host"] == f'ns1.{testconfig["dns"]["coredns_zone"]}'
+    )
+    assert authoritative_record.values[0] == 1.0
+
+    dns_provider_authoritative_record_spec_info = authoritative_record_metrics.filter(
+        has_label("__name__", "dns_provider_authoritative_record_spec_info")
+    )
+    assert len(dns_provider_authoritative_record_spec_info.metrics) == 1
+    assert (
+        dns_provider_authoritative_record_spec_info.metrics[0]["metric"]["root_host"]
+        == f'ns1.{testconfig["dns"]["coredns_zone"]}'
+    )
+    assert dns_provider_authoritative_record_spec_info.values[0] == 1
+
+    assert "dns_provider_write_counter" in authoritative_record_metrics.names
+
+
+def test_delegating_record_metrics(testconfig, dns_metrics, dnsrecord1, dnsrecord2):
+    """Test metrics for 2 delegating DNSRecords"""
+    for rec in [dnsrecord1, dnsrecord2]:
+        delegating_record_metrics = dns_metrics.filter(has_label("dns_record_name", rec.name()))
+
+        delegating_record = delegating_record_metrics.filter(has_label("dns_record_is_delegating", "true"))
+        assert len(delegating_record.metrics) == 1
+        assert (
+            delegating_record.metrics[0]["metric"]["dns_record_root_host"] == f'ns1.{testconfig["dns"]["coredns_zone"]}'
+        )
+        assert delegating_record.metrics[0]["metric"]["dns_record_namespace"] == rec.namespace()
+        assert delegating_record.names[0] == "dns_provider_record_ready"
+        assert delegating_record.values[0] == 1.0
+
+        if rec is dnsrecord1:
+            assert "dns_provider_write_counter" in delegating_record_metrics.names
+
+
+def test_multi_cluster_count_metrics(dns_metrics):
+    """Test metric for active multi-cluster kubeconfig secrets loaded"""
+    active_multi_cluster_count = dns_metrics.filter(has_label("__name__", "dns_provider_active_multi_cluster_count"))
+    assert len(active_multi_cluster_count.metrics) == 1
+    assert active_multi_cluster_count.values[0] == 1
+
+
+def test_remote_records_metrics(dns_metrics, kubeconfig_secrets):
+    """Test metrics for remote records loaded from secondary clusters"""
+    remote_records_metrics = dns_metrics.filter(has_label("cluster", kubeconfig_secrets[0].name()))
+
+    remote_record = remote_records_metrics.filter(has_label("__name__", "dns_provider_remote_records"))
+    assert len(remote_record.metrics) == 1
+    assert remote_record.values[0] == 1
+
+    assert "dns_provider_remote_record_reconcile_count" in remote_records_metrics.names


### PR DESCRIPTION
## Summary

Add metrics testing for CoreDNS multicluster DNS operations in the Kuadrant testsuite.

Closes #772

## Changes

- **New metrics tests:**
  - Authoritative DNS record metrics verification (dns_provider_record_ready, dns_provider_write_counter, dns_provider_authoritative_record_spec_info)
  - Delegating DNS record metrics testing across primary/secondary clusters
  - Multi-cluster count metrics validation (dns_provider_active_multi_cluster_count)
  - Remote DNS records metrics testing (dns_provider_remote_records, dns_provider_remote_record_reconcile_count)

## Verification Steps

```bash
flags=-n1 make testsuite/tests/multicluster/coredns/two_clusters/metrics
```
You would need a 1 primary and 1 secondary cluster for this test. Primaries, at the moment of writing, are kua-419 and kua-419. Secondray can be whatever cluster with coredns service account installed on it