### PR TITLE
feat(dns): Add smarter wait for changing dns zone asserts

### DIFF
--- a/testsuite/tests/multicluster/load_balanced/test_change_default_geo.py
+++ b/testsuite/tests/multicluster/load_balanced/test_change_default_geo.py
@@ -1,10 +1,9 @@
 """Test for modification of default geolocation in DNSPolicy"""
 
-from time import sleep
-
 import pytest
 import dns.resolver
 from testsuite.config import settings
+from testsuite.utils import wait_for_dns
 
 pytestmark = [pytest.mark.multicluster]
 
@@ -28,5 +27,6 @@ def test_change_default_geo(hostname, gateway, gateway2, dns_policy, dns_policy2
     dns_policy2.apply()
     dns_policy2.wait_for_ready()
 
-    sleep(300)  # wait for DNS propagation on providers
-    assert resolver.resolve(hostname.hostname)[0].address == gateway2.external_ip().split(":")[0]
+    answer = wait_for_dns(hostname.hostname, gateway2.external_ip().split(":")[0], resolver=resolver)
+    assert gateway2.external_ip().split(":")[0] in answer.addresses()
+    assert gateway.external_ip().split(":")[0] not in answer.addresses()


### PR DESCRIPTION
## Description
Work on https://github.com/Kuadrant/testsuite/issues/660

To introduce smarter waits for DNS related waiting. Not sure I covered all places in the codebase that would benefit from this util function. To benefit from https://github.com/Kuadrant/helm-charts-olm/pull/60 this refactor was needed.

## Changes
- Added `wait_for_dns` util method which does dns query with retries and expected result.
- Refactored two tests which had `sleep(300)` previously

## Verification
Just two tests affected.
```sh
make testsuite/tests/multicluster/load_balanced/test_change_strategy.py testsuite/tests/multicluster/load_balanced/test_change_default_geo.py
```
