### PR TITLE
fix: prevent empty defaults/overrides dicts in policy spec

### DIFF
--- a/testsuite/kuadrant/policy/authorization/auth_policy.py
+++ b/testsuite/kuadrant/policy/authorization/auth_policy.py
@@ -55,15 +55,27 @@ class AuthPolicy(Policy, AuthConfig):
         if self.spec_section is None:
             raise TypeError("Strategy can only be set on defaults or overrides")
 
-        self.spec_section["strategy"] = strategy.value
+        section = self.spec_section
+        if isinstance(self.spec_section, str):
+            # String marker - create the section now
+            section = self.model.spec.setdefault(self.spec_section, {})
+
+        section["strategy"] = strategy.value
         self.spec_section = None
 
     @property
     def auth_section(self):
+        """Returns the rules section for adding auth configuration"""
         if self.spec_section is None:
-            self.spec_section = self.model.spec
+            # Implicit mode - use model.spec directly
+            spec_section = self.model.spec
+        elif isinstance(self.spec_section, str):
+            # String marker ("defaults" or "overrides") - create the section now
+            spec_section = self.model.spec.setdefault(self.spec_section, {})
+        else:
+            # Already a dict (shouldn't happen with new code but keep for compatibility)
+            spec_section = self.spec_section
 
-        spec_section = self.spec_section
         self.spec_section = None
         return spec_section.setdefault("rules", {})
 
@@ -75,13 +87,17 @@ class AuthPolicy(Policy, AuthConfig):
     @property
     def defaults(self):
         """Add new rule into the `defaults` AuthPolicy section"""
-        self.spec_section = self.model.spec.setdefault("defaults", {})
+        # Don't create the dict yet - only mark which section to use
+        # The dict will be created when auth_section is called
+        self.spec_section = "defaults"
         return self
 
     @property
     def overrides(self):
         """Add new rule into the `overrides` AuthPolicy section"""
-        self.spec_section = self.model.spec.setdefault("overrides", {})
+        # Don't create the dict yet - only mark which section to use
+        # The dict will be created when auth_section is called
+        self.spec_section = "overrides"
         return self
 
     @modify

--- a/testsuite/kuadrant/policy/rate_limit.py
+++ b/testsuite/kuadrant/policy/rate_limit.py
@@ -67,9 +67,16 @@ class RateLimitPolicy(Policy):
             limit["counters"] = [asdict(rule) for rule in counters]
 
         if self.spec_section is None:
-            self.spec_section = self.model.spec
+            # Implicit mode - use model.spec directly
+            spec_section = self.model.spec
+        elif isinstance(self.spec_section, str):
+            # String marker ("defaults" or "overrides") - create the section now
+            spec_section = self.model.spec.setdefault(self.spec_section, {})
+        else:
+            # Already a dict (shouldn't happen with new code but keep for compatibility)
+            spec_section = self.spec_section
 
-        self.spec_section.setdefault("limits", {})[name] = limit
+        spec_section.setdefault("limits", {})[name] = limit
         self.spec_section = None
 
     @modify
@@ -78,19 +85,29 @@ class RateLimitPolicy(Policy):
         if self.spec_section is None:
             raise TypeError("Strategy can only be set on defaults or overrides")
 
-        self.spec_section["strategy"] = strategy.value
+        if isinstance(self.spec_section, str):
+            # String marker - create the section now
+            section = self.model.spec.setdefault(self.spec_section, {})
+        else:
+            section = self.spec_section
+
+        section["strategy"] = strategy.value
         self.spec_section = None
 
     @property
     def defaults(self):
         """Add new rule into the `defaults` RateLimitPolicy section"""
-        self.spec_section = self.model.spec.setdefault("defaults", {})
+        # Don't create the dict yet - only mark which section to use
+        # The dict will be created when add_limit or strategy is called
+        self.spec_section = "defaults"
         return self
 
     @property
     def overrides(self):
         """Add new rule into the `overrides` RateLimitPolicy section"""
-        self.spec_section = self.model.spec.setdefault("overrides", {})
+        # Don't create the dict yet - only mark which section to use
+        # The dict will be created when add_limit or strategy is called
+        self.spec_section = "overrides"
         return self
 
     def wait_for_ready(self):


### PR DESCRIPTION
## Description

  - Fixed a bug in `AuthPolicy` where accessing `defaults` or `overrides` properties would immediately create empty dicts in the spec, even when no rules were added
  - Changed the implementation to use lazy initialization with string markers instead of eager dict creation
  - This prevents empty `defaults: {}` or `overrides: {}` sections from appearing in committed AuthPolicy specs

  ## Changes

  ### Bug Fix
  - Modified `defaults` and `overrides` properties to use string markers (`"defaults"`, `"overrides"`) instead of immediately calling `setdefault()`
  - Updated `auth_section` property to check for string markers and only create the dict when actually needed
  - Updated `strategy()` method to handle string markers and create the section dict on-demand
  - Added inline comments explaining the lazy initialization pattern

  ## Technical Details

  The previous implementation would create empty dicts when accessing properties:
  ```python
  self.spec_section = self.model.spec.setdefault("defaults", {})  # Creates empty dict immediately
```

  New implementation uses lazy initialization:
  self.spec_section = "defaults"  # Just a marker, no dict created yet

  The actual dict is only created when auth_section or strategy() is called to add actual configuration.

 ### Verification steps

  No test files were modified. Existing tests verify the fix:
  # Test defaults/overrides exclusivity rules
  poetry run pytest -vv testsuite/tests/singlecluster/defaults/test_rules_exclusivity.py testsuite/tests/singlecluster/overrides/test_rules_exclusivity.py

  # Test that defaults/overrides functionality still works
  poetry run pytest -vv testsuite/tests/singlecluster/defaults/ testsuite/tests/singlecluster/overrides/
