### PR TITLE
test: Add tests for named HTTPRouteRule sectionName targeting

### DIFF
--- a/testsuite/gateway/gateway_api/route.py
+++ b/testsuite/gateway/gateway_api/route.py
@@ -90,7 +90,9 @@ class HTTPRoute(KubernetesObject, GatewayRoute):
         self.model.spec.hostnames = []
 
     @modify
-    def add_rule(self, backend: "Backend", *route_matches: RouteMatch, filters: list[URLRewriteFilter] = None):
+    def add_rule(
+        self, backend: "Backend", *route_matches: RouteMatch, filters: list[URLRewriteFilter] = None, name: str = None
+    ):
         """Adds rule to the Route"""
         rules: dict[str, typing.Any] = {"backendRefs": [backend.reference]}
         matches = list(route_matches)
@@ -100,6 +102,8 @@ class HTTPRoute(KubernetesObject, GatewayRoute):
         rules["matches"] = [asdict(match) for match in matches]
         if filters:
             rules["filters"] = [asdict(f) for f in filters]
+        if name:
+            rules["name"] = name
         self.model.spec.rules.append(rules)
 
     @modify
@@ -108,10 +112,11 @@ class HTTPRoute(KubernetesObject, GatewayRoute):
         self.model.spec.rules = []
 
     @modify
-    def add_backend(self, backend: "Backend", prefix="/"):
-        self.model.spec.rules.append(
-            {"backendRefs": [backend.reference], "matches": [{"path": {"value": prefix, "type": "PathPrefix"}}]}
-        )
+    def add_backend(self, backend: "Backend", prefix="/", name: str = None):
+        rule = {"backendRefs": [backend.reference], "matches": [{"path": {"value": prefix, "type": "PathPrefix"}}]}
+        if name:
+            rule["name"] = name
+        self.model.spec.rules.append(rule)
 
     @modify
     def remove_all_backend(self):

--- a/testsuite/gateway/gateway_api/route.py
+++ b/testsuite/gateway/gateway_api/route.py
@@ -113,7 +113,7 @@ class HTTPRoute(KubernetesObject, GatewayRoute):
 
     @modify
     def add_backend(self, backend: "Backend", prefix="/", name: str = None):
-        rule = {"backendRefs": [backend.reference], "matches": [{"path": {"value": prefix, "type": "PathPrefix"}}]}
+        rule: dict[str, typing.Any] = {"backendRefs": [backend.reference], "matches": [{"path": {"value": prefix, "type": "PathPrefix"}}]}
         if name:
             rule["name"] = name
         self.model.spec.rules.append(rule)

--- a/testsuite/gateway/gateway_api/route.py
+++ b/testsuite/gateway/gateway_api/route.py
@@ -113,7 +113,10 @@ class HTTPRoute(KubernetesObject, GatewayRoute):
 
     @modify
     def add_backend(self, backend: "Backend", prefix="/", name: str = None):
-        rule: dict[str, typing.Any] = {"backendRefs": [backend.reference], "matches": [{"path": {"value": prefix, "type": "PathPrefix"}}]}
+        rule: dict[str, typing.Any] = {
+            "backendRefs": [backend.reference],
+            "matches": [{"path": {"value": prefix, "type": "PathPrefix"}}],
+        }
         if name:
             rule["name"] = name
         self.model.spec.rules.append(rule)

--- a/testsuite/tests/singlecluster/gateway/authpolicy/test_authpolicy_named_http_route_rule.py
+++ b/testsuite/tests/singlecluster/gateway/authpolicy/test_authpolicy_named_http_route_rule.py
@@ -1,0 +1,57 @@
+"""
+Tests that an AuthPolicy is correctly applied to a specific named rule section of
+an HTTPRoute, protecting only the traffic handled by that named rule.
+"""
+
+import pytest
+from testsuite.kuadrant.policy.authorization.auth_policy import AuthPolicy
+
+pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only]
+
+
+@pytest.fixture(scope="module")
+def route(route, backend):
+    """
+    Overrides the default route to have two paths: one for a protected
+    service (/get) and one for a public one (/anything).
+    Rules are explicitly named.
+    """
+    route.remove_all_rules()
+    route.add_backend(backend, "/get", name="get-rule")  # This becomes the target "get-rule"
+    route.add_backend(backend, "/anything", name="anything-rule")  # This is the public rule
+    return route
+
+
+@pytest.fixture(scope="module")
+def authorization(cluster, blame, module_label, oidc_provider, route):
+    """
+    Creates an AuthPolicy that targets a specific named rule ('get-rule') within the
+    HTTPRoute.
+    """
+    policy = AuthPolicy.create_instance(
+        cluster,
+        blame("authz"),
+        route,  # Target is the HTTPRoute
+        section_name="get-rule",  # Target the specific named rule
+        labels={"testRun": module_label},
+    )
+    policy.identity.add_oidc("basic", oidc_provider.well_known["issuer"])
+    return policy
+
+
+def test_authpolicy_section_name_targeting_named_http_route_rule(client, auth):
+    """
+    Tests that an AuthPolicy attached to a specific explicitly named HTTPRoute rule protects
+    only the requests handled by that rule.
+    """
+    # The '/anything' path is handled by a different, untargeted rule and should be public.
+    response = client.get("/anything")
+    assert response.status_code == 200
+
+    # The '/get' path is handled by the targeted 'get-rule' and should require authentication.
+    response = client.get("/get")
+    assert response.status_code == 401
+
+    # The '/get' path with a valid token should be allowed.
+    response = client.get("/get", auth=auth)
+    assert response.status_code == 200

