### PR TITLE
test: Add backend not reached test

### DIFF
--- a/testsuite/tests/singlecluster/authorino/test_backend_not_reached.py
+++ b/testsuite/tests/singlecluster/authorino/test_backend_not_reached.py
@@ -1,0 +1,42 @@
+"""Test that checks if requests that are blocked by Authorino do not reach the backend"""
+
+import pytest
+
+from testsuite.kuadrant.policy.authorization import DenyResponse, Value
+from testsuite.utils import rego_allow_header
+
+
+@pytest.fixture(scope="module")
+def require_observability_disabled(kuadrant):
+    """
+    Skip test if tracing is enabled in the Kuadrant CR.
+    This test does not verify properly with tracing enabled
+    """
+    tracing_spec = kuadrant.model.spec.get("observability", {}).get("tracing")
+    if tracing_spec is not None and tracing_spec.get("defaultEndpoint") is not None:
+        pytest.skip("This test does not verify properly with tracing enabled")
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization):
+    """
+    Adds OPA policy that accepts all requests that contain `header`
+    Adds unauthorized message as it adds processing delay, increasing the chance for the bug to appear.
+    """
+    authorization.identity.clear_all()
+    authorization.authorization.add_opa_policy("opa", rego_allow_header("key", "value"))
+    authorization.responses.set_unauthorized(DenyResponse(body=Value("Custom response")))
+    return authorization
+
+
+@pytest.mark.issue("https://github.com/Kuadrant/wasm-shim/pull/321")
+def test_backend_not_reached(client, require_observability_disabled):  # pylint: disable=unused-argument
+    """
+    Get current value of the counter. This counter increments by every request.
+    Do unauthorized requests which should not increment the counter.
+    Lastly check the counter if it contains expected value.
+    """
+    before_counter = client.get("/counter", headers={"key": "value"}).json()["counter"]
+    client.get_many("/counter", 10)
+    after_counter = client.get("/counter", headers={"key": "value"}).json()["counter"]
+    assert after_counter == before_counter + 1


### PR DESCRIPTION
## Description
Implements test for bug fixed by https://github.com/Kuadrant/wasm-shim/pull/321 
The bug is a race condition where request gets sent to backend even when rejected by policy and client sees rejected status code.

## Changes
Adds 1 test
Adds 1 endpoint to Httpbin https://gitlab.cee.redhat.com/kuadrant-qe/httpbin/-/commit/f231b78970b6351ca9a58270ffeaa16ad8b3ebe0 
Due to recent build the `latest` tag on clusters will take some time to propagate, because Deployments created by testsuite uses pull strategy `PullIfNotPresent` I can change it in this PR if needed, or change `latest` tag with `0.2` in settings.

## Verification
On cluster with tracing disabled (not observability) run:
```
KUADRANT_HTTPBIN__IMAGE="quay.io/rhn_support_azgabur/httpbin:0.2" make testsuite/tests/singlecluster/authorino/test_backend_not_reached.py
```
Bug was fixed in Kuadrant v1.4.3 so you can test that the test is failing in 1.4.2 and passing in v1.4.3-rc2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new test verifying that requests blocked by the authorisation layer never reach or increment backend counters.
  * Added module-scoped test helpers to disable observability checks and to set up/clear authorization state with a custom denial response for deterministic test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->