### PR TITLE
fix: detect handshake timeout as TLS error in test assertions

### DIFF
--- a/testsuite/httpx/__init__.py
+++ b/testsuite/httpx/__init__.py
@@ -71,6 +71,7 @@ class Result:
             self.has_error("SSL: UNEXPECTED_EOF_WHILE_READING")
             or self.has_error("Connection refused")
             or self.has_error("Connection reset by peer")
+            or self.has_error("The handshake operation timed out")
         )
 
     def has_cert_verify_error(self):


### PR DESCRIPTION
## Description
For some reason if using clusters outside RHT VPN (I noticed this one on AWS) the error returned in response might be different than the test expects: https://github.com/Kuadrant/testsuite/blob/main/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_tlspolicy_target_ref.py#L73

This is similar to my recent PR: https://github.com/Kuadrant/testsuite/pull/838

## Changes
Add "handshake operation timed out" to TLS error detection in has_tls_error().

I am not sure whether this could create false positives in other scenarios but most likely not, this method is used in 2 tests only. It actually sounds like TLS error to me (if SSL handshake is meant).

## Verification
```
make testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_tlspolicy_target_ref.py
make testsuite/tests/singlecluster/gateway/tlspolicy/test_tls_policy_section_targeting_gateway.py
```
- but you need to have a cluster outside RHT VPN to fully validate this. Given how small the modifications in the PR are I'd say eye review is sufficient and we will see whether this works in nightlies.

---

**PR Title Guidelines (Conventional Commits)**

Your PR title must follow the conventional commit format:

```
<type>[optional scope]: <description>
```

**Examples:**
- `feat: add rate limiting policy for gateways`
- `feat(gateway): add rate limiting policy`
- `fix(authorino): resolve authorization timeout issue`
- `test: add tests for DNS policy reconciliation`
- `docs: update installation guide`

**Allowed types:**
- `feat` - New feature
- `fix` - Bug fix
- `docs` - Documentation changes
- `style` - Code style changes (formatting, no logic change)
- `refactor` - Code refactoring
- `perf` - Performance improvements
- `test` - Adding or updating tests
- `build` - Build system changes
- `ci` - CI/CD changes
- `chore` - Other changes (dependencies, tooling)
- `revert` - Revert a previous commit

**Optional scopes:**
- `authorino`, `chore`, `ci`, `dns`, `docs`, `gateway`, `limitador`, `multicluster`, `perf`, `refactor`, `style`, `test`, `tls`
