### PR TITLE
refactor: change cluster metadata collection for ReportPortal

### DIFF
--- a/scripts/junit2reportportal
+++ b/scripts/junit2reportportal
@@ -78,21 +78,40 @@ launch_import_rq = {
 }
 launch_import_rq["attributes"].extend([{"key": "ocp", "value": args.ocp_version}] if args.ocp_version else [])
 
-component_metadata_count = 0
-if xml is not None:
+cluster_info = {}
+
+for junitfile in args.junitfile:
     try:
-        global_properties = xml.xpath("//testcase/properties/property")
-        for prop in global_properties:
+        xml = etree.parse(junitfile)
+        properties = xml.xpath("//testcase/properties/property")
+        for prop in properties:
             name = prop.get("name", "")
             value = prop.get("value", "")
-            if name.endswith(("-sha", "-tag")) or name in ["Kuadrant", "kuadrant_image", "kuadrant_cluster"]:
-                launch_import_rq["attributes"].append({"key": name, "value": str(value)})
-                component_metadata_count += 1
-        
-        if component_metadata_count > 0:
-            print(f"Added {component_metadata_count} component metadata attributes from junit XML")
+
+        if name.startswith("https://"):
+            parts = value.split("|")
+            cluster_kubeconfig = None
+            cluster_entry_parts = []
+            for part in parts:
+                if ":" in part:
+                    key, val = part.split(":", 1)
+                    if key == "Name":
+                        cluster_kubeconfig = val
+                    else:
+                        cluster_entry_parts.append(f"  - {key}: `{val}`\n")
+            header = f"- {name} ({cluster_kubeconfig})\n" if cluster_kubeconfig else f"- {name}\n"
+            cluster_entry = header + "".join(cluster_entry_parts)
+            cluster_info[name] = cluster_entry.rstrip()
     except Exception as e:
-        print(f"Warning: Failed to extract component metadata from junit XML: {e}")
+        print(f"Warning: Failed to extract metadata from {junitfile}: {e}")
+
+if cluster_info:
+    count = len(cluster_info)
+    cluster_section = f"\n\n**Cluster Information ({count} cluster{'s' if count != 1 else ''}):**\n" + "\n".join(cluster_info.values())
+    if launch_import_rq["description"]:
+        launch_import_rq["description"] += cluster_section
+    else:
+        launch_import_rq["description"] = cluster_section.strip()
 
 print(
     requests.post(


### PR DESCRIPTION
 ## Description

  - Refactored cluster metadata collection for ReportPortal to support multi-cluster environments (cluster1, cluster2, cluster3) instead of just the primary cluster
  - Simplified metadata collection to focus only on kuadrant-operator image, removing unnecessary collection of all Kuadrant component images (authorino, limitador, dns-operator, etc.)
  - Changed ReportPortal metadata format from flat attributes to structured cluster information embedded in launch description
  
Note: Actual results from nightly test pipeline running on the testsuite image from this PR can be seen in ReportPortal Testsuite project under the launch name [test_attributes-all #4](https://reportportal-kuadrant-qe.apps.dno.ocp-hub.prod.psi.redhat.com/ui/#testsuite/launches/all/1141)

  ## Changes

  ### Refactoring
  - **`testsuite/component_metadata.py`**: Complete refactor of metadata collection
    - Replaced detailed multi-component tracking with focused kuadrant-operator image collection only
    - Removed `ComponentImage` dataclass and `KUADRANT_COMPONENTS` configuration dictionary
    - Added new `ReportPortalMetadataCollector` class to orchestrate multi-cluster metadata collection from all configured clusters
    - Metadata now includes cluster console URL, OCP version, and kuadrant-operator image in pipe-delimited format (e.g., `OCP:4.20|Kuadrant:quay.io/kuadrant/kuadrant-operator:nightly-02-02-2026`)

  - **`testsuite/tests/conftest.py`**: Simplified pytest hook to use new multi-cluster collector
    - Updated `pytest_collection_modifyitems()` to use `ReportPortalMetadataCollector` instead of single-cluster `ComponentMetadataCollector`

  - **`scripts/junit2reportportal`**: Updated ReportPortal upload script
    - Changed to extract cluster information from JUnit properties with console URLs as keys
    - Cluster metadata is now appended to launch description as formatted markdown sections instead of individual attributes

Closes #842 
