### PR TITLE
fix: add retry logic to kuadrant metrics tests

### DIFF
--- a/testsuite/prometheus.py
+++ b/testsuite/prometheus.py
@@ -1,5 +1,6 @@
 """Simple client for the Prometheus metrics"""
 
+import operator
 from datetime import datetime, timezone
 from typing import Callable
 
@@ -106,6 +107,29 @@ class Prometheus:
             return False
 
         assert _wait_for_scrape(), "Scrape wasn't done in time"
+
+    def wait_for_metric(
+        self,
+        metric_name: str,
+        metric_value: float,
+        labels: dict[str, str] = None,
+        compare: Callable[[float, float], bool] = operator.eq,
+    ) -> bool:
+        """Wait for a metric to reach the expected value by polling with retries.
+        Treats missing metrics as value 0.
+        Supports any comparison via operator module (e.g. operator.eq, operator.ge, operator.lt)."""
+
+        @backoff.on_predicate(backoff.constant, interval=10, jitter=None, max_tries=5)
+        def _wait():
+            metrics = self.get_metrics(key=metric_name, labels=labels)
+            values = metrics.values
+            if not values:
+                return compare(0, metric_value)
+            if len(values) > 1:
+                raise AssertionError(f"Metric '{metric_name}' returned {len(values)} series; use stricter labels.")
+            return compare(values[0], metric_value)
+
+        return _wait()
 
     @backoff.on_predicate(backoff.constant, interval=5, max_tries=12, jitter=None)
     def verify_no_observability_targets(self, label_filters: dict[str, list[str]]) -> bool:

--- a/testsuite/tests/singlecluster/observability/conftest.py
+++ b/testsuite/tests/singlecluster/observability/conftest.py
@@ -97,8 +97,17 @@ def pod_monitor_metrics(client, pod_monitor, prometheus):
 
 
 @pytest.fixture(scope="module")
-def kuadrant_operator_metrics(prometheus):
+def kuadrant_service_monitor(service_monitors):
+    """Return the kuadrant-operator ServiceMonitor"""
+    monitor = next((sm for sm in service_monitors if "kuadrant-operator-monitor" in sm.name()), None)
+    assert monitor is not None, "kuadrant-operator-monitor ServiceMonitor not found"
+    return monitor
+
+
+@pytest.fixture(scope="module")
+def kuadrant_operator_metrics(prometheus, kuadrant_service_monitor):
     """Return all metrics from the Kuadrant operator metrics endpoint"""
+    prometheus.wait_for_scrape(kuadrant_service_monitor, "/metrics")
     return prometheus.get_metrics(
         labels={"service": "kuadrant-operator-metrics", "namespace": settings["service_protection"]["system_project"]}
     )

--- a/testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics.py
+++ b/testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics.py
@@ -1,7 +1,10 @@
 """Tests for Kuadrant policy metrics (policies total and policies enforced per policy kind)."""
 
+import operator
+
 import pytest
 
+from testsuite.config import settings
 from testsuite.gateway import Exposer, TLSGatewayListener
 from testsuite.prometheus import has_label
 from testsuite.gateway.gateway_api.gateway import KuadrantGateway
@@ -115,14 +118,15 @@ def test_metric_kuadrant_policies_total(kuadrant_operator_metrics, policy_kind):
 
 
 @pytest.mark.parametrize("policy_kind", POLICY_KINDS)
-def test_metric_kuadrant_policies_enforced(kuadrant_operator_metrics, policy_kind):
+def test_metric_kuadrant_policies_enforced(prometheus, policy_kind):
     """Tests that kuadrant_policies_enforced metric has value >= 1 for each enforced policy kind"""
