### PR TITLE
fix: detect connection reset as TLS error in test assertions

### DIFF
--- a/testsuite/httpx/__init__.py
+++ b/testsuite/httpx/__init__.py
@@ -67,7 +67,11 @@ class Result:
 
     def has_tls_error(self):
         """True, if the result failed due to TLS failure"""
-        return self.has_error("SSL: UNEXPECTED_EOF_WHILE_READING") or self.has_error("Connection refused")
+        return (
+            self.has_error("SSL: UNEXPECTED_EOF_WHILE_READING")
+            or self.has_error("Connection refused")
+            or self.has_error("Connection reset by peer")
+        )
 
     def has_cert_verify_error(self):
         """True, if the result failed due to TLS certificate verification failure"""


### PR DESCRIPTION
## Description
For some reason if using clusters outside RHT VPN (ARO, AWS, GCP) the error returned in response in [./testsuite/tests/singlecluster/gateway/tlspolicy/test_tls_policy_section_targeting_gateway.py](https://github.com/Kuadrant/testsuite/blob/main/testsuite/tests/singlecluster/gateway/tlspolicy/test_tls_policy_section_targeting_gateway.py#L135) is different than the test expects.

## Changes
Add "Connection reset by peer" to TLS error detection in has_tls_error().

I am not sure whether "Connection reset by peer" could create false positives in other scenarios but most likely not, this method is used in 2 tests only.

## Verification
`./testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_tlspolicy_target_ref.py`
` make testsuite/tests/singlecluster/gateway/tlspolicy/test_tls_policy_section_targeting_gateway.py`

- but you need to have a cluster outside RHT VPN to fully validate this. Given how small the modifications in the PR are I'd say eye review is sufficient and we will see whether this works in nightlies.

---

**PR Title Guidelines (Conventional Commits)**

Your PR title must follow the conventional commit format:

```
<type>[optional scope]: <description>
```

**Examples:**
- `feat: add rate limiting policy for gateways`
- `feat(gateway): add rate limiting policy`
- `fix(authorino): resolve authorization timeout issue`
- `test: add tests for DNS policy reconciliation`
- `docs: update installation guide`

**Allowed types:**
- `feat` - New feature
- `fix` - Bug fix
- `docs` - Documentation changes
- `style` - Code style changes (formatting, no logic change)
- `refactor` - Code refactoring
- `perf` - Performance improvements
- `test` - Adding or updating tests
- `build` - Build system changes
- `ci` - CI/CD changes
- `chore` - Other changes (dependencies, tooling)
- `revert` - Revert a previous commit

**Optional scopes:**
- `authorino`, `chore`, `ci`, `dns`, `docs`, `gateway`, `limitador`, `multicluster`, `perf`, `refactor`, `style`, `test`, `tls`
