### PR TITLE
refactor: refactor mtls test to support Istio 1.27+ native sidecars

### DIFF
--- a/testsuite/tests/singlecluster/gateway/mtls/conftest.py
+++ b/testsuite/tests/singlecluster/gateway/mtls/conftest.py
@@ -64,12 +64,13 @@ def wait_for_injected_pod(cluster, testconfig):
             pods = selector("pods", labels={f"{component_label}-resource": component_label}).objects()
             for pod in pods:
                 labels = pod.model.metadata.labels
+                # Check both spec.containers (Istio <1.27) and spec.initContainers (native sidecars in Istio 1.27+)
                 containers = [c.name for c in pod.model.spec.containers]
-
+                init_containers = [c.name for c in pod.model.spec.get("initContainers", [])]
                 if (
                     labels.get("sidecar.istio.io/inject") == "true"
                     and labels.get("kuadrant.io/managed") == "true"
-                    and "istio-proxy" in containers
+                    and ("istio-proxy" in containers or "istio-proxy" in init_containers)
                 ):
                     return pod
         return None

--- a/testsuite/tests/singlecluster/gateway/mtls/test_mtls_configuration.py
+++ b/testsuite/tests/singlecluster/gateway/mtls/test_mtls_configuration.py
@@ -54,13 +54,17 @@ def test_pods_have_istio_sidecar_and_labels(
         assert pod is not None, f"No pod with sidecar found for component '{comp}'"
         pod_name = pod.name()
         pod_labels = pod.model.metadata.labels
+        # Check both spec.containers (Istio <1.27) and spec.initContainers (native sidecars in Istio 1.27+)
         container_names = [c.name for c in pod.model.spec.containers]
+        init_container_names = [c.name for c in pod.model.spec.get("initContainers", [])]
 
         assert (
             pod_labels.get("sidecar.istio.io/inject") == "true"
         ), f"{pod_name} missing label 'sidecar.istio.io/inject: true'"
         assert pod_labels.get("kuadrant.io/managed") == "true", f"{pod_name} missing label 'kuadrant.io/managed: true'"
-        assert "istio-proxy" in container_names, f"{pod_name} does not have 'istio-proxy' sidecar container"
+        assert (
+            "istio-proxy" in container_names or "istio-proxy" in init_container_names
+        ), f"{pod_name} does not have 'istio-proxy' sidecar (checked both containers and initContainers)"
 
 
 @pytest.mark.parametrize("component", component_cases, indirect=True)


### PR DESCRIPTION
## Description        
    
  - Refactored mTLS test `test_pods_have_istio_sidecar_and_labels` to support Istio 1.27+ native sidecars which now default to `initContainers` instead of regular `containers`                                                                                                                                                             
  - Maintained backward compatibility with Istio <1.27 by checking both container locations                                                                                                                                                                                                   
     
Closes #882 
                                                                                                                                                                                                                                                                                       
## Changes      

  - Updated `test_pods_have_istio_sidecar_and_labels` test to verify `istio-proxy` presence in both container locations
  - Updated `wait_for_injected_pod` fixture in `conftest.py` to check both `spec.containers` and `spec.initContainers` for the `istio-proxy` sidecar
  - Added `or []` fallback when accessing `initContainers` as it's optional in the pod spec

## Verification steps
Run the test on a cluster with Istio 1.27 (I tested on `kua-420-2` which is configured with it):
 
 ```bash
  poetry run pytest -vv testsuite/tests/singlecluster/gateway/mtls/test_mtls_configuration.py::test_pods_have_istio_sidecar_and_labels