### PR TITLE
test(x509): add Tier 1, Client-Cert header and multi CA trust tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ markers = [
     "cli: Test is using CLI tools (kubectl-dns, kuadrantctl)",
     "egress_gateway: Test is using egress gateway",
     "min_ocp_version: Minimum OpenShift version required for test (e.g., @pytest.mark.min_ocp_version((4, 20)))",
+    "gateway_api_version: Gateway API version requirement (e.g., @pytest.mark.gateway_api_version((1, 5, 0)) or @pytest.mark.gateway_api_version((1, 5, 0), operator.eq))",
 ]
 filterwarnings = [
     "ignore: WARNING the new order is not taken into account:UserWarning",

--- a/testsuite/certificates.py
+++ b/testsuite/certificates.py
@@ -1,5 +1,6 @@
 """Module containing classes for working with TLS certificates"""
 
+import base64
 import dataclasses
 import datetime
 import json
@@ -11,6 +12,7 @@ from typing import Optional, List, Dict, Collection, Union
 from urllib.parse import quote
 
 from cryptography import x509
+from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.types import CertificatePublicKeyTypes
 
 
@@ -70,6 +72,18 @@ class Certificate:
     def xfcc_header(self) -> str:
         """Returns X-Forwarded-Client-Cert header value with this certificate"""
         return f'Hash=placeholder;Cert="{quote(self.certificate, safe="")}"'
+
+    @cached_property
+    def client_cert_header(self) -> str:
+        """Returns RFC 9440 Client-Cert header value (colon-delimited base64-encoded DER certificate)"""
+        der_bytes = self.decoded.public_bytes(serialization.Encoding.DER)
+        encoded = base64.b64encode(der_bytes).decode("ascii")
+        return f":{encoded}:"
+
+    @cached_property
+    def url_encoded_pem(self) -> str:
+        """Returns URL-encoded PEM certificate"""
+        return quote(self.certificate, safe="")
 
 
 @dataclasses.dataclass

--- a/testsuite/gateway/exposers.py
+++ b/testsuite/gateway/exposers.py
@@ -1,6 +1,5 @@
 """General exposers, not tied to Envoy or Gateway API"""
 
-from testsuite.certificates import Certificate
 from testsuite.gateway import Exposer, Gateway, Hostname
 from testsuite.httpx import KuadrantClient, ForceSNIClient
 from testsuite.kubernetes.openshift.route import OpenshiftRoute
@@ -43,20 +42,23 @@ class OpenShiftExposer(Exposer):
 class StaticLocalHostname(Hostname):
     """Static local IP hostname"""
 
-    def __init__(self, hostname, ip_getter, verify: Certificate = None, force_https: bool = False):
+    def __init__(self, hostname, ip_getter, verify_getter=None, force_https: bool = False):
         self._hostname = hostname
-        self.verify = verify
         self.ip_getter = ip_getter
+        self.verify_getter = verify_getter
         self.force_https = force_https
 
     def client(self, **kwargs) -> KuadrantClient:
         headers = kwargs.setdefault("headers", {})
         headers["Host"] = self.hostname
+        ip = self.ip_getter()
+        verify = self.verify_getter() if self.verify_getter else None
         protocol = "http"
-        if self.verify or self.force_https:
+        if verify or self.force_https:
+            ip = ip.replace(":80", ":443")
             protocol = "https"
-            kwargs.setdefault("verify", self.verify)
-        return ForceSNIClient(base_url=f"{protocol}://{self.ip_getter()}", sni_hostname=self.hostname, **kwargs)
+            kwargs.setdefault("verify", verify)
+        return ForceSNIClient(base_url=f"{protocol}://{ip}", sni_hostname=self.hostname, **kwargs)
 
     @property
     def hostname(self):
@@ -69,7 +71,7 @@ class LoadBalancerServiceExposer(Exposer):
     def expose_hostname(self, name, gateway: Gateway) -> Hostname:
         hostname = f"{name}.{self.base_domain}"
         return StaticLocalHostname(
-            hostname, gateway.external_ip, gateway.get_tls_cert(hostname), force_https=self.passthrough
+            hostname, gateway.external_ip, lambda: gateway.get_tls_cert(hostname), force_https=self.passthrough
         )
 
     @property

--- a/testsuite/gateway/gateway_api/gateway.py
+++ b/testsuite/gateway/gateway_api/gateway.py
@@ -47,6 +47,20 @@ class KuadrantGateway(KubernetesObject, Gateway):
         self.model.spec.listeners.append(asdict(listener))
 
     @modify
+    def set_frontend_tls_validation(self, ca_certificate_refs: list[dict], mode: str = "AllowValidOnly"):
+        """Configures Gateway API v1.5+ frontend TLS client certificate validation"""
+        self.model.spec.tls = {
+            "frontend": {
+                "default": {
+                    "validation": {
+                        "caCertificateRefs": ca_certificate_refs,
+                        "mode": mode,
+                    }
+                }
+            }
+        }
+
+    @modify
     def remove_listener(self, listener_name: str):
         """Removes a listener from Gateway."""
         self.model.spec.listeners = list(filter(lambda i: i["name"] != listener_name, self.model.spec.listeners))

--- a/testsuite/kuadrant/policy/authorization/__init__.py
+++ b/testsuite/kuadrant/policy/authorization/__init__.py
@@ -189,4 +189,4 @@ class X509Source:
 
     xfccHeader: Optional[str] = None
     clientCertHeader: Optional[str] = None
-    expression: Optional[CelExpression] = None
+    expression: Optional[str] = None

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -1,5 +1,6 @@
 """Root conftest"""
 
+import operator
 import signal
 from urllib.parse import urlparse
 
@@ -111,6 +112,22 @@ def term_handler():
     signal.signal(signal.SIGTERM, orig)
 
 
+def _detect_gateway_api_version():
+    """Detect Gateway API CRD version from the cluster at collection time"""
+    try:
+        cluster = settings["control_plane"]["cluster"].change_project(settings["service_protection"]["project"])
+    except (KeyError, ValidationError):
+        return None
+
+    with cluster.context:
+        if (crd := selector("crd/gateways.gateway.networking.k8s.io").object(ignore_not_found=True)) is None:
+            return None
+
+    if (version_str := crd.model.metadata.annotations.get("gateway.networking.k8s.io/bundle-version")) is None:
+        return None
+    return tuple(int(p) for p in str(version_str).removeprefix("v").split(".")[:3])
+
+
 def pytest_collection_modifyitems(session, config, items):  # pylint: disable=unused-argument
     """
     Add user properties to testcases for xml output
@@ -131,6 +148,20 @@ def pytest_collection_modifyitems(session, config, items):  # pylint: disable=un
         func = getattr(item, "function", None)
         if func and func.__doc__:
             item.user_properties.append(("__rp_case_description", func.__doc__))
+
+    gateway_api_ver = _detect_gateway_api_version()
+    for item in items:
+        marker = item.get_closest_marker("gateway_api_version")
+        if marker:
+            required = marker.args[0]
+            op = marker.args[1] if len(marker.args) > 1 else operator.ge
+            if gateway_api_ver is None or not op(gateway_api_ver, required):
+                got = f"v{'.'.join(map(str, gateway_api_ver))}" if gateway_api_ver else "unknown"
+                item.add_marker(
+                    pytest.mark.skip(
+                        reason=f"Requires Gateway API CRDs {op.__name__} v{'.'.join(map(str, required))}, got {got}"
+                    )
+                )
 
 
 @pytest.fixture(scope="session")

--- a/testsuite/tests/singlecluster/authorino/identity/x509/conftest.py
+++ b/testsuite/tests/singlecluster/authorino/identity/x509/conftest.py
@@ -62,15 +62,23 @@ def certificate_selector_labels(blame):
 
 
 @pytest.fixture(scope="module")
-def client_ca_secret(request, testconfig, cluster, blame, client_ca, certificate_selector_labels):
-    """Create CA certificate Kubernetes Secret in system namespace, with labels matching the selector in AuthPolicy"""
-    sys_proj = cluster.change_project(testconfig["service_protection"]["system_project"])
-    secret = Secret.create_instance(
-        sys_proj, blame("client-ca"), stringData={"ca.crt": client_ca.certificate}, labels=certificate_selector_labels
-    )
-    request.addfinalizer(secret.delete)
-    secret.commit()
-    return secret
+def create_secret(blame, request, testconfig, cluster):
+    """Factory for creating Secrets in the system namespace"""
+
+    def _create_secret(name, string_data, labels=None):
+        sys_proj = cluster.change_project(testconfig["service_protection"]["system_project"])
+        secret = Secret.create_instance(sys_proj, blame(name), stringData=string_data, labels=labels)
+        request.addfinalizer(secret.delete)
+        secret.commit()
+        return secret
+
+    return _create_secret
+
+
+@pytest.fixture(scope="module")
+def client_ca_secret(create_secret, client_ca, certificate_selector_labels):
+    """CA certificate Secret in system namespace, with labels matching the selector in AuthPolicy"""
+    return create_secret("client-ca", {"ca.crt": client_ca.certificate}, labels=certificate_selector_labels)
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/singlecluster/authorino/identity/x509/gateway_validation/conftest.py
+++ b/testsuite/tests/singlecluster/authorino/identity/x509/gateway_validation/conftest.py
@@ -1,0 +1,77 @@
+"""Conftest for gateway-level client certificate validation tests with frontend TLS validation"""
+
+import pytest
+
+from testsuite.gateway import TLSGatewayListener, Exposer
+from testsuite.gateway.gateway_api.gateway import KuadrantGateway
+from testsuite.kuadrant.policy.tls import TLSPolicy
+from testsuite.kubernetes.config_map import ConfigMap
+
+
+@pytest.fixture(scope="module")
+def exposer(request, testconfig, cluster) -> Exposer:
+    """Exposer object instance with TLS passthrough"""
+    exposer = testconfig["default_exposer"](cluster)
+    exposer.passthrough = True  # Gateway needs to terminate TLS to validate client certificates
+    request.addfinalizer(exposer.delete)
+    exposer.commit()
+    return exposer
+
+
+@pytest.fixture(scope="module")
+def base_domain(exposer):
+    """Returns preconfigured base domain"""
+    return exposer.base_domain
+
+
+@pytest.fixture(scope="module")
+def wildcard_domain(base_domain):
+    """Wildcard domain for the exposer"""
+    return f"*.{base_domain}"
+
+
+@pytest.fixture(scope="module")
+def client_ca_config_map(request, cluster, blame, client_ca):
+    """ConfigMap containing the trusted CA certificate for frontend TLS validation"""
+    config_map = ConfigMap.create_instance(cluster, blame("client-ca"), data={"ca.crt": client_ca.certificate})
+    request.addfinalizer(config_map.delete)
+    config_map.commit()
+    return config_map
+
+
+@pytest.fixture(scope="module")
+def gateway(request, cluster, blame, wildcard_domain, module_label, client_ca_config_map):
+    """Gateway with TLS listener and frontend TLS client certificate validation"""
+    gateway_name = blame("gw")
+    gw = KuadrantGateway.create_instance(cluster, gateway_name, labels={"app": module_label})
+    gw.add_listener(TLSGatewayListener(hostname=wildcard_domain, gateway_name=gateway_name))
+    gw.set_frontend_tls_validation(
+        [{"name": client_ca_config_map.name(), "kind": "ConfigMap", "group": ""}],
+    )
+    request.addfinalizer(gw.delete)
+    gw.commit()
+    gw.wait_for_ready()
+    return gw
+
+
+@pytest.fixture(scope="module")
+def server_ca(gateway, hostname):
+    """Server-side TLS certificate from the gateway for verifying the TLS connection"""
+    return gateway.get_tls_cert(hostname.hostname)
+
+
+@pytest.fixture(scope="module")
+def tls_policy(blame, gateway, module_label, cluster_issuer):
+    """TLSPolicy"""
+    return TLSPolicy.create_instance(
+        gateway.cluster, blame("tls"), parent=gateway, issuer=cluster_issuer, labels={"app": module_label}
+    )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def commit(request, tls_policy, authorization):
+    """Commits TLSPolicy and AuthPolicy"""
+    for component in [tls_policy, authorization]:
+        request.addfinalizer(component.delete)
+        component.commit()
+        component.wait_for_ready()

--- a/testsuite/tests/singlecluster/authorino/identity/x509/gateway_validation/test_envoy_filter.py
+++ b/testsuite/tests/singlecluster/authorino/identity/x509/gateway_validation/test_envoy_filter.py
@@ -9,9 +9,8 @@ from the X-Forwarded-Client-Cert (XFCC) header.
 
 import pytest
 
-from testsuite.gateway import Exposer, TLSGatewayListener
+from testsuite.gateway import TLSGatewayListener
 from testsuite.gateway.gateway_api.gateway import KuadrantGateway
-from testsuite.kuadrant.policy.tls import TLSPolicy
 from testsuite.kubernetes.deployment import SecretVolume, VolumeMount
 from testsuite.kubernetes.envoy_filter import EnvoyFilter
 from testsuite.kubernetes.secret import Secret
@@ -20,30 +19,8 @@ pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only]
 
 
 @pytest.fixture(scope="module")
-def exposer(request, testconfig, cluster) -> Exposer:
-    """Exposer object instance with TLS passthrough"""
-    exposer = testconfig["default_exposer"](cluster)
-    exposer.passthrough = True  # Gateway needs to terminate TLS to validate client certificates
-    request.addfinalizer(exposer.delete)
-    exposer.commit()
-    return exposer
-
-
-@pytest.fixture(scope="module")
-def base_domain(exposer):
-    """Returns preconfigured base domain"""
-    return exposer.base_domain
-
-
-@pytest.fixture(scope="module")
-def wildcard_domain(base_domain):
-    """Wildcard domain for the exposer"""
-    return f"*.{base_domain}"
-
-
-@pytest.fixture(scope="module")
 def gateway(request, cluster, blame, wildcard_domain, module_label):
-    """Gateway with TLS listener"""
+    """Gateway with TLS listener without frontend validation (EnvoyFilter handles L4 validation)"""
     gateway_name = blame("gw")
     gw = KuadrantGateway.create_instance(cluster, gateway_name, labels={"app": module_label})
     gw.add_listener(TLSGatewayListener(hostname=wildcard_domain, gateway_name=gateway_name))
@@ -76,27 +53,13 @@ def envoy_filter(request, cluster, blame, gateway, gateway_ca_secret, module_lab
     return envoy_filter
 
 
-@pytest.fixture(scope="module")
-def tls_policy(blame, gateway, module_label, cluster_issuer):
-    """TLSPolicy fixture"""
-    return TLSPolicy.create_instance(
-        gateway.cluster, blame("tls"), parent=gateway, issuer=cluster_issuer, labels={"app": module_label}
-    )
-
-
 @pytest.fixture(scope="module", autouse=True)
 def commit(request, tls_policy, authorization, envoy_filter):  # pylint: disable=unused-argument
-    """Commits AuthPolicy and TLSPolicy"""
+    """Commits TLSPolicy and AuthPolicy after EnvoyFilter is set up"""
     for component in [tls_policy, authorization]:
         request.addfinalizer(component.delete)
         component.commit()
         component.wait_for_ready()
-
-
-@pytest.fixture(scope="module")
-def server_ca(gateway, hostname):
-    """Server-side TLS certificate from the gateway for verifying the TLS connection"""
-    return gateway.get_tls_cert(hostname.hostname)
 
 
 def test_valid_cert(hostname, server_ca, valid_cert):

--- a/testsuite/tests/singlecluster/authorino/identity/x509/gateway_validation/test_gateway_tls_frontend_validation.py
+++ b/testsuite/tests/singlecluster/authorino/identity/x509/gateway_validation/test_gateway_tls_frontend_validation.py
@@ -1,0 +1,39 @@
+"""Tests for x509 client certificate authentication using Gateway API v1.5+ frontend TLS validation.
+Tier 1 from RFC 0015 - https://github.com/Kuadrant/architecture/blob/main/rfcs/0015-x509-client-cert-authpolicy.md
+
+Client certificate validation is configured at the gateway level using the standard Gateway API
+spec.tls.frontend.default.validation configuration. The gateway validates client certificates
+at L4 (TLS layer) and populates the XFCC header for Authorino to extract and validate
+the certificate via x509 identity in AuthPolicy.
+"""
+
+import pytest
+
+pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only, pytest.mark.gateway_api_version((1, 5, 0))]
+
+
+def test_valid_cert(hostname, server_ca, valid_cert):
+    """Test that a request with a valid client certificate succeeds"""
+    with hostname.client(verify=server_ca, cert=valid_cert) as client:
+        response = client.get("/get")
+        assert response.status_code == 200
+
+
+def test_no_cert(hostname, server_ca):
+    """
+    Test that a request without a client certificate is rejected at the gateway level (L4),
+    where certificate validation is happening due to the Gateway API frontend TLS validation configuration
+    """
+    with hostname.client(verify=server_ca) as client:
+        response = client.get("/get")
+        assert response.has_cert_required_error()
+
+
+def test_invalid_cert(hostname, server_ca, invalid_cert):
+    """
+    Test that a request with a certificate signed by an untrusted CA is rejected at the gateway level (L4),
+    where certificate validation is happening due to the Gateway API frontend TLS validation configuration
+    """
+    with hostname.client(verify=server_ca, cert=invalid_cert) as client:
+        response = client.get("/get")
+        assert response.has_unknown_ca_error()

--- a/testsuite/tests/singlecluster/authorino/identity/x509/gateway_validation/test_multi_ca_trust.py
+++ b/testsuite/tests/singlecluster/authorino/identity/x509/gateway_validation/test_multi_ca_trust.py
@@ -1,0 +1,116 @@
+"""Tests for x509 multi-CA trust via label selectors.
+
+Verifies that AuthPolicy can trust multiple intermediate CAs independently via label selectors.
+The gateway trusts a root CA at L4 (all certs pass TLS), while Authorino selects
+trusted CA secrets by label, providing fine-grained L7 trust control.
+"""
+
+import time
+
+import pytest
+
+from testsuite.certificates import CertInfo
+from testsuite.utils import cert_builder
+from testsuite.kubernetes import Selector
+from testsuite.kuadrant.policy.authorization import X509Source
+from ..conftest import XFCC_HEADER_NAME
+
+pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only, pytest.mark.gateway_api_version((1, 5, 0))]
+
+
+@pytest.fixture(scope="module")
+def certificates(cfssl, wildcard_domain, cert_attributes):
+    """Certificate hierarchy: root CA with three intermediate CAs, each signing a client certificate"""
+    chain = {
+        "root_ca": CertInfo(
+            children={
+                "ca_team_a": CertInfo(children={"cert_team_a": CertInfo(names=[cert_attributes])}),
+                "ca_team_b": CertInfo(children={"cert_team_b": CertInfo(names=[cert_attributes])}),
+                "ca_untrusted": CertInfo(children={"cert_untrusted": CertInfo(names=[cert_attributes])}),
+            }
+        ),
+    }
+    return cert_builder(cfssl, chain, wildcard_domain)
+
+
+@pytest.fixture(scope="module")
+def client_ca(certificates):
+    """Root CA for gateway-level TLS validation, trusting all intermediate CAs"""
+    return certificates["root_ca"]
+
+
+@pytest.fixture(scope="module")
+def cert_team_a(certificates):
+    """Client certificate signed by trusted intermediate CA team A"""
+    return certificates["cert_team_a"]
+
+
+@pytest.fixture(scope="module")
+def cert_team_b(certificates):
+    """Client certificate signed by trusted intermediate CA team B"""
+    return certificates["cert_team_b"]
+
+
+@pytest.fixture(scope="module")
+def cert_untrusted(certificates):
+    """Client certificate signed by untrusted intermediate CA"""
+    return certificates["cert_untrusted"]
+
+
+@pytest.fixture(scope="module")
+def certificate_selector_labels(blame):
+    """Labels for Selector to match trusted CA secrets"""
+    return {"cert-selector": blame("multi-ca")}
+
+
+@pytest.fixture(scope="module")
+def ca_secret_team_a(create_secret, certificates, certificate_selector_labels):
+    """Intermediate CA team A secret in system namespace with matching labels"""
+    return create_secret(
+        "ca-team-a", {"ca.crt": certificates["ca_team_a"].certificate}, labels=certificate_selector_labels
+    )
+
+
+@pytest.fixture(scope="module")
+def ca_secret_team_b(create_secret, certificates, certificate_selector_labels):
+    """Intermediate CA team B secret in system namespace with matching labels"""
+    return create_secret(
+        "ca-team-b", {"ca.crt": certificates["ca_team_b"].certificate}, labels=certificate_selector_labels
+    )
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization, certificate_selector_labels):
+    """AuthPolicy with x509 identity selecting multiple CA secrets by label"""
+    authorization.identity.clear_all()
+    authorization.identity.add_mtls(
+        "x509",
+        Selector(matchLabels=certificate_selector_labels),
+        source=X509Source(xfccHeader=XFCC_HEADER_NAME),
+    )
+    return authorization
+
+
+@pytest.fixture(scope="module", autouse=True)
+def commit(request, tls_policy, authorization, ca_secret_team_a, ca_secret_team_b):  # pylint: disable=unused-argument
+    """Commits TLSPolicy and AuthPolicy with delay for WasmPlugin sync"""
+    for component in [tls_policy, authorization]:
+        request.addfinalizer(component.delete)
+        component.commit()
+        component.wait_for_ready()
+    time.sleep(15)  # Kind workaround before https://github.com/envoyproxy/envoy/pull/43928 is released in istio 1.30
+
+
+def test_multi_ca_trust(hostname, server_ca, cert_team_a, cert_team_b, cert_untrusted):
+    """Test that certificates from labeled CAs succeed and unlabeled CA is rejected at L7"""
+    with hostname.client(verify=server_ca, cert=cert_team_a) as client:
+        response = client.get("/get")
+        assert response.status_code == 200
+
+    with hostname.client(verify=server_ca, cert=cert_team_b) as client:
+        response = client.get("/get")
+        assert response.status_code == 200
+
+    with hostname.client(verify=server_ca, cert=cert_untrusted) as client:
+        response = client.get("/get")
+        assert response.status_code == 401

--- a/testsuite/tests/singlecluster/authorino/identity/x509/test_cel_expression.py
+++ b/testsuite/tests/singlecluster/authorino/identity/x509/test_cel_expression.py
@@ -1,0 +1,47 @@
+"""Tests for x509 client certificate authentication using CEL expression source.
+
+L7-only validation where the gateway does NOT validate client certificates at the TLS level.
+The client sends the URL-encoded PEM certificate in a custom header, and Authorino extracts it
+using a CEL expression pointing to that header via x509 identity with expression source.
+"""
+
+import pytest
+
+from testsuite.kubernetes import Selector
+from testsuite.kuadrant.policy.authorization import X509Source
+
+pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only]
+
+CERT_HEADER_NAME = "pem-encoded-client-cert"
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization, certificate_selector_labels, client_ca_secret):  # pylint: disable=unused-argument
+    """AuthPolicy with x509 identity configured to extract certificate via CEL expression"""
+    authorization.identity.clear_all()
+    authorization.identity.add_mtls(
+        "x509",
+        Selector(matchLabels=certificate_selector_labels),
+        source=X509Source(expression=f'request.headers["{CERT_HEADER_NAME}"]'),
+    )
+    return authorization
+
+
+def test_valid_cert(client, valid_cert):
+    """Test that a request with a valid URL-encoded PEM certificate in header specified by CEL succeeds"""
+    response = client.get("/get", headers={CERT_HEADER_NAME: valid_cert.url_encoded_pem})
+    assert response.status_code == 200
+
+
+def test_no_header(client):
+    """Test that a request without the certificate header specified by CEL is rejected by Authorino (L7)"""
+    response = client.get("/get")
+    assert not response.has_cert_required_error()
+    assert response.status_code == 401
+
+
+def test_invalid_cert(client, invalid_cert):
+    """Test that an invalid certificate in header specified by CEL is rejected by Authorino (L7)"""
+    response = client.get("/get", headers={CERT_HEADER_NAME: invalid_cert.url_encoded_pem})
+    assert not response.has_unknown_ca_error()
+    assert response.status_code == 401

--- a/testsuite/tests/singlecluster/authorino/identity/x509/test_client_cert_header.py
+++ b/testsuite/tests/singlecluster/authorino/identity/x509/test_client_cert_header.py
@@ -1,0 +1,48 @@
+"""Tests for x509 client certificate authentication using RFC 9440 Client-Cert header.
+https://github.com/Kuadrant/testsuite/issues/900
+
+L7-only validation where the gateway does NOT validate client certificates at the TLS level.
+Instead, the client sends the certificate in the Client-Cert header (base64-encoded DER format),
+and Authorino extracts and validates it using x509 identity with clientCertHeader source.
+"""
+
+import pytest
+
+from testsuite.kubernetes import Selector
+from testsuite.kuadrant.policy.authorization import X509Source
+
+pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only]
+
+CLIENT_CERT_HEADER_NAME = "Client-Cert"
+
+
+@pytest.fixture(scope="module")
+def authorization(authorization, certificate_selector_labels, client_ca_secret):  # pylint: disable=unused-argument
+    """AuthPolicy with x509 identity configured to read from Client-Cert header"""
+    authorization.identity.clear_all()
+    authorization.identity.add_mtls(
+        "x509",
+        Selector(matchLabels=certificate_selector_labels),
+        source=X509Source(clientCertHeader=CLIENT_CERT_HEADER_NAME),
+    )
+    return authorization
+
+
+def test_valid_cert(client, valid_cert):
+    """Test that a request with a valid client certificate in Client-Cert header succeeds"""
+    response = client.get("/get", headers={CLIENT_CERT_HEADER_NAME: valid_cert.client_cert_header})
+    assert response.status_code == 200
+
+
+def test_no_header(client):
+    """Test that a request without Client-Cert header is rejected by Authorino (L7)"""
+    response = client.get("/get")
+    assert not response.has_cert_required_error()
+    assert response.status_code == 401
+
+
+def test_invalid_cert(client, invalid_cert):
+    """Test that an invalid certificate in Client-Cert header is rejected by Authorino (L7)"""
+    response = client.get("/get", headers={CLIENT_CERT_HEADER_NAME: invalid_cert.client_cert_header})
+    assert not response.has_unknown_ca_error()
+    assert response.status_code == 401


### PR DESCRIPTION
> [!IMPORTANT]                                                                                                                                                                         
  > This PR modifies shared/core testsuite code that could potentially affect multiple test areas. 2 reviewers should review this PR to ensure adequate coverage.
                                                                                                                                                                                         
  ## Description                                                                                                                                                                         
  - Add x509 client certificate tests covering Gateway API v1.5+ frontend TLS validation (Tier 1), RFC 9440 `Client-Cert` header, CEL expression source, and multi-CA trust via label selectors                 
  - Reorganize existing x509 tests into `gateway_validation/` subdirectory and extract shared fixtures into a new conftest                                                               
  - Add `gateway_api_version` pytest marker with collection-time skip to prevent fixture setup failures on clusters with older Gateway API CRDs                                          
  - Fix `LoadBalancerServiceExposer` to support TLS passthrough by lazily resolving server certificates                                                                                  
                                                                                                                                                                                         
  ## Changes                                                                                                                                                                             
                                                                                                                                                                                         
  ### Test topology                                                                                                                                                                      
```
  x509/                                                                                                                                                                                  
  ├── conftest.py                                      # fixtures: shared cert chain, CA secrets, authorization
  ├── test_cel_expression.py                           # L7-only CEL expression source validation
  ├── test_client_cert_header.py                       # L7-only RFC 9440 Client-Cert header validation                                                                                  
  ├── test_xfcc_forwarding.py                          # L7-only XFCC header passthrough (Tier 3)                                                                                        
  └── gateway_validation/                                                                                                                                                                
      ├── conftest.py                                  # fixtures: TLS passthrough exposer, gateway with frontend TLS, TLSPolicy                                                                   
      ├── test_envoy_filter.py                         # Tier 2 EnvoyFilter L4 validation                                                                                                
      ├── test_gateway_tls_frontend_validation.py      # Tier 1 Gateway API L4 validation                                                                                                
      └── test_multi_ca_trust.py                       # Multi-CA trust via label selectors                                                                                              
```
  ### New/changed tests                                                                                                                                                                  
                                                                                                                                                                                         
  - `test_gateway_tls_frontend_validation.py` — Tier 1 x509 tests using Gateway API `spec.tls.frontend` for L4 client certificate validation: valid cert (200), no cert (TLS error), invalid cert (TLS error) (Closes #893)                                                                                                                                                 
  - `test_multi_ca_trust.py` — Multi-CA trust via label selectors with three intermediate CAs: two labeled (trusted), one unlabeled (untrusted). Gateway trusts root CA at L4, Authorino selects CAs by label at L7 (Closes #897, Closes #899)                                                                                                                                         
  - `test_client_cert_header.py` — L7-only validation using RFC 9440 `Client-Cert` header (no gateway-level TLS validation): valid cert (200), no header (401), invalid cert (401) (Closes #900)                                                                                                                                                                          
  - `test_cel_expression.py` — L7-only validation using CEL expression (`source.expression`) to extract URL-encoded PEM client certificate from a custom request header: valid cert (200), no header (401), invalid cert (401) (Closes #937)
  - `test_envoy_filter.py` — Moved from `x509/` to `x509/gateway_validation/`, fixtures extracted to shared conftest
                                                                                                                                                                                         
  ### Infrastructure changes                                                                                                                                                             
                                                                                                                                                                                         
  - `KuadrantGateway.set_frontend_tls_validation()` — new method for Gateway API v1.5+ `spec.tls.frontend` configuration                                                                 
  - `Certificate.client_cert_header` — RFC 9440 Client-Cert header value (base64-encoded DER)
  - `Certificate.url_encoded_pem` — URL-encoded PEM certificate for CEL expression-based header validation
  - `IdentitySection.add_mtls()` — filter `None` values from `X509Source` to support partial source configs (e.g., `clientCertHeader` without `xfccHeader`)                              
  - `X509Source.expression` — type changed from `CelExpression` to `str` to support raw CEL expression strings
  - `LoadBalancerServiceExposer` — lazily resolve TLS cert via `verify_getter` lambda to support TLS passthrough with TLSPolicy-provisioned certs                                        
  - `pytest.mark.gateway_api_version` — new marker with collection-time skip via `pytest_collection_modifyitems` (prevents module fixture setup on unsupported CRDs)                     
                                                                                                                                                                                         
  ### Known limitations                                                                                                                                                                  
                                                                                                                                                                                         
  `test_multi_ca_trust.py` includes a `time.sleep(15)` workaround in the commit fixture. On kind clusters, the Envoy proxy crashes with a V8 segfault ([wasm-shim#314](https://github.com/Kuadrant/wasm-shim/issues/314)) during WasmPlugin load due to a [JSDispatchTable race condition](https://github.com/nicolo-ribaudo/tc39-proposal-structs/issues/18) in V8 ≤13.8. The fix ([envoyproxy/envoy#43928](https://github.com/envoyproxy/envoy/pull/43928)) ships with Envoy 1.38 / Istio 1.30. Until then, the sleep gives the proxy time to recover after the crash-restart cycle.

  ## Verification steps

  ```bash
  # 1. Run on OpenShift (gateway_api_version tests will be automatically skipped)
  make testsuite/tests/singlecluster/authorino/identity/x509/                                                                                                                            
   
  # 2. Run Gateway API v1.5+ tests on kind                                                                                                                                               
  SAIL_OPERATOR_VERSION=v1.28-latest ISTIO_VERSION=v1.28-latest GATEWAY_API_VERSION=v1.5.0 make local-setup
  KUBECONFIG=~/.kube/config make testsuite/tests/singlecluster/authorino/identity/x509/gateway_validation/test_gateway_tls_frontend_validation.py testsuite/tests/singlecluster/authorino/identity/x509/gateway_validation/test_multi_ca_trust.py
  ```


## Summary by CodeRabbit

* **New Features**
  * Gateway API v1.5+ frontend TLS client-certificate validation at the gateway (L4).
  * RFC 9440 Client-Cert header and URL-encoded-PEM support for x509 client certificate auth.

* **Tests**
  * New and expanded tests covering gateway TLS frontend validation, Client-Cert header, CEL-extracted headers, and multi-CA trust scenarios.

* **Chores**
  * Test collection skipping based on detected Gateway API version via a new pytest marker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Gateway API v1.5+ frontend TLS certificate validation.
  * Added x509 client certificate authentication via RFC 9440-style headers and CEL expressions.
  * Introduced multi-CA trust validation using label selectors.
  * Added Gateway API version detection and test-gating capability.

* **Tests**
  * New comprehensive test suite for gateway-level and application-level x509 certificate validation scenarios.

* **Refactor**
  * Optimised certificate exposure and secret creation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->