### PR TITLE
Add xfail for gcp not supported default geo

### DIFF
--- a/testsuite/tests/multicluster/load_balanced/test_change_default_geo.py
+++ b/testsuite/tests/multicluster/load_balanced/test_change_default_geo.py
@@ -4,10 +4,15 @@ from time import sleep
 
 import pytest
 import dns.resolver
+from testsuite.config import settings
 
 pytestmark = [pytest.mark.multicluster]
 
 
+@pytest.mark.xfail(
+    settings["control_plane"]["provider_secret"].startswith("gcp"),
+    reason="Default geo not supported on GCP",
+)
 def test_change_default_geo(hostname, gateway, gateway2, dns_policy, dns_policy2, dns_default_geo_server):
     """Test changing dns default geolocation and verify that changes are propagated"""
     resolver = dns.resolver.Resolver(configure=False)


### PR DESCRIPTION
Test `testsuite/tests/multicluster/load_balanced/test_change_default_geo.py` is failing with gcp provider but this is expected as gcp does not have support for default geo zone.

## Verification

Set up multicluster config. Then run following make command while setting `provider_secret` to aws, gcp and azure. Do not forget about setting correct `dns.geo_code` for each provider
```sh
make testsuite/tests/multicluster/load_balanced/test_change_default_geo.py
```
For gcp is should XFAIL, rest should PASS.

Or just eye review.
