### PR TITLE
feat: change authorino test for smoke target

### DIFF
--- a/testsuite/tests/singlecluster/authorino/identity/api_key/test_auth_credentials.py
+++ b/testsuite/tests/singlecluster/authorino/identity/api_key/test_auth_credentials.py
@@ -22,6 +22,11 @@ def authorization(authorization, api_key, credentials):
     return authorization
 
 
+@pytest.mark.parametrize(
+    "credentials",
+    [pytest.param("authorizationHeader", marks=pytest.mark.smoke), "customHeader", "queryString", "cookie"],
+    indirect=True,
+)
 def test_custom_selector(client, auth, credentials):
     """Test if auth credentials are stored in right place"""
     response = client.get("/get", headers={"authorization": "APIKEY " + auth.api_key})

--- a/testsuite/tests/singlecluster/authorino/identity/auth/test_auth_identity.py
+++ b/testsuite/tests/singlecluster/authorino/identity/auth/test_auth_identity.py
@@ -32,7 +32,7 @@ def wrong_auth(oidc_provider, auth0, keycloak):
 
 @pytest.mark.parametrize(
     "oidc_provider",
-    [pytest.param("keycloak", marks=[pytest.mark.smoke]), pytest.param("auth0")],
+    [pytest.param("keycloak"), pytest.param("auth0")],
     indirect=True,
 )
 def test_auth_identity(client, auth, wrong_auth):


### PR DESCRIPTION
Test that we use for authorino in our smoke target currently uses keycloak , therefore can be unstable for the smoke sometimes