### PR TITLE
feat: update of envoy image used in standalone Authorino tests

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -22,7 +22,7 @@ default:
     project: "kuadrant"
     project2: "kuadrant2"
     envoy:
-      image: "quay.io/trepel/envoy:v1.35-latest"
+      image: "quay.io/trepel/envoy:v1.37.0"
     gateway:
        project: "istio-system"
        name: "istio-ingressgateway"


### PR DESCRIPTION
## Description
Update of envoy image used in standalone Authorino tests. This is good to do time to time so that we don't use too old envoy image.

It is re-tagged from https://hub.docker.com/layers/envoyproxy/envoy/v1.37.0/images/sha256-ee6db70f38ba0b95c10817484ecb7f8d71d3276b5e4dc7b52f12125806d5d419 (and pushed) using `docker buildx imagetools create --tag quay.io/trepel/envoy:v1.37.0 envoyproxy/envoy:v1.37.0` command.


## Changes
just image update in config/settings.yaml

## Verification
Since it is used in standalone Authorino tests use:
`make authorino-standalone`
However, I did that so maybe just try to pull the image and that's it:
`docker pull quay.io/trepel/envoy:v1.37.0`

```
$ make authorino
authorino             authorino-standalone  
17:39:41 testsuite$ make authorino-standalone 
poetry run python -m pytest --tb=short -o cache_dir=./.pytest_cache.authorino-standalone -n4 -m 'authorino and not kuadrant_only and not disruptive' --dist loadfile --enforce --standalone  testsuite/tests/singlecluster/authorino/
======================================================================================= test session starts =======================================================================================
platform linux -- Python 3.13.11, pytest-8.4.1, pluggy-1.6.0
cachedir: .pytest_cache.authorino-standalone

rootdir: /home/trepel/work/githubRepos/testsuite
configfile: pyproject.toml
plugins: anyio-4.9.0, metadata-3.1.1, xdist-3.8.0, html-4.1.1, base-url-2.1.0, playwright-0.7.2
4 workers [211 items]   
........................................................................................................................................................................................... [ 88%]
........................                                                                                                                                                                    [100%]
======================================================================================== warnings summary =========================================================================================
testsuite/tests/singlecluster/authorino/operator/tls/mtls/test_mtls_identity.py: 5 warnings
testsuite/tests/singlecluster/authorino/operator/tls/test_tls.py: 2 warnings
testsuite/tests/singlecluster/authorino/operator/tls/mtls/test_mtls_trust_chain.py: 3 warnings
testsuite/tests/singlecluster/authorino/operator/tls/mtls/test_mtls_attributes.py: 2 warnings
  /home/trepel/work/githubRepos/testsuite/.venv/lib/python3.13/site-packages/httpx/_config.py:63: DeprecationWarning: `cert=...` is deprecated. Use `verify=<ssl_context>` instead,with `.load_cert_chain()` to configure the certificate chain.
    warnings.warn(message, DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================== 211 passed, 12 warnings in 1114.46s (0:18:34) ==========================================================================
```

---

**PR Title Guidelines (Conventional Commits)**

Your PR title must follow the conventional commit format:

```
<type>[optional scope]: <description>
```

**Examples:**
- `feat: add rate limiting policy for gateways`
- `feat(gateway): add rate limiting policy`
- `fix(authorino): resolve authorization timeout issue`
- `test: add tests for DNS policy reconciliation`
- `docs: update installation guide`

**Allowed types:**
- `feat` - New feature
- `fix` - Bug fix
- `docs` - Documentation changes
- `style` - Code style changes (formatting, no logic change)
- `refactor` - Code refactoring
- `perf` - Performance improvements
- `test` - Adding or updating tests
- `build` - Build system changes
- `ci` - CI/CD changes
- `chore` - Other changes (dependencies, tooling)
- `revert` - Revert a previous commit

**Optional scopes:**
- `authorino`, `chore`, `ci`, `dns`, `docs`, `gateway`, `limitador`, `multicluster`, `perf`, `refactor`, `style`, `test`, `tls`
