### PR TITLE
refactor: refactor topology UI tests for PF version compatibility

### DIFF
--- a/testsuite/page_objects/topology/topology_page.py
+++ b/testsuite/page_objects/topology/topology_page.py
@@ -26,8 +26,11 @@ class TopologyPage(Navigable):
         return True
 
     def get_resource_dropdown(self):
-        """Get the Resource filter dropdown button"""
-        return self.page.locator("//button[contains(@class, 'pf-v6-c-menu-toggle') and contains(., 'Resource')]").first
+        """Get the Resource filter dropdown button (PF5 and PF6 compatible)"""
+        return self.page.locator(
+            "//button[(contains(@class, 'pf-v6-c-menu-toggle') or contains(@class, 'pf-v5-c-menu-toggle')) "
+            "and contains(., 'Resource')]"
+        ).first
 
     def get_namespace_dropdown(self):
         """Get the Namespace filter dropdown button"""

--- a/testsuite/tests/singlecluster/ui/console_plugin/topology/test_topology.py
+++ b/testsuite/tests/singlecluster/ui/console_plugin/topology/test_topology.py
@@ -42,8 +42,13 @@ def test_topology_resources_appear(navigator, gateway, route, authorization, rat
     assert topology_page.has_connections(), "No connections found in topology"
 
 
+@pytest.mark.min_ocp_version((4, 20))
 def test_topology_filters_work(navigator, gateway, route, cluster):
-    """Verify namespace and resource filters control which resources are shown"""
+    """Verify namespace and resource filters control which resources are shown (OCP 4.20+ / PF6)
+
+    Skipped on OCP < 4.20 due to unreliable PF5 filter behavior
+    For more info, see: https://github.com/Kuadrant/kuadrant-console-plugin/issues/373
+    """
     # Navigate to topology page
     topology_page = navigator.navigate(TopologyPage)
     assert topology_page.page_displayed(), "Topology page did not load"


### PR DESCRIPTION
## Description
- Updated topology UI test `test_topology_page_loads` to handle PatternFly version differences for the Resource filter dropdown
- Added version constraint to skip filter test `test_topology_filters_work` on OCP < 4.20 due to PatternFly 5 console plugin version limitations, see https://github.com/Kuadrant/kuadrant-console-plugin/issues/373 for more info

## Changes

- Made `get_resource_dropdown()` locator compatible with both PatternFly 5 and PatternFly 6 by checking for both `pf-v5-c-menu-toggle` and `pf-v6-c-menu-toggle` classes
- Added `@pytest.mark.min_ocp_version((4, 20))` to `test_topology_filters_work` to skip on OCP < 4.20 where PatternFly 5 filter behavior is currently unreliable

## Verification steps
Run the topology tests:
```bash
pytest -n2 testsuite/tests/singlecluster/ui/console_plugin/topology/test_topology.py
```
**Observe:** On OCP 4.20+, `test_topology_filters_work` will run as expected. On OCP 4.19 and below, it should skip with the minimum version requirement message. `test_topology_page_loads` should now pass on all versions. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved topology feature test reliability across different platform versions.
  * Enhanced test compatibility for various UI framework configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->