-    metrics = (
-        kuadrant_operator_metrics.filter(has_label("__name__", "kuadrant_policies_enforced"))
-        .filter(has_label("kind", policy_kind))
-        .filter(has_label("status", "true"))
+    labels = {
+        "service": "kuadrant-operator-metrics",
+        "namespace": settings["service_protection"]["system_project"],
+        "kind": policy_kind,
+        "status": "true",
+    }
+    assert prometheus.wait_for_metric("kuadrant_policies_enforced", 1, labels=labels, compare=operator.ge), (
+        f"Expected 'kuadrant_policies_enforced' for kind '{policy_kind}' "
+        f"to have value >= 1, but got: {prometheus.get_metrics(key='kuadrant_policies_enforced', labels=labels).values}"
     )
-    assert metrics, f"'kuadrant_policies_enforced' metric wasn't found for kind '{policy_kind}'"
-    assert (
-        metrics.values[0] >= 1
-    ), f"Expected 'kuadrant_policies_enforced' for kind '{policy_kind}' to have value >= 1, but got: {metrics.values}"

--- a/testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics_lifecycle.py
+++ b/testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics_lifecycle.py
@@ -10,48 +10,52 @@ pytestmark = [pytest.mark.observability, pytest.mark.disruptive]
 POLICY_METRICS = ["kuadrant_policies_total", "kuadrant_policies_enforced"]
 
 
-@pytest.fixture(scope="module")
-def service_monitor(service_monitors):
-    """Return the kuadrant-operator ServiceMonitor"""
-    return next(sm for sm in service_monitors if "kuadrant-operator-monitor" in sm.name())
-
-
-def _get_metric_value(prometheus, metric, kind):
-    """Helper to get current metric value for a given policy kind"""
+def _metric_labels(metric, policy_kind):
+    """Return Prometheus query labels for a given metric and policy kind"""
     labels = {
         "service": "kuadrant-operator-metrics",
-        "kind": kind,
+        "kind": policy_kind,
         "namespace": settings["service_protection"]["system_project"],
     }
     if metric == "kuadrant_policies_enforced":
         labels["status"] = "true"
+    return labels
 
-    metrics = prometheus.get_metrics(key=metric, labels=labels)
+
+def _get_metric_value(prometheus, metric, policy_kind):
+    """Helper to get current metric value for a given policy kind"""
+    metrics = prometheus.get_metrics(key=metric, labels=_metric_labels(metric, policy_kind))
     return metrics.values[0] if metrics.values else 0
 
 
-def test_metric_policy_lifecycle(prometheus, cluster, blame, route, module_label, service_monitor):
+def test_metric_policy_lifecycle(request, prometheus, cluster, blame, route, module_label):
     """Tests that policy metrics increment on create and decrement on delete"""
     initial_counts = {m: _get_metric_value(prometheus, m, "RateLimitPolicy") for m in POLICY_METRICS}
 
     policy = RateLimitPolicy.create_instance(cluster, blame("rlp-lc"), route, labels={"testRun": module_label})
+    request.addfinalizer(policy.delete)
     policy.add_limit("basic", [Limit(5, "10s")])
     policy.commit()
     policy.wait_for_ready()
 
-    prometheus.wait_for_scrape(service_monitor, "/metrics")
-
     for metric in POLICY_METRICS:
-        current_count = _get_metric_value(prometheus, metric, "RateLimitPolicy")
-        assert (
-            current_count == initial_counts[metric] + 1
-        ), f"Expected '{metric}' to be {initial_counts[metric] + 1}, got {current_count}"
+        assert prometheus.wait_for_metric(
+            metric,
+            initial_counts[metric] + 1,
+            labels=_metric_labels(metric, "RateLimitPolicy"),
+        ), (
+            f"Expected '{metric}' to be {initial_counts[metric] + 1} on policy creation,"
+            f" got {_get_metric_value(prometheus, metric, 'RateLimitPolicy')}"
+        )
 
     policy.delete()
-    prometheus.wait_for_scrape(service_monitor, "/metrics")
 
     for metric in POLICY_METRICS:
-        current_count = _get_metric_value(prometheus, metric, "RateLimitPolicy")
-        assert (
-            current_count == initial_counts[metric]
-        ), f"Expected '{metric}' to be {initial_counts[metric]}, got {current_count}"
+        assert prometheus.wait_for_metric(
+            metric,
+            initial_counts[metric],
+            labels=_metric_labels(metric, "RateLimitPolicy"),
+        ), (
+            f"Expected '{metric}' to be {initial_counts[metric]} on policy deletion,"
+            f" got {_get_metric_value(prometheus, metric, 'RateLimitPolicy')}"
+        )


### PR DESCRIPTION
## Description
  - Fix intermittent failures observed in nightly test pipeline for `test_metric_kuadrant_policies_enforced` where `kuadrant_policies_enforced` metric shows `0.0` for `RateLimitPolicy` and `TokenRateLimitPolicy`
  - Fix intermittent failures observed in nightly test pipeline for `test_metric_policy_lifecycle` where metrics don't reflect policy deletion in time
 - Possible root cause: the kuadrant-operator updates policy metrics from an in-memory topology snapshot that may lag one reconciliation cycle behind the actual policy state in etcd, causing a race condition between policy
  enforcement and metric updates. Policies committed last (`RateLimitPolicy`, `TokenRateLimitPolicy`) are most affected as they have less time for the operator to complete the follow-up reconciliation cycle

## Changes

  ### New Features
  - Add `wait_for_metric` method to `Prometheus` class that polls a metric value with backoff retries, supporting custom comparisons via `operator` module (e.g. `operator.eq`, `operator.ge`, `operator.lt`)

  ### Bug Fixes
  - Replace single-shot metric assertions with `prometheus.wait_for_metric` in `test_metric_kuadrant_policies_enforced` to wait for Prometheus to reflect enforced status
  - Replace `wait_for_scrape` with `prometheus.wait_for_metric` in `test_metric_policy_lifecycle` for both policy creation and deletion metric checks
  - Add `request.addfinalizer(policy.delete)` to `test_metric_policy_lifecycle` to prevent policy resource leaks when assertions fail before `policy.delete()` is reached

  ### Refactoring
  - Move `service_monitor` fixture to `conftest.py` as `kuadrant_service_monitor` for reuse across test modules
  - Add `wait_for_scrape` to `kuadrant_operator_metrics` fixture in `conftest.py` to ensure fresh metrics after policy commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a polling-based Prometheus wait that retries with configurable comparison, handles absent or multiple series, and surfaces latest observed values on failure.
  * Tests now explicitly wait for the operator service scrape readiness before validating metrics and use the new polling approach for lifecycle assertions.
  * Improved teardown sequencing to ensure resources are deleted reliably.

* **Refactor**
  * Consolidated and centralised metric label construction for consistent observability queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->