### PR TITLE
fix: fix version mismatch and SSL errors in UI tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ openshift-client = ">=2"
 apyproxy = "*"
 weakget = "*"
 pytest-playwright = "*"
+playwright = "1.57.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "*"

--- a/testsuite/tests/singlecluster/ui/console_plugin/conftest.py
+++ b/testsuite/tests/singlecluster/ui/console_plugin/conftest.py
@@ -21,7 +21,7 @@ def auth_state_file(browser, cluster, testconfig, request):
     request.addfinalizer(state_file.close)
 
     # Create temporary context for login
-    temp_context = browser.new_context()
+    temp_context = browser.new_context(ignore_https_errors=True)
     page = temp_context.new_page()
 
     # Perform login
@@ -57,6 +57,7 @@ def browser_context_args(browser_context_args, auth_state_file):
     return {
         **browser_context_args,
         "storage_state": auth_state_file,  # Load cookies/session from file
+        "ignore_https_errors": True,
     }
 
 


### PR DESCRIPTION
## Description

This PR pins Playwright to 1.57.0 and adds SSL certificate bypass to fix test failures in UI image.  

Without pinning, Poetry installs the latest Playwright (1.58.0) which doesn't match the browser binaries in mcr.microsoft.com/playwright/python:v1.57.0-noble, causing: `BrowserType.launch: Executable doesn't exist at /ms-playwright/firefox-1509/firefox`                                                                                                         

We're staying on 1.57.0 for now because it works reliably. Playwright 1.58.0 has an issue with JS redirects in headless mode that I need to investigate more.

Also, as there is no CA certificates in the UI image, this is causing SSL errors when using the image. Adding `ignore_https_errors=True` flag bypasses certificate validation during both login and test execution. This will also need to be added to image at a later stage. 

## Changes                                                                                                                                                                                                  
                                                                                                                                                                                                           
  - `pyproject.toml`: Pin `playwright = "1.57.0"` to match Docker base image                                                                                                                                   
  - `conftest.py`: Add `ignore_https_errors=True` to browser contexts   

## Verification Steps

```
  docker run --rm \                                                                                                                                                                                        
    -v ~/.kube/config:/run/kubeconfig:ro \                                                                                                                                                                 
    -v $(pwd)/config/settings.local.yaml:/run/secrets.yaml:ro \                                                                                                                                            
    -v $(pwd)/test-run-results:/test-run-results \                                                                                                                                                         
    quay.io/rh-ee-eroche/testsuite-ui:unstable`
```