### PR TITLE
test: DNSPolicy load-balancing strategy conflict

### DIFF
--- a/testsuite/tests/multicluster/conftest.py
+++ b/testsuite/tests/multicluster/conftest.py
@@ -3,6 +3,7 @@
 from importlib import resources
 
 import pytest
+from dynaconf import ValidationError
 
 from testsuite.backend.httpbin import Httpbin
 from testsuite.certificates import Certificate
@@ -13,6 +14,16 @@ from testsuite.gateway.gateway_api.hostname import DNSPolicyExposer
 from testsuite.gateway.gateway_api.route import HTTPRoute
 from testsuite.kuadrant.policy.dns import DNSPolicy
 from testsuite.kuadrant.policy.tls import TLSPolicy
+
+
+@pytest.fixture(scope="package")
+def dns_server(testconfig, skip_or_fail):
+    """DNS server in the first geo region"""
+    try:
+        testconfig.validators.validate(only=["dns.dns_server"])
+        return testconfig["dns"]["dns_server"]
+    except ValidationError as exc:
+        return skip_or_fail(f"DNS servers configuration is missing: {exc}")
 
 
 @pytest.fixture(scope="session")

--- a/testsuite/tests/multicluster/load_balanced/conftest.py
+++ b/testsuite/tests/multicluster/load_balanced/conftest.py
@@ -7,25 +7,13 @@ from testsuite.kuadrant.policy.dns import DNSPolicy, LoadBalancing
 
 
 @pytest.fixture(scope="package")
-def dns_config(testconfig, skip_or_fail):
-    """Configuration for DNS tests"""
+def dns_server2(testconfig, skip_or_fail):
+    """DNS server in the second geo region"""
     try:
-        testconfig.validators.validate(only=["dns.dns_server", "dns.dns_server2"])
-        return testconfig["dns"]
+        testconfig.validators.validate(only=["dns.dns_server2"])
+        return testconfig["dns"]["dns_server2"]
     except ValidationError as exc:
         return skip_or_fail(f"DNS servers configuration is missing: {exc}")
-
-
-@pytest.fixture(scope="package")
-def dns_server(dns_config):
-    """DNS server in the first geo region"""
-    return dns_config["dns_server"]
-
-
-@pytest.fixture(scope="package")
-def dns_server2(dns_config):
-    """DNS server in the second geo region"""
-    return dns_config["dns_server2"]
 
 
 @pytest.fixture(scope="session")

--- a/testsuite/tests/multicluster/test_strategy_conflict.py
+++ b/testsuite/tests/multicluster/test_strategy_conflict.py
@@ -1,0 +1,54 @@
+"""Test DNSPolicy strategy conflict - two DNSPolicies use same hostname but different load-balancing strategies"""
+
+import pytest
+import dns.resolver
+
+from testsuite.kuadrant.policy import has_condition
+from testsuite.kuadrant.policy.dns import DNSPolicy, LoadBalancing, has_record_condition
+
+pytestmark = [pytest.mark.multicluster]
+
+
+@pytest.fixture(scope="module")
+def dns_policy2(blame, cluster2, gateway2, dns_server, module_label, dns_provider_secret):
+    """DNSPolicy with different load-balancing strategy for the second cluster"""
+    lb = LoadBalancing(defaultGeo=False, geo=dns_server["geo_code"])
+    return DNSPolicy.create_instance(
+        cluster2, blame("dns"), gateway2, dns_provider_secret, load_balancing=lb, labels={"app": module_label}
+    )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def commit(
+    request, routes, gateway, gateway2, dns_policy, dns_policy2, tls_policy, tls_policy2
+):  # pylint: disable=unused-argument
+    """Commits gateways and all policies before tests. Commits dns_policy2 last where conflict is expected to occur"""
+    for component in [gateway, gateway2, dns_policy, tls_policy, tls_policy2]:
+        request.addfinalizer(component.delete)
+        component.commit()
+        component.wait_for_ready()
+
+    request.addfinalizer(dns_policy2.delete)
+    dns_policy2.commit()
+
+
+def test_lb_strategy_conflict(wildcard_domain, hostname, dns_policy2, gateway):
+    """
+    Test DNSPolicy load-balancing strategy conflict
+    - Checks status messages on DNSPolicy and associated DNS record
+    - Checks that DNS resolution returns only the first gateway IP address in A record set
+    """
+    assert dns_policy2.wait_until(has_condition("Enforced", "False"))
+    assert dns_policy2.wait_until(
+        has_record_condition(
+            "Ready",
+            "False",
+            "ProviderError",
+            "The DNS provider failed to ensure the record: record type conflict, cannot update "
+            f"endpoint '{wildcard_domain}' with record type 'CNAME' when endpoint already exists with record type 'A'",
+        )
+    ), f"DNSPolicy did not reach expected record status, instead it was: {dns_policy2.model.status.recordConditions}"
+
+    gw1_ip = gateway.external_ip().split(":")[0]
+    dns_ips = {ip.address for ip in dns.resolver.resolve(hostname.hostname)}
+    assert {gw1_ip} == dns_ips, "Only the first gateway IP address is expected in A record set"


### PR DESCRIPTION
## Description
  - Adds test coverage for DNSPolicy load-balancing strategy conflicts in multicluster environments
  - Validates that when two DNSPolicies target the same hostname with different load-balancing strategies, the second policy is rejected with proper error messaging
  - Refactors `dns_server` and `dns_server2` fixtures to be available at the multicluster package level for better reusability
  
Closes #789 

  ## Changes

  ### New Features
  - **New test file**: `testsuite/tests/multicluster/test_strategy_conflict.py`
    - Implements `test_lb_strategy_conflict()` to verify DNSPolicy strategy conflict detection
    - Tests that conflicting DNSPolicy shows `Enforced=False` condition
    - Validates DNS record condition shows `ProviderError` with CNAME/A record type conflict message
    - Verifies DNS resolution returns only the first gateway's IP address

  ### Refactoring
  - **Moved `dns_server` fixture** from `testsuite/tests/multicluster/load_balanced/conftest.py` to `testsuite/tests/multicluster/conftest.py` for package-level availability
  - **Simplified `dns_server2` fixture** in `testsuite/tests/multicluster/load_balanced/conftest.py` to validate and return only the second DNS server configuration
  - **Removed `dns_config` fixture** from load_balanced tests (no longer needed with individual server fixtures)

  ## Verification steps

  Run the new test:
  ```bash
  poetry run pytest -vv testsuite/tests/multicluster/test_strategy_conflict.py

  # Verify existing load-balanced tests still pass:
  poetry run pytest -vv testsuite/tests/multicluster/load_balanced/
