### PR TITLE
fix: use KuadrantClient to handle 503 errors

### DIFF
--- a/testsuite/spicedb/spicedb.py
+++ b/testsuite/spicedb/spicedb.py
@@ -3,9 +3,9 @@
 from dataclasses import dataclass
 from typing import List
 import backoff
-import httpx
 
 from testsuite.backend import Backend
+from testsuite.httpx import KuadrantClient
 from testsuite.kubernetes import Selector
 from testsuite.kubernetes.client import KubernetesClient
 from testsuite.kubernetes.deployment import Deployment
@@ -63,11 +63,10 @@ class SpiceDBClient:
     def __init__(self, server_url: str, token: str):
         """
         Initialize HTTP client for SpiceDB.
-
         """
         self.server_url = server_url.rstrip("/")
         self.token = token
-        self.client = httpx.Client(
+        self.client = KuadrantClient(
             base_url=self.server_url,
             headers={"Authorization": f"Bearer {token}"},
             timeout=30.0,
@@ -144,7 +143,7 @@ class SpiceDBClient:
         interval=5,
         jitter=None,
         on_giveup=lambda details: (_ for _ in ()).throw(
-            TimeoutError(f"SpiceDB relationships not ready after {details['tries']} tries. ")
+            TimeoutError(f"SpiceDB relationships not ready after {details['tries']} tries.")
         ),
     )
     def wait_for_relationship(self, schema_config: SchemaConfig, relationship_config: RelationshipConfig):


### PR DESCRIPTION
## Problem

  SpiceDB test fails on nightly testsuite run with `503 Service Unavailable` when attempting schema writes:

  E   httpx.HTTPStatusError: Server error '503 Service Unavailable' for url 'http://spicedb-.../v1/schema/write'

  ## Solution

 - Replaced `httpx.Client` with `KuadrantClient` in SpiceDB client to leverage built-in retry logic for handling 503 errors
 
  ## Testing

I was unable to reproduce the 503 error in local test runs, but I manually verified the backoff mechanism by scaling the SpiceDB deployment down and up during test execution:

  09:48:40 POST /v1/schema/write "503 Service Unavailable"
    09:48:40 Backing off request(...) for 1.0s (Result[status_code=503])
    09:48:41 POST /v1/schema/write "200 OK"
    09:48:41 POST /v1/relationships/write "200 OK"
  ...
  PASSED ✓

  The KuadrantClient retry logic successfully catches the 503 error and automatically retries.

