### PR TITLE
Add CoreDNS cluster exposer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,15 @@ kuadrant-only: poetry-no-dev
 
 multicluster: ## Run Multicluster only tests
 multicluster: poetry-no-dev
-	$(PYTEST) -n2 -m 'multicluster and not disruptive' --dist loadfile --enforce $(flags) testsuite
+	$(PYTEST) -n2 -m 'multicluster and not disruptive' --dist loadfile --enforce $(flags) testsuite/tests/multicluster/
+
+coredns_one_primary: ## Run coredns one primary tests
+coredns_one_primary: poetry-no-dev
+	$(PYTEST) -n1 -m 'coredns_one_primary' --dist loadfile --enforce $(flags) testsuite/tests/multicluster/coredns/
+
+coredns_two_primaries: ## Run coredns two primary tests
+coredns_two_primaries: poetry-no-dev
+	$(PYTEST) -n1 -m 'coredns_two_primaries' --dist loadfile --enforce $(flags) testsuite/tests/multicluster/coredns/
 
 dnstls: ## Run DNS and TLS tests
 dnstls: poetry-no-dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ markers = [
     "smoke: Build verification test",
     "disruptive: Test is disruptive",
     "multicluster: Test is specifc to Multicluster deployment",
+    "coredns_one_primary: CoreDNS multicluster tests using one primary cluster",
+    "coredns_two_primaries: CoreDNS multicluster tests using two primary clusters",
 ]
 filterwarnings = [
     "ignore: WARNING the new order is not taken into account:UserWarning",

--- a/testsuite/config/__init__.py
+++ b/testsuite/config/__init__.py
@@ -60,6 +60,7 @@ settings = Dynaconf(
             Validator("letsencrypt.issuer.name", must_exist=True, ne=None)
             & Validator("letsencrypt.issuer.kind", must_exist=True, is_in={"Issuer", "ClusterIssuer"})
         ),
+        Validator("dns.coredns_zone", must_exist=True, ne=None),
         (
             Validator("dns.dns_server.address", must_exist=True, ne=None, cast=hostname_to_ip)
             & Validator("dns.dns_server.geo_code", must_exist=True, ne=None)

--- a/testsuite/gateway/gateway_api/hostname.py
+++ b/testsuite/gateway/gateway_api/hostname.py
@@ -64,3 +64,12 @@ class DNSPolicyExposer(Exposer):
 
     def delete(self):
         pass
+
+
+class CoreDNSExposer(DNSPolicyExposer):
+    """CoreDNS exposer with hosted coredns zone for base domain"""
+
+    @cached_property
+    def base_domain(self) -> str:
+        settings.validators.validate(only="dns.coredns_zone")
+        return f'{generate_tail(5)}.{settings["dns"]["coredns_zone"]}'

--- a/testsuite/tests/multicluster/conftest.py
+++ b/testsuite/tests/multicluster/conftest.py
@@ -34,7 +34,7 @@ def hostname(gateway, exposer, blame) -> Hostname:
     return exposer.expose_hostname(blame("hostname"), gateway)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def exposer(request, cluster) -> Exposer:
     """Expose using DNSPolicy"""
     exposer = DNSPolicyExposer(cluster)

--- a/testsuite/tests/multicluster/coredns/three_clusters/conftest.py
+++ b/testsuite/tests/multicluster/coredns/three_clusters/conftest.py
@@ -60,17 +60,13 @@ def coredns_secrets(
 
 
 @pytest.fixture(scope="module")
-def dnsrecord3(cluster3, testconfig, blame, module_label):
+def dnsrecord3(cluster3, testconfig, hostname, blame, module_label):
     """Return a DNSRecord instance ready for commit"""
     return DNSRecord.create_instance(
         cluster3,
         blame("rcrd3"),
-        f'ns1.{testconfig["dns"]["coredns_zone"]}',
-        endpoints=[
-            DNSRecordEndpoint(
-                dnsName=f'ns1.{testconfig["dns"]["coredns_zone"]}', recordType="A", recordTTL=60, targets=[IP3]
-            )
-        ],
+        testconfig["dns"]["coredns_zone"],
+        endpoints=[DNSRecordEndpoint(dnsName=hostname.hostname, recordType="A", recordTTL=60, targets=[IP3])],
         delegate=True,
         labels={"app": module_label},
     )

--- a/testsuite/tests/multicluster/coredns/three_clusters/test_one_primary_two_secondary.py
+++ b/testsuite/tests/multicluster/coredns/three_clusters/test_one_primary_two_secondary.py
@@ -7,7 +7,7 @@ from testsuite.kubernetes.secret import Secret
 from ..conftest import IP1, IP2
 from .conftest import IP3
 
-pytestmark = [pytest.mark.multicluster, pytest.mark.disruptive]
+pytestmark = [pytest.mark.coredns_one_primary]
 
 
 @pytest.fixture(scope="module")
@@ -57,7 +57,7 @@ def kubeconfig_secrets(testconfig, cluster, cluster2, cluster3, blame, module_la
     return secrets
 
 
-def test_one_primary_two_secondary(testconfig):
+def test_one_primary_two_secondary(hostname):
     """IPs from 1 primary and 2 secondary clusters should return in DNS A record set"""
-    dns_ips = {ip.address for ip in dns.resolver.resolve(f'ns1.{testconfig["dns"]["coredns_zone"]}')}
+    dns_ips = {ip.address for ip in dns.resolver.resolve(hostname.hostname)}
     assert {IP1, IP2, IP3} == dns_ips, "CoreDNS should have returned all 3 IP addresses in A record set"

--- a/testsuite/tests/multicluster/coredns/three_clusters/test_two_primary_one_secondary.py
+++ b/testsuite/tests/multicluster/coredns/three_clusters/test_two_primary_one_secondary.py
@@ -7,7 +7,7 @@ from testsuite.kubernetes.secret import Secret
 from ..conftest import IP1, IP2
 from .conftest import IP3
 
-pytestmark = [pytest.mark.multicluster, pytest.mark.disruptive]
+pytestmark = [pytest.mark.coredns_two_primaries]
 
 
 @pytest.fixture(scope="module")
@@ -39,7 +39,7 @@ def kubeconfig_secrets(testconfig, blame, module_label, cluster, cluster2, clust
     return kubeconfig_secrets
 
 
-def test_two_primary_one_secondary(testconfig):
+def test_two_primary_one_secondary(hostname):
     """IPs from 2 primary and 1 secondary clusters should return in DNS A record set"""
-    dns_ips = {ip.address for ip in dns.resolver.resolve(f'ns1.{testconfig["dns"]["coredns_zone"]}')}
+    dns_ips = {ip.address for ip in dns.resolver.resolve(hostname.hostname)}
     assert {IP1, IP2, IP3} == dns_ips, "CoreDNS should have returned all 3 IP addresses in A record set"

--- a/testsuite/tests/multicluster/coredns/two_clusters/metrics/test_metrics.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/metrics/test_metrics.py
@@ -4,7 +4,7 @@ import pytest
 
 from testsuite.prometheus import has_label
 
-pytestmark = [pytest.mark.multicluster, pytest.mark.disruptive]
+pytestmark = [pytest.mark.coredns_one_primary]
 
 
 @pytest.fixture(scope="module")
@@ -22,9 +22,7 @@ def test_authoritative_record_metrics(testconfig, dns_metrics, dnsrecord1):
         has_label("__name__", "dns_provider_record_ready") and has_label("dns_record_is_delegating", "false")
     )
     assert len(authoritative_record.metrics) == 1
-    assert (
-        authoritative_record.metrics[0]["metric"]["dns_record_root_host"] == f'ns1.{testconfig["dns"]["coredns_zone"]}'
-    )
+    assert authoritative_record.metrics[0]["metric"]["dns_record_root_host"] == testconfig["dns"]["coredns_zone"]
     assert authoritative_record.values[0] == 1.0
 
     dns_provider_authoritative_record_spec_info = authoritative_record_metrics.filter(
@@ -33,7 +31,7 @@ def test_authoritative_record_metrics(testconfig, dns_metrics, dnsrecord1):
     assert len(dns_provider_authoritative_record_spec_info.metrics) == 1
     assert (
         dns_provider_authoritative_record_spec_info.metrics[0]["metric"]["root_host"]
-        == f'ns1.{testconfig["dns"]["coredns_zone"]}'
+        == testconfig["dns"]["coredns_zone"]
     )
     assert dns_provider_authoritative_record_spec_info.values[0] == 1
 
@@ -47,9 +45,7 @@ def test_delegating_record_metrics(testconfig, dns_metrics, dnsrecord1, dnsrecor
 
         delegating_record = delegating_record_metrics.filter(has_label("dns_record_is_delegating", "true"))
         assert len(delegating_record.metrics) == 1
-        assert (
-            delegating_record.metrics[0]["metric"]["dns_record_root_host"] == f'ns1.{testconfig["dns"]["coredns_zone"]}'
-        )
+        assert delegating_record.metrics[0]["metric"]["dns_record_root_host"] == testconfig["dns"]["coredns_zone"]
         assert delegating_record.metrics[0]["metric"]["dns_record_namespace"] == rec.namespace()
         assert delegating_record.names[0] == "dns_provider_record_ready"
         assert delegating_record.values[0] == 1.0

--- a/testsuite/tests/multicluster/coredns/two_clusters/test_authoritative_record_removal.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/test_authoritative_record_removal.py
@@ -8,7 +8,7 @@ from testsuite.kubernetes.secret import Secret
 from testsuite.utils import sleep_ttl
 from ..conftest import IP1, IP2
 
-pytestmark = [pytest.mark.multicluster, pytest.mark.disruptive]
+pytestmark = [pytest.mark.coredns_one_primary]
 
 
 @pytest.fixture(scope="module")
@@ -29,20 +29,20 @@ def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
     ]
 
 
-def test_authoritative_record_removal_cleans_up_provider(testconfig, dnsrecord1, dnsrecord2):
+def test_authoritative_record_removal_cleans_up_provider(hostname, dnsrecord1, dnsrecord2):
     """Delete DNSRecords from both primary and secondary clusters and check they are really cleaned up"""
-    dns_ips = {ip.address for ip in dns.resolver.resolve(f'ns1.{testconfig["dns"]["coredns_zone"]}')}
+    dns_ips = {ip.address for ip in dns.resolver.resolve(hostname.hostname)}
     assert {IP1, IP2} == dns_ips, "CoreDNS should have returned both IP addresses in A record set"
 
     dnsrecord2.delete()
-    sleep_ttl(f'ns1.{testconfig["dns"]["coredns_zone"]}')
-    dns_ips = {ip.address for ip in dns.resolver.resolve(f'ns1.{testconfig["dns"]["coredns_zone"]}')}
+    sleep_ttl(hostname.hostname)
+    dns_ips = {ip.address for ip in dns.resolver.resolve(hostname.hostname)}
     assert {IP1} == dns_ips, "CoreDNS should have only returned the primary IP address in A record set"
 
     authoritative_record = dnsrecord1.get_authoritative_dns_record()
     assert authoritative_record.exists()[0], "Authoritative DNSRecord should still exist"
 
     dnsrecord1.delete()
-    sleep_ttl(f'ns1.{testconfig["dns"]["coredns_zone"]}')
+    sleep_ttl(hostname.hostname)
     assert not authoritative_record.exists()[0], "Authoritative DNSRecord should be cleaned up"
-    assert is_nxdomain(f'ns1.{testconfig["dns"]["coredns_zone"]}')
+    assert is_nxdomain(hostname.hostname)

--- a/testsuite/tests/multicluster/coredns/two_clusters/test_delegate_false.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/test_delegate_false.py
@@ -9,10 +9,12 @@ import pytest
 from testsuite.gateway import GatewayListener
 from testsuite.kubernetes.secret import Secret
 from testsuite.kuadrant.policy.dns import DNSPolicy
+from testsuite.gateway.gateway_api.route import HTTPRoute
+from testsuite.gateway.gateway_api.hostname import DNSPolicyExposer
 from testsuite.gateway.gateway_api.gateway import KuadrantGateway
 from ..conftest import IP1, IP2
 
-pytestmark = [pytest.mark.multicluster, pytest.mark.disruptive]
+pytestmark = [pytest.mark.coredns_one_primary]
 
 
 @pytest.fixture(scope="module")
@@ -34,12 +36,38 @@ def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
 
 
 @pytest.fixture(scope="module")
-def gateway2(cluster2, blame, label, wildcard_domain):
-    """Overriding Gateway with not tls listener for this test"""
+def exposer2(request, cluster2):
+    """Expose using DNSPolicy for the not delegated DNSPolicy"""
+    exposer = DNSPolicyExposer(cluster2)
+    request.addfinalizer(exposer.delete)
+    exposer.commit()
+    return exposer
+
+
+@pytest.fixture(scope="module")
+def hostname2(gateway2, exposer2, blame):
+    """Exposed hostname for the not delegated DNSPolicy"""
+    return exposer2.expose_hostname(blame("hostname"), gateway2)
+
+
+@pytest.fixture(scope="module")
+def gateway2(cluster2, blame, label, exposer2):
+    """Gateway object for the not delegated DNSPolicy"""
     name = blame("gw")
     gw = KuadrantGateway.create_instance(cluster2, name, {"app": label})
-    gw.add_listener(GatewayListener(hostname=wildcard_domain))
+    gw.add_listener(GatewayListener(hostname=f"*.{exposer2.base_domain}"))
     return gw
+
+
+@pytest.fixture(scope="module")
+def route2(request, gateway2, blame, hostname2, backends, module_label):
+    """Route object for the not delegated DNSPolicy"""
+    route = HTTPRoute.create_instance(gateway2.cluster, blame("route"), gateway2, {"app": module_label})
+    route.add_hostname(hostname2.hostname)
+    route.add_backend(backends[1])
+    request.addfinalizer(route.delete)
+    route.commit()
+    return route
 
 
 @pytest.fixture(scope="module")
@@ -52,7 +80,7 @@ def dns_policy2(blame, cluster2, gateway2, dns_provider_secret, module_label):
 
 @pytest.fixture(scope="module", autouse=True)
 def commit(
-    request, coredns_secrets, kubeconfig_secrets, dnsrecord1, dnsrecord2, routes, gateway2, dns_policy2
+    request, coredns_secrets, kubeconfig_secrets, dnsrecord1, dnsrecord2, route2, gateway2, dns_policy2
 ):  # pylint: disable=unused-argument
     """Commits all components required for the test and adds finalizers to delete them on cleanup"""
     for component in [*kubeconfig_secrets, dnsrecord1, dnsrecord2, gateway2, dns_policy2]:
@@ -62,16 +90,16 @@ def commit(
         component.wait_for_ready()
 
 
-def test_delegate_false(testconfig, gateway2, hostname):
+def test_delegate_false(gateway2, hostname, hostname2):
     """
     Test that DNSPolicy created with delegate: false on secondary cluster
     won't propagate its external DNS provider IP to the authoritative DNS record
     """
-    dns_ips = {ip.address for ip in dns.resolver.resolve(f'ns1.{testconfig["dns"]["coredns_zone"]}')}
+    dns_ips = {ip.address for ip in dns.resolver.resolve(hostname.hostname)}
     assert {IP1, IP2} == dns_ips, "CoreDNS should have returned both IP addresses in A record set"
 
     assert (
-        dns.resolver.resolve(hostname.hostname)[0].address == gateway2.external_ip().split(":")[0]
+        dns.resolver.resolve(hostname2.hostname)[0].address == gateway2.external_ip().split(":")[0]
     ), "external DNS provider IP SHOULD be in a AWS DNS record"
     assert (
         gateway2.external_ip().split(":")[0] not in dns_ips

--- a/testsuite/tests/multicluster/coredns/two_clusters/test_one_primary_one_secondary.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/test_one_primary_one_secondary.py
@@ -6,7 +6,7 @@ import pytest
 from testsuite.kubernetes.secret import Secret
 from ..conftest import IP1, IP2
 
-pytestmark = [pytest.mark.multicluster, pytest.mark.disruptive]
+pytestmark = [pytest.mark.coredns_one_primary]
 
 
 @pytest.fixture(scope="module")
@@ -27,7 +27,7 @@ def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
     ]
 
 
-def test_one_primary_one_secondary(testconfig):
+def test_one_primary_one_secondary(hostname):
     """IPs from both, primary and secondary, clusters should return in DNS A record set"""
-    dns_ips = {ip.address for ip in dns.resolver.resolve(f'ns1.{testconfig["dns"]["coredns_zone"]}')}
+    dns_ips = {ip.address for ip in dns.resolver.resolve(hostname.hostname)}
     assert {IP1, IP2} == dns_ips, "CoreDNS should have returned both IP addresses in A record set"

--- a/testsuite/tests/multicluster/coredns/two_clusters/test_two_primary.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/test_two_primary.py
@@ -6,7 +6,7 @@ import pytest
 from testsuite.kubernetes.secret import Secret
 from ..conftest import IP1, IP2
 
-pytestmark = [pytest.mark.multicluster]
+pytestmark = [pytest.mark.coredns_two_primaries]
 
 
 @pytest.fixture(scope="module")
@@ -39,7 +39,7 @@ def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
     return secrets
 
 
-def test_two_primary(testconfig):
+def test_two_primary(hostname):
     """IPs from both primary clusters should return in DNS A record set"""
-    dns_ips = {ip.address for ip in dns.resolver.resolve(f'ns1.{testconfig["dns"]["coredns_zone"]}')}
+    dns_ips = {ip.address for ip in dns.resolver.resolve(hostname.hostname)}
     assert {IP1, IP2} == dns_ips, "CoreDNS should have returned both IP addresses in A record set"


### PR DESCRIPTION
I have added CoreDNS cluster exposer and overwritten coredns tests to use it. 

### Changes
- Add new CoreDNS cluster exposer
- Change CoreDNS tests to use the new exposer
- Add CoreDNS single primary and double primary test marks, which should simplify the execution
- Add CoreDNS zone setting validator

### Verification steps
Use nameservers with `averevki-single` and `averevki-double` in our main AWS zone as a setting for `dns.coredns_zone` for according tests: 
```
make coredns_one_primary
make coredns_two_primaries
```