### PR TITLE
fix: remove --enforce from observability make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ dnstls: poetry-no-dev  ## Run DNS and TLS tests
 extensions: poetry-no-dev  ## Run extensions tests
 	$(PYTEST) -n4 -m 'extensions and not disruptive' --dist loadfile --enforce $(flags) testsuite/tests/singlecluster/
 
-observability: poetry-no-dev  ## Run metrics, tracing and logging tests
-	$(PYTEST) -n4 -m 'observability and not disruptive' --dist loadfile --enforce $(flags) testsuite/tests/singlecluster/
+observability: poetry-no-dev  ## Run metrics, tracing and logging tests (add `flags=--standalone` to only run tests capable of running with standalone Authorino)
+	$(PYTEST) -n4 -m 'observability and not disruptive' --dist loadfile $(flags) testsuite/tests/singlecluster/
 
 defaults_overrides: poetry-no-dev  ## Run Defaults and Overrides tests
 	$(PYTEST) -n4 -m 'defaults_overrides and not disruptive' --dist loadfile --enforce $(flags) testsuite/tests/singlecluster/


### PR DESCRIPTION
### Summary

The new `make observability` target fails some tests that could only run under testsuite configuration for standalone authorino (aka with --standalone flag). Removing `--enforce` flag from observability target so it is possible run it with either standard authorino or with standalone authorino by adding `--standalone` flag to the observability target.

```
ERROR testsuite/tests/singlecluster/authorino/metrics/test_deep_metrics.py::test_deep_metrics[authorization] - Failed: Unable to run Standalone only test: Standalone mode is disabled, please use --standalone flag
ERROR testsuite/tests/singlecluster/authorino/metrics/test_deep_metrics.py::test_deep_metrics[identity] - Failed: Unable to run Standalone only test: Standalone mode is disabled, please use --standalone flag
ERROR testsuite/tests/singlecluster/authorino/metrics/test_deep_metrics.py::test_deep_metrics[metadata] - Failed: Unable to run Standalone only test: Standalone mode is disabled, please use --standalone flag
ERROR testsuite/tests/singlecluster/authorino/metrics/test_deep_metrics.py::test_deep_metrics[response] - Failed: Unable to run Standalone only test: Standalone mode is disabled, please use --standalone flag
ERROR testsuite/tests/singlecluster/authorino/operator/tracing/test_tracing.py::test_tracing - Failed: Unable to run Standalone only test: Standalone mode is disabled, please use --standalone flag
ERROR testsuite/tests/singlecluster/authorino/operator/tracing/test_tracing_tags.py::test_tracing_tags - Failed: Unable to run Standalone only test: Standalone mode is disabled, please use --standalone flag
```

### Verification steps

```sh
# run mark with the standard authorino and see how some metrics and tracing tests will be skipped instead of failed
flags=-vv make observability

# run only observability tests capable running with standalone authorino
flags="-vv --standalone" make observability
```