### PR TITLE
TelemetryPolicy's status has been implemented

### DIFF
--- a/testsuite/kuadrant/extensions/telemetry_policy.py
+++ b/testsuite/kuadrant/extensions/telemetry_policy.py
@@ -44,7 +44,3 @@ class TelemetryPolicy(Policy):
         default = metrics.setdefault("default", {})
         labels = default.setdefault("labels", {})
         labels[label_name] = label_path
-
-    def wait_for_ready(self):
-        # TODO: Delete this method when TelemetryPolicy status is fixed.
-        pass


### PR DESCRIPTION
## Description

TelemetryPolicy's status has been implemented so we can wait for it to get ready in a standard way.

### Verification Steps

Run some test that uses TelemetryPolicy:
```
make testsuite/tests/singlecluster/limitador/metrics/trlp_metrics/test_trlp_metrics.py
```

Note: the tests only work with Kuadrant v1.3.0+, do not work with RHCL v1.1.1 and before