--- a/testsuite/tests/singlecluster/limitador/section/test_named_route_rule.py
+++ b/testsuite/tests/singlecluster/limitador/section/test_named_route_rule.py
@@ -6,6 +6,8 @@ from testsuite.kuadrant.policy.rate_limit import Limit, RateLimitPolicy
 
 pytestmark = [pytest.mark.limitador]
 
+LIMIT = Limit(2, "10s")
+
 
 @pytest.fixture(scope="module")
 def route(route, backend):
@@ -20,13 +22,13 @@ def route(route, backend):
 def rate_limit(cluster, blame, module_label, route):
     """Add a RateLimitPolicy targeting the get-rule HTTPRoute Rule."""
     rlp = RateLimitPolicy.create_instance(cluster, blame("limit"), route, "get-rule", labels={"testRun": module_label})
-    rlp.add_limit("basic", [Limit(2, "10s")])
+    rlp.add_limit("basic", [LIMIT])
     return rlp
 
 
 def test_limit_match_named_route_rule(client):
     """Tests that RLP correctly applies to the specific named HTTPRoute Rule"""
-    responses = client.get_many("/get", 2)
+    responses = client.get_many("/get", LIMIT.limit)
     responses.assert_all(status_code=200)
     assert client.get("/get").status_code == 429
 

--- a/testsuite/tests/singlecluster/limitador/section/test_named_route_rule.py
+++ b/testsuite/tests/singlecluster/limitador/section/test_named_route_rule.py
@@ -1,0 +1,34 @@
+"""Tests that the RLP is correctly applied to the specific named route rule"""
+
+import pytest
+
+from testsuite.kuadrant.policy.rate_limit import Limit, RateLimitPolicy
+
+pytestmark = [pytest.mark.limitador]
+
+
+@pytest.fixture(scope="module")
+def route(route, backend):
+    """Add two named backend rules for different paths to the route"""
+    route.remove_all_rules()
+    route.add_backend(backend, "/get", name="get-rule")
+    route.add_backend(backend, "/anything", name="anything-rule")
+    return route
+
+
+@pytest.fixture(scope="module")
+def rate_limit(cluster, blame, module_label, route):
+    """Add a RateLimitPolicy targeting the get-rule HTTPRoute Rule."""
+    rlp = RateLimitPolicy.create_instance(cluster, blame("limit"), route, "get-rule", labels={"testRun": module_label})
+    rlp.add_limit("basic", [Limit(2, "10s")])
+    return rlp
+
+
+def test_limit_match_named_route_rule(client):
+    """Tests that RLP correctly applies to the specific named HTTPRoute Rule"""
+    responses = client.get_many("/get", 2)
+    responses.assert_all(status_code=200)
+    assert client.get("/get").status_code == 429
+
+    response = client.get("/anything")
+    assert response.status_code == 200


### PR DESCRIPTION
## Description
This PR adds support for explicitly named HTTPRoute rules in the testsuite models and introduces test coverage to verify that Kuadrant policies can correctly target these named rules via the `sectionName` field. This aligns the testsuite with the Gateway API's introduction of explicit naming for HTTPRouteRule entries (kubernetes-sigs/gateway-api#995) and Kuadrant's policy-machinery support for it (Kuadrant/policy-machinery#63).

Issue #942 

## Changes
- Updated ``HTTPRoute.add_backend`()` and ``HTTPRoute.add_rule`()` in ``testsuite/gateway/gateway_api/route.py`` to accept an optional `name` parameter, allowing rules to be explicitly named instead of relying solely on auto-generated names.
- Added ``test_named_route_rule.py`` in the Limitador section tests to verify that a `RateLimitPolicy` correctly applies to a specific named rule (`section_name="get-rule"`).
- Added ``test_authpolicy_named_http_route_rule.py`` in the AuthPolicy section tests to verify that an `AuthPolicy` correctly protects traffic for a specific named rule without affecting untargeted rules.

## Verification
- Added new automated tests (`test_limit_match_named_route_rule` and `test_authpolicy_section_name_targeting_named_http_route_rule`) which create an `HTTPRoute` with explicitly named rules (e.g., `get-rule` and `anything-rule`).
- The tests verify that when a policy targets the `get-rule` section name, the policy is enforced exclusively on that rule's route, while the other route remains unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP route rules can be explicitly named, allowing AuthPolicy and RateLimitPolicy to target specific named rule sections.

* **Tests**
  * Added tests validating AuthPolicy section-name targeting for named route rules.
  * Added tests validating RateLimitPolicy targeting for named route rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/testsuite/pull/943?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->