### PR TITLE
fix: remove whitespace in mockserver URL construction

### DIFF
--- a/testsuite/tests/singlecluster/gateway/dnspolicy/health_check/test_additional_headers.py
+++ b/testsuite/tests/singlecluster/gateway/dnspolicy/health_check/test_additional_headers.py
@@ -62,7 +62,7 @@ def headers_secret(request, cluster, blame):
 @pytest.fixture(scope="module")
 def mockserver_client(backend):
     """Returns Mockserver client from load-balanced service IP"""
-    return Mockserver(KuadrantClient(base_url=f"http://{backend.service.refresh().external_ip}: 8080"))
+    return Mockserver(KuadrantClient(base_url=f"http://{backend.service.refresh().external_ip}:8080"))
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary
- Fixed URL formatting bug in health check test where space was incorrectly placed between host IP and port number

## Details
The mockserver client was being instantiated with `http://{ip}: 8080` instead of `http://{ip}:8080`, causing connection failures in DNSPolicy health check tests.

**File changed:** `testsuite/tests/singlecluster/gateway/dnspolicy/health_check/test_additional_headers.py:65`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected URL formatting in test infrastructure to ensure accurate request handling during testing procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->