### PR TITLE
fix(dnscli): change secret-generation command name to add-cluster-secret

### DIFF
--- a/testsuite/tests/multicluster/coredns/two_clusters/kubectl_dns/test_secret_generation.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/kubectl_dns/test_secret_generation.py
@@ -1,4 +1,4 @@
-"""Test kubectl-dns secret-generate command with basic coredns setup with 1 primary and 1 secondary clusters"""
+"""Test kubectl-dns add-cluster-secret command with basic coredns setup with 1 primary and 1 secondary clusters"""
 
 import shutil
 
@@ -22,7 +22,7 @@ def kubectl_dns(testconfig, skip_or_fail):
 
 @pytest.fixture(scope="module")
 def kubeconfig_secrets(request, testconfig, cluster, cluster2, kubectl_dns, blame):
-    """Run generate-secret command on merged kubeconfig to generate kubeconfig secret for the secondary cluster"""
+    """Run add-cluster-secret command on merged kubeconfig to generate kubeconfig secret for the secondary cluster"""
     system_project = testconfig["service_protection"]["system_project"]
     secret_name = blame("kubecfg")
     request.addfinalizer(
@@ -31,7 +31,7 @@ def kubeconfig_secrets(request, testconfig, cluster, cluster2, kubectl_dns, blam
 
     merged_kubeconfig = cluster.create_merged_kubeconfig(cluster2)
     result = kubectl_dns.run(
-        "secret-generation",
+        "add-cluster-secret",
         "--name",
         secret_name,
         "--context",


### PR DESCRIPTION
## Description

CoreDNS secret-generation command name was changed to `add-cluster-secret`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Updated test invocations to reflect the command name change from `secret-generation` to `add-cluster-secret` in cluster secret generation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->