### PR TITLE
chore: remove hard rollout workaround in test_disk.py for #196 and #227

### DIFF
--- a/testsuite/tests/singlecluster/limitador/storage/disk/test_disk.py
+++ b/testsuite/tests/singlecluster/limitador/storage/disk/test_disk.py
@@ -24,12 +24,10 @@ def test_basic(client):
 def test_durability(client, limitador, rate_limit):
     """
     Basic test checking that after Limitador pod restart, counters are preserved.
-    'hard' rollout is required due to pod getting stuck in graceful rollout
-        see https://github.com/Kuadrant/limitador-operator/issues/196
     """
     responses = client.get_many("/get", LIMIT.limit)
     responses.assert_all(status_code=200)
-    limitador.deployment.rollout(hard=True)
+    limitador.deployment.rollout()
     limitador.wait_for_ready()
     rate_limit.wait_for_ready()
     assert client.get("/get").status_code == 429


### PR DESCRIPTION
## Description
This PR removes a legacy rollout workaround and associated comment in the Limitador storage test. These were previously necessary due to a "Multi-Attach error" and reconciliation issues when using disk storage.

## Changes
Removed hard=True parameter from limitador.deployment.rollout() in test_durability within test_disk.py.
Updated the test docstring to remove references to bug Kuadrant/limitador-operator#196.

## Verification
Created a Limitador instance with storage.disk on the nightly cluster. 
Verified that the Limitador CR correctly transitions to Ready: True status (Kuadrant/limitador-operator#227).
Performed a rollout restart and confirmed the new pod reaches Running status without "Multi-Attach" errors (Kuadrant/limitador-operator#196), confirming the new Recreate deployment strategy works as expected.