### PR TITLE
test: add Kuadrant operator metrics tests

### DIFF
--- a/testsuite/prometheus.py
+++ b/testsuite/prometheus.py
@@ -41,6 +41,9 @@ class Metrics:
         After the filtering, new Metrics object will be returned."""
         return Metrics([m for m in self.metrics if func(m)])
 
+    def __len__(self):
+        return len(self.metrics)
+
     @property
     def names(self) -> list[str]:
         """Return list of metrics names"""

--- a/testsuite/tests/singlecluster/observability/conftest.py
+++ b/testsuite/tests/singlecluster/observability/conftest.py
@@ -4,6 +4,7 @@ import backoff
 import pytest
 from openshift_client import selector
 
+from testsuite.config import settings
 from testsuite.kubernetes.monitoring.pod_monitor import PodMonitor
 from testsuite.kubernetes.monitoring.service_monitor import ServiceMonitor
 
@@ -93,3 +94,11 @@ def pod_monitor_metrics(client, pod_monitor, prometheus):
 
     metrics = prometheus.get_metrics(labels={"job": f"{pod_monitor.namespace()}/{pod_monitor.name()}"})
     return metrics
+
+
+@pytest.fixture(scope="module")
+def kuadrant_operator_metrics(prometheus):
+    """Return all metrics from the Kuadrant operator metrics endpoint"""
+    return prometheus.get_metrics(
+        labels={"service": "kuadrant-operator-metrics", "namespace": settings["service_protection"]["system_project"]}
+    )

--- a/testsuite/tests/singlecluster/observability/test_kuadrant_operator_health_metrics.py
+++ b/testsuite/tests/singlecluster/observability/test_kuadrant_operator_health_metrics.py
@@ -1,0 +1,124 @@
+"""Tests for Kuadrant operator health metrics (existence, readiness, component and dependency status)."""
+
+import pytest
+from openshift_client import selector
+
+from testsuite.prometheus import has_label
+
+pytestmark = [pytest.mark.observability]
+
+
+@pytest.fixture(scope="module")
+def is_istio(cluster, skip_or_fail):
+    """Skip if Istio is not installed on the cluster"""
+    if not selector("Istio", all_namespaces=True, static_context=cluster.context).objects():
+        skip_or_fail("Istio is not installed on the cluster")
+
+
+def test_metric_kuadrant_exist(kuadrant_operator_metrics):
+    """Tests that kuadrant_exists metric is present and has value 1"""
+    metrics = kuadrant_operator_metrics.filter(has_label("__name__", "kuadrant_exists"))
+    assert metrics, "'kuadrant_exists' metric wasn't found"
+    assert metrics.values[0] == 1, f"Expected 'kuadrant_exists' to have value 1, but got values: {metrics.values}"
+
+
+def test_metric_kuadrant_ready(kuadrant_operator_metrics, kuadrant):
+    """Tests that kuadrant_ready metric is present and has value 1"""
+    metrics = kuadrant_operator_metrics.filter(has_label("__name__", "kuadrant_ready")).filter(
+        has_label("name", kuadrant.name())
+    )
+    assert metrics, "'kuadrant_ready' metric wasn't found"
+    assert metrics.values[0] == 1, f"Expected 'kuadrant_ready' to have value 1, but got values: {metrics.values}"
+
+
+@pytest.mark.parametrize("component", ["authorino", "limitador"])
+def test_metric_kuadrant_component_ready(kuadrant_operator_metrics, component):
+    """Tests that kuadrant_component_ready metric is present and has value 1 for each component"""
+    metrics = kuadrant_operator_metrics.filter(has_label("__name__", "kuadrant_component_ready")).filter(
+        has_label("component", component)
+    )
+    assert metrics, f"'kuadrant_component_ready' metric wasn't found for component '{component}'"
+    assert metrics.values[0] == 1, (
+        f"Expected 'kuadrant_component_ready' for component '{component}' to have value 1, "
+        f"but got values: {metrics.values}"
+    )
+
+
+@pytest.mark.parametrize(
+    "dependency",
+    [
+        "authorino-operator",
+        "limitador-operator",
+        "cert-manager",
+        "dns-operator",
+    ],
+)
+def test_metric_kuadrant_dependency_detected(kuadrant_operator_metrics, dependency):
+    """Tests that kuadrant_dependency_detected metric has expected value for each dependency"""
+    metrics = kuadrant_operator_metrics.filter(has_label("__name__", "kuadrant_dependency_detected")).filter(
+        has_label("dependency", dependency)
+    )
+    assert metrics, f"'kuadrant_dependency_detected' metric wasn't found for dependency '{dependency}'"
+    assert (
+        metrics.values[0] == 1
+    ), f"Expected 'kuadrant_dependency_detected' for '{dependency}' to be 1, but got: {metrics.values}"
+
+
+@pytest.mark.parametrize(
+    "dependency, expected",
+    [
+        ("istio", 1),
+        ("envoygateway", 0),
+    ],
+)
+def test_metric_kuadrant_gateway_provider_detected(
+    kuadrant_operator_metrics, dependency, expected, is_istio
+):  # pylint: disable=unused-argument
+    """Tests that gateway provider dependencies are correctly detected when Istio is installed"""
+    metrics = kuadrant_operator_metrics.filter(has_label("__name__", "kuadrant_dependency_detected")).filter(
+        has_label("dependency", dependency)
+    )
+    assert metrics, f"'kuadrant_dependency_detected' metric wasn't found for dependency '{dependency}'"
+    assert (
+        metrics.values[0] == expected
+    ), f"Expected 'kuadrant_dependency_detected' for '{dependency}' to be {expected}, but got: {metrics.values}"
+
+
+@pytest.mark.parametrize(
+    "controller",
+    [
+        "auth_policies",
+        "rate_limit_policies",
+        "dns_policies",
+        "tls_policies",
+    ],
+)
+def test_metric_kuadrant_controller_registered(kuadrant_operator_metrics, controller):
+    """Tests that kuadrant_controller_registered metric has expected value for each controller"""
+    metrics = kuadrant_operator_metrics.filter(has_label("__name__", "kuadrant_controller_registered")).filter(
+        has_label("controller", controller)
+    )
+    assert metrics, f"'kuadrant_controller_registered' metric wasn't found for controller '{controller}'"
+    assert (
+        metrics.values[0] == 1
+    ), f"Expected 'kuadrant_controller_registered' for '{controller}' to be 1, but got: {metrics.values}"
+
+
+@pytest.mark.parametrize(
+    "controller, expected",
+    [
+        ("istio_integration", 1),
+        ("envoygateway_integration", 0),
+    ],
+)
+def test_metric_kuadrant_gateway_controller_registered(
+    kuadrant_operator_metrics, controller, expected, is_istio
+):  # pylint: disable=unused-argument
+    """Tests that gateway provider controllers are correctly registered when Istio is installed"""
+    metrics = kuadrant_operator_metrics.filter(has_label("__name__", "kuadrant_controller_registered")).filter(
+        has_label("controller", controller)
+    )
+    assert metrics, f"'kuadrant_controller_registered' metric wasn't found for controller '{controller}'"
+    assert (
+        metrics.values[0] == expected
+    ), f"Expected 'kuadrant_controller_registered' for '{controller}' to be {expected}, but got: {metrics.values}"

--- a/testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics.py
+++ b/testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics.py
@@ -1,0 +1,128 @@
+"""Tests for Kuadrant policy metrics (policies total and policies enforced per policy kind)."""
+
+import pytest
+
+from testsuite.gateway import Exposer, TLSGatewayListener
+from testsuite.prometheus import has_label
+from testsuite.gateway.gateway_api.gateway import KuadrantGateway
+from testsuite.gateway.gateway_api.hostname import DNSPolicyExposer
+from testsuite.kuadrant.policy.rate_limit import Limit
+from testsuite.kuadrant.policy.token_rate_limit import TokenRateLimitPolicy
+from testsuite.kuadrant.policy.dns import DNSPolicy
+from testsuite.kuadrant.policy.tls import TLSPolicy
+
+pytestmark = [pytest.mark.observability]
+
+POLICY_KINDS = ["AuthPolicy", "RateLimitPolicy", "DNSPolicy", "TLSPolicy", "TokenRateLimitPolicy"]
+
+
+@pytest.fixture(scope="module")
+def dns_exposer(request, cluster) -> Exposer:
+    """DNSPolicyExposer for DNS/TLS tests"""
+    exposer = DNSPolicyExposer(cluster)
+    request.addfinalizer(exposer.delete)
+    exposer.commit()
+    return exposer
+
+
+@pytest.fixture(scope="module")
+def dns_base_domain(dns_exposer):
+    """DNS base domain for DNS/TLS tests"""
+    return dns_exposer.base_domain
+
+
+@pytest.fixture(scope="module")
+def dns_wildcard_domain(dns_base_domain):
+    """DNS wildcard domain for DNS/TLS tests"""
+    return f"*.{dns_base_domain}"
+
+
+@pytest.fixture(scope="module")
+def hostname(gateway, dns_exposer, domain_name):
+    """Override to use dns_exposer instead of session exposer"""
+    return dns_exposer.expose_hostname(domain_name, gateway)
+
+
+@pytest.fixture(scope="module")
+def gateway(request, cluster, blame, dns_wildcard_domain, module_label):
+    """Returns gateway with TLS listener for DNS/TLS policy support"""
+    gateway_name = blame("gw")
+    gw = KuadrantGateway.create_instance(cluster, gateway_name, {"app": module_label})
+    gw.add_listener(TLSGatewayListener(hostname=dns_wildcard_domain, gateway_name=gateway_name))
+    request.addfinalizer(gw.delete)
+    gw.commit()
+    gw.wait_for_ready()
+    return gw
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization):
+    """Create AuthPolicy targeting the route with anonymous identity"""
+    authorization.identity.add_anonymous("anonymous")
+    return authorization
+
+
+@pytest.fixture(scope="module")
+def rate_limit(rate_limit):
+    """Create RateLimitPolicy targeting the route"""
+    rate_limit.add_limit("basic", [Limit(5, "10s")])
+    return rate_limit
+
+
+@pytest.fixture(scope="module")
+def token_rate_limit(cluster, blame, route, module_label):
+    """Create TokenRateLimitPolicy targeting the route"""
+    policy = TokenRateLimitPolicy.create_instance(cluster, blame("trlp"), route, labels={"testRun": module_label})
+    policy.add_limit("basic", [Limit(5, "10s")])
+    return policy
+
+
+@pytest.fixture(scope="module")
+def dns_policy(cluster, blame, gateway, module_label, dns_provider_secret):
+    """Create DNSPolicy targeting the gateway"""
+    return DNSPolicy.create_instance(
+        cluster, blame("dns"), gateway, dns_provider_secret, labels={"testRun": module_label}
+    )
+
+
+@pytest.fixture(scope="module")
+def tls_policy(cluster, blame, gateway, module_label, cluster_issuer):
+    """Create TLSPolicy targeting the gateway"""
+    return TLSPolicy.create_instance(
+        cluster, blame("tls"), parent=gateway, issuer=cluster_issuer, labels={"testRun": module_label}
+    )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def commit(request, authorization, rate_limit, token_rate_limit, dns_policy, tls_policy):
+    """Commit all policies and register finalizers for cleanup"""
+    for component in [dns_policy, tls_policy, authorization, rate_limit, token_rate_limit]:
+        request.addfinalizer(component.delete)
+        component.commit()
+        component.wait_for_ready()
+
+
+@pytest.mark.parametrize("policy_kind", POLICY_KINDS)
+def test_metric_kuadrant_policies_total(kuadrant_operator_metrics, policy_kind):
+    """Tests that kuadrant_policies_total metric has value >= 1 for each policy kind"""
+    metrics = kuadrant_operator_metrics.filter(has_label("__name__", "kuadrant_policies_total")).filter(
+        has_label("kind", policy_kind)
+    )
+    assert metrics, f"'kuadrant_policies_total' metric wasn't found for kind '{policy_kind}'"
+    assert (
+        metrics.values[0] >= 1
+    ), f"Expected 'kuadrant_policies_total' for kind '{policy_kind}' to have value >= 1, but got: {metrics.values}"
+
+
+@pytest.mark.parametrize("policy_kind", POLICY_KINDS)
+def test_metric_kuadrant_policies_enforced(kuadrant_operator_metrics, policy_kind):
+    """Tests that kuadrant_policies_enforced metric has value >= 1 for each enforced policy kind"""
+    metrics = (
+        kuadrant_operator_metrics.filter(has_label("__name__", "kuadrant_policies_enforced"))
+        .filter(has_label("kind", policy_kind))
+        .filter(has_label("status", "true"))
+    )
+    assert metrics, f"'kuadrant_policies_enforced' metric wasn't found for kind '{policy_kind}'"
+    assert (
+        metrics.values[0] >= 1
+    ), f"Expected 'kuadrant_policies_enforced' for kind '{policy_kind}' to have value >= 1, but got: {metrics.values}"

--- a/testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics_lifecycle.py
+++ b/testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics_lifecycle.py
@@ -1,0 +1,57 @@
+"""Tests for Kuadrant policy metrics lifecycle (increment/decrement on policy create/delete)."""
+
+import pytest
+
+from testsuite.config import settings
+from testsuite.kuadrant.policy.rate_limit import RateLimitPolicy, Limit
+
+pytestmark = [pytest.mark.observability, pytest.mark.disruptive]
+
+POLICY_METRICS = ["kuadrant_policies_total", "kuadrant_policies_enforced"]
+
+
+@pytest.fixture(scope="module")
+def service_monitor(service_monitors):
+    """Return the kuadrant-operator ServiceMonitor"""
+    return next(sm for sm in service_monitors if "kuadrant-operator-monitor" in sm.name())
+
+
+def _get_metric_value(prometheus, metric, kind):
+    """Helper to get current metric value for a given policy kind"""
+    labels = {
+        "service": "kuadrant-operator-metrics",
+        "kind": kind,
+        "namespace": settings["service_protection"]["system_project"],
+    }
+    if metric == "kuadrant_policies_enforced":
+        labels["status"] = "true"
+
+    metrics = prometheus.get_metrics(key=metric, labels=labels)
+    return metrics.values[0] if metrics.values else 0
+
+
+def test_metric_policy_lifecycle(prometheus, cluster, blame, route, module_label, service_monitor):
+    """Tests that policy metrics increment on create and decrement on delete"""
+    initial_counts = {m: _get_metric_value(prometheus, m, "RateLimitPolicy") for m in POLICY_METRICS}
+
+    policy = RateLimitPolicy.create_instance(cluster, blame("rlp-lc"), route, labels={"testRun": module_label})
+    policy.add_limit("basic", [Limit(5, "10s")])
+    policy.commit()
+    policy.wait_for_ready()
+
+    prometheus.wait_for_scrape(service_monitor, "/metrics")
+
+    for metric in POLICY_METRICS:
+        current_count = _get_metric_value(prometheus, metric, "RateLimitPolicy")
+        assert (
+            current_count == initial_counts[metric] + 1
+        ), f"Expected '{metric}' to be {initial_counts[metric] + 1}, got {current_count}"
+
+    policy.delete()
+    prometheus.wait_for_scrape(service_monitor, "/metrics")
+
+    for metric in POLICY_METRICS:
+        current_count = _get_metric_value(prometheus, metric, "RateLimitPolicy")
+        assert (
+            current_count == initial_counts[metric]
+        ), f"Expected '{metric}' to be {initial_counts[metric]}, got {current_count}"

--- a/testsuite/tests/singlecluster/observability/test_observability.py
+++ b/testsuite/tests/singlecluster/observability/test_observability.py
@@ -37,7 +37,7 @@ POD_MONITOR_METRICS = [
 def test_service_monitor_metrics_per_service(metric, service_monitor_metrics_by_service):
     """Tests that all expected metrics appear in the data collected from each ServiceMonitor"""
     for service_name, metrics in service_monitor_metrics_by_service.items():
-        assert metric in metrics, f"Expected metric '{metric}' in '{service_name}'. Metrics found: {metrics}"
+        assert metric in metrics, f"Expected metric '{metric}' not found in '{service_name}'. Metrics found: {metrics}"
 
 
 @pytest.mark.parametrize("metric", POD_MONITOR_METRICS)


### PR DESCRIPTION
## Description                                                                                                                                                                                                                   
  - Add observability tests for Kuadrant operator health metrics (existence, readiness, components, dependencies, controllers)                                                                                                     
  - Add observability tests for Kuadrant policy metrics (`kuadrant_policies_total` and `kuadrant_policies_enforced`) across all policy kinds                                                                                       
  - Add disruptive lifecycle test verifying policy metrics increment/decrement on policy create/delete
  - Fix assertion message in existing `test_observability.py` for clarity                                                                                                                                                          
                                                                                                                                                                                                                                   
  Closes #875

## Verification steps
  ```bash
  poetry run pytest -vv -n4 --dist loadfile\
    testsuite/tests/singlecluster/observability/test_kuadrant_operator_health_metrics.py \
    testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics.py
  ```

  The lifecycle test requires sequential execution (marked `disruptive`):
  ```bash
  poetry run pytest -vv testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics_lifecycle.py
  ```
