### PR TITLE
fix: update DNS provider error message assertion

### DIFF
--- a/testsuite/tests/singlecluster/gateway/dnspolicy/test_no_dns_provider_secret.py
+++ b/testsuite/tests/singlecluster/gateway/dnspolicy/test_no_dns_provider_secret.py
@@ -36,6 +36,6 @@ def test_default_secret_provider_not_found(dns_policy):
             "Ready",
             "False",
             "DNSProviderError",
-            f'The dns provider could not be loaded: Secret "{NON_EXISTING_SECRET}" not found',
+            f'The dns provider could not be loaded: secrets "{NON_EXISTING_SECRET}" not found',
         )
     ), f"DNSPolicy did not reach expected record status, instead it was: {dns_policy.model.status.recordConditions}"


### PR DESCRIPTION
## Description
Update expected error message in test_no_dns_provider_secret.py to match the current error format. The error message now uses lowercase "secrets" instead of "Secret".

## Changes
  - Fix test assertion to match updated DNS provider error message format

## Verification

`make ./testsuite/tests/singlecluster/gateway/dnspolicy/test_no_dns_provider_secret.py`

---

**PR Title Guidelines (Conventional Commits)**

Your PR title must follow the conventional commit format:

```
<type>[optional scope]: <description>
```

**Examples:**
- `feat: add rate limiting policy for gateways`
- `feat(gateway): add rate limiting policy`
- `fix(authorino): resolve authorization timeout issue`
- `test: add tests for DNS policy reconciliation`
- `docs: update installation guide`

**Allowed types:**
- `feat` - New feature
- `fix` - Bug fix
- `docs` - Documentation changes
- `style` - Code style changes (formatting, no logic change)
- `refactor` - Code refactoring
- `perf` - Performance improvements
- `test` - Adding or updating tests
- `build` - Build system changes
- `ci` - CI/CD changes
- `chore` - Other changes (dependencies, tooling)
- `revert` - Revert a previous commit

**Optional scopes:**
- `authorino`, `chore`, `ci`, `dns`, `docs`, `gateway`, `limitador`, `multicluster`, `perf`, `refactor`, `style`, `test`, `tls`
