### PR TITLE
feat(testsuite): introduce pytest-rerunfailures plugin

### DIFF
--- a/.claude/rules/test-reruns.md
+++ b/.claude/rules/test-reruns.md
@@ -1,0 +1,34 @@
+# Test Reruns (`@pytest.mark.flaky`)
+
+The testsuite uses `pytest-rerunfailures` to automatically retry failed tests (default: `--reruns 3` in the Makefile). The `@pytest.mark.flaky` marker controls rerun behavior per test.
+
+**Disable reruns** for tests that cannot recover from a failure, because they delete or modify module-scoped fixtures during the test. Since `pytest-rerunfailures` only reruns the test function (not module-scoped fixtures), the deleted/modified resource will not be recreated:
+
+```python
+@pytest.mark.flaky(reruns=0)
+def test_policy_deletion(policy):
+    """This test deletes a module-scoped fixture, so rerunning would fail"""
+    policy.delete()
+    assert not policy.exists()
+```
+
+**Add a delay** for rate limit tests that exhaust a counter and assert `429`. On rerun, the counter from the previous attempt may still be active. Set `reruns_delay` to the rate limit window + 5 seconds:
+
+```python
+@pytest.mark.flaky(reruns=3, reruns_delay=15)  # Limit window is 10s, wait 15s
+def test_rate_limit(client):
+    responses = client.get_many("/get", 5)
+    responses.assert_all(status_code=200)
+    assert client.get("/get").status_code == 429
+```
+
+**When to use which:**
+
+| Situation | Marker |
+|-----------|--------|
+| Test deletes or modifies a module-scoped fixture | `@pytest.mark.flaky(reruns=0)` |
+| Test creates and deletes resources within the test body (e.g., UI tests) | `@pytest.mark.flaky(reruns=0)` |
+| Rate limit test with 5s window | `@pytest.mark.flaky(reruns=3, reruns_delay=10)` |
+| Rate limit test with 10s window | `@pytest.mark.flaky(reruns=3, reruns_delay=15)` |
+| Rate limit test with 60s window | `@pytest.mark.flaky(reruns=3, reruns_delay=65)` |
+| Normal test (no side effects) | No marker needed (uses global `--reruns 3`) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,10 @@ Tests use markers to categorize functionality. All available markers are defined
 - `@pytest.mark.issue("https://github.com/...")` - Linked to GitHub/Jira issues
 - `@pytest.mark.min_ocp_version((4, 20))` - Minimum OpenShift version requirement
 
+### Test Reruns (`@pytest.mark.flaky`)
+
+See `.claude/rules/test-reruns.md` for detailed guidance on using `@pytest.mark.flaky` to control rerun behavior per test.
+
 ## Coding Conventions
 
 ### Docstrings

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ else
 resultsdir ?= .
 endif
 
-PYTEST = poetry run python -m pytest --tb=$(TB) -o cache_dir=$(resultsdir)/.pytest_cache.$(@F)
+PYTEST = poetry run python -m pytest --tb=$(TB) --reruns 3 -o cache_dir=$(resultsdir)/.pytest_cache.$(@F)
 RUNSCRIPT = poetry run ./scripts/
 
 ifdef junit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ apyproxy = "*"
 weakget = "*"
 pytest-playwright = "*"
 playwright = "1.57.0"
+pytest-rerunfailures = "*"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "*"

--- a/testsuite/component_metadata.py
+++ b/testsuite/component_metadata.py
@@ -62,7 +62,7 @@ class ReportPortalMetadataCollector:
                     return metadata
                 for container in deployment.model.spec.template.spec.containers:
                     if container.name == container_name:
-                        metadata["kuadrant_image"] = container.image
+                        metadata["kuadrant_image"] = container.image.split("@", 1)[0]
                         break
         except (oc.OpenShiftPythonException, AttributeError, KeyError, IndexError, ValueError) as e:
             logger.warning("Failed to get kuadrant-operator image: %s", e)

--- a/testsuite/kubernetes/__init__.py
+++ b/testsuite/kubernetes/__init__.py
@@ -29,8 +29,15 @@ class KubernetesObject(APIObject, LifecycleObject):
         """
         Creates object on the server and returns created entity.
         It will be the same class but attributes might differ, due to server adding/rejecting some of them.
+        If the object already exists (e.g. during a pytest rerun), it falls back to apply.
         """
-        self.create(["--save-config=true"])
+        try:
+            self.create(["--save-config=true"])
+        except OpenShiftPythonException as e:
+            if "AlreadyExists" in str(e):
+                self.apply()
+            else:
+                raise
         self._committed = True
         return self.refresh()
 

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -64,9 +64,60 @@ def pytest_runtest_setup(item):
             skip_or_fail(f"Unable to locate Kuadrant installation: {error}")
 
 
+def _format_failure_message(call, report):
+    """Extract failure message from call/report, keeping only testsuite frames."""
+    if not call.excinfo:
+        return str(report.longrepr or "")
+    tb_lines = []
+    for entry in call.excinfo.traceback:
+        if "site-packages" not in str(entry.path):
+            tb_lines.append(f"{entry.path}:{entry.lineno}: in {entry.name}\n    {entry.statement}")
+
+    exc = call.excinfo.value
+    exc_message = str(exc)
+    # OpenShiftPythonException embeds full K8s objects in its message;
+    # extract just the stderr from each action
+    result = getattr(exc, "result", None)
+    if result is not None and callable(getattr(result, "actions", None)):
+        errs = [a.err.strip() for a in result.actions() if getattr(a, "err", None)]
+        if errs:
+            exc_message = "; ".join(errs)
+
+    tb_lines.append(f"E   {call.excinfo.type.__name__}: {exc_message}")
+    return "\n".join(tb_lines)
+
+
+def _collect_rerun_attempt(item, call, report):
+    """Record failure message and captured output for one rerun attempt."""
+    message = _format_failure_message(call, report)
+    if report.failed and call.excinfo:
+        exc = call.excinfo.value
+        result = getattr(exc, "result", None)
+        if result is not None and callable(getattr(result, "actions", None)):
+            report.longrepr = message
+    item.rerun_messages = getattr(item, "rerun_messages", []) + [message]
+
+    captured_output = "".join(content for _, content in report.sections if content)
+    item.rerun_outputs = getattr(item, "rerun_outputs", []) + [captured_output]
+
+
+def _write_rerun_properties(item, report):
+    """Write collected rerun data into JUnit XML user properties at teardown."""
+    execution_count = getattr(item, "execution_count", 1)
+    if execution_count > 1:
+        rerun_messages = getattr(item, "rerun_messages", [])
+        rerun_outputs = getattr(item, "rerun_outputs", [])
+        report.user_properties.append(("__rp_reruns", str(execution_count - 1)))
+        for i, msg in enumerate(rerun_messages, start=1):
+            report.user_properties.append((f"__rp_rerun_{i}_message", msg))
+        for i, output in enumerate(rerun_outputs, start=1):
+            if output:
+                report.user_properties.append((f"__rp_rerun_{i}_output", output))
+
+
 @pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_makereport(item, call):  # pylint: disable=unused-argument
-    """Add jira link to html report"""
+def pytest_runtest_makereport(item, call):
+    """Add jira link to html report and record rerun count for JUnit XML."""
     pytest_html = item.config.pluginmanager.getplugin("html")
     outcome = yield
     report = outcome.get_result()
@@ -81,6 +132,10 @@ def pytest_runtest_makereport(item, call):  # pylint: disable=unused-argument
                 label = issue
             extra.append(pytest_html.extras.url(issue, name=label))
         report.extra = extra
+    if report.when in ("call", "setup") and (report.failed or report.outcome == "rerun"):
+        _collect_rerun_attempt(item, call, report)
+    if report.when == "teardown":
+        _write_rerun_properties(item, report)
 
 
 def pytest_report_header(config):

--- a/testsuite/tests/kuadrantctl/cli/test_simple_limit.py
+++ b/testsuite/tests/kuadrantctl/cli/test_simple_limit.py
@@ -22,6 +22,7 @@ def oas(oas, blame, gateway, hostname, backend):
 
 @pytest.mark.parametrize("encoder", [pytest.param("as_json", id="JSON"), pytest.param("as_yaml", id="YAML")])
 @pytest.mark.parametrize("stdin", [pytest.param(True, id="STDIN"), pytest.param(False, id="File")])
+@pytest.mark.flaky(reruns=3, reruns_delay=25)
 def test_generate_limit(request, kuadrantctl, oas, encoder, cluster, client, stdin):
     """Tests that RateLimitPolicy can be generated and that it is enforced as expected"""
     encoded = getattr(oas, encoder)()

--- a/testsuite/tests/multicluster/coredns/two_clusters/test_authoritative_record_removal.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/test_authoritative_record_removal.py
@@ -29,6 +29,7 @@ def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
     ]
 
 
+@pytest.mark.flaky(reruns=0)
 def test_authoritative_record_removal_cleans_up_provider(hostname, dnsrecord1, dnsrecord2):
     """Delete DNSRecords from both primary and secondary clusters and check they are really cleaned up"""
     dns_ips = {ip.address for ip in dns.resolver.resolve(hostname.hostname)}

--- a/testsuite/tests/multicluster/coredns/two_clusters/test_update_secondary.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/test_update_secondary.py
@@ -30,6 +30,7 @@ def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
     ]
 
 
+@pytest.mark.flaky(reruns=0)
 def test_update_secondary(hostname, dnsrecord2):
     """Test if update/delete changes on secondary DNSRecord are propagated to the authoritative DNS record"""
     dns_ips = {ip.address for ip in dns.resolver.resolve(hostname.hostname)}

--- a/testsuite/tests/multicluster/global_rate_limiting/test_global_rate_limit.py
+++ b/testsuite/tests/multicluster/global_rate_limiting/test_global_rate_limit.py
@@ -31,6 +31,7 @@ class Xfailexception(Exception):
 
 @pytest.mark.issue("https://github.com/Kuadrant/limitador-operator/issues/197")
 @pytest.mark.xfail(reason="https://github.com/Kuadrant/limitador-operator/issues/197", raises=Xfailexception)
+@pytest.mark.flaky(reruns=3, reruns_delay=35)
 def test_global_limit_is_shared(
     client1,
     client2,

--- a/testsuite/tests/multicluster/load_balanced/test_change_default_geo.py
+++ b/testsuite/tests/multicluster/load_balanced/test_change_default_geo.py
@@ -13,6 +13,7 @@ pytestmark = [pytest.mark.multicluster]
     settings["control_plane"]["provider_secret"].startswith("gcp"),
     reason="Default geo not supported on GCP",
 )
+@pytest.mark.flaky(reruns=0)
 def test_change_default_geo(hostname, gateway, gateway2, dns_policy, dns_policy2, dns_default_geo_server):
     """Test changing dns default geolocation and verify that changes are propagated"""
     resolver = dns.resolver.Resolver(configure=False)

--- a/testsuite/tests/multicluster/load_balanced/test_change_strategy.py
+++ b/testsuite/tests/multicluster/load_balanced/test_change_strategy.py
@@ -10,6 +10,7 @@ from testsuite.kuadrant.policy.dns import has_record_condition
 pytestmark = [pytest.mark.multicluster]
 
 
+@pytest.mark.flaky(reruns=0)
 def test_change_lb_strategy(hostname, gateway, gateway2, dns_policy2, dns_server, dns_server2, wildcard_domain):
     """Verify that removing DNSPolicy load-balancing configuration removes GEO load-balancing endpoint from the pool"""
     resolver = dns.resolver.Resolver(configure=False)

--- a/testsuite/tests/singlecluster/authorino/identity/api_key/test_reconciliation.py
+++ b/testsuite/tests/singlecluster/authorino/identity/api_key/test_reconciliation.py
@@ -35,6 +35,7 @@ def test_create_new_api_key(client, create_api_key, module_label):
     assert response.status_code == 200
 
 
+@pytest.mark.flaky(reruns=0)
 def test_delete_api_key(client, auth, api_key):
     """Test reconciliation when API key Secret is deleted"""
     response = client.get("/get", auth=auth)

--- a/testsuite/tests/singlecluster/authorino/operator/sharding/test_preexisting_auth.py
+++ b/testsuite/tests/singlecluster/authorino/operator/sharding/test_preexisting_auth.py
@@ -6,6 +6,7 @@ pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
 
 
 @pytest.mark.issue("https://github.com/Kuadrant/authorino/pull/349")
+@pytest.mark.flaky(reruns=0)
 def test_preexisting_auth(
     setup_authorino, setup_authorization, setup_gateway, setup_route, exposer, wildcard_domain, blame
 ):  # pylint: disable=too-many-locals

--- a/testsuite/tests/singlecluster/defaults/merge/rate_limit/same_target/test_ab_strategy.py
+++ b/testsuite/tests/singlecluster/defaults/merge/rate_limit/same_target/test_ab_strategy.py
@@ -22,6 +22,7 @@ def commit(request, route, rate_limit, global_rate_limit):  # pylint: disable=un
     [("gateway", "gateway"), ("route", "route")],
     indirect=True,
 )
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_multiple_policies_merge_default_ab(client, rate_limit, global_rate_limit):
     """Test RateLimitPolicy with merge defaults being enforced due to age"""
     assert rate_limit.wait_until(

--- a/testsuite/tests/singlecluster/defaults/merge/rate_limit/same_target/test_ba_startegy.py
+++ b/testsuite/tests/singlecluster/defaults/merge/rate_limit/same_target/test_ba_startegy.py
@@ -22,6 +22,7 @@ def commit(request, route, rate_limit, global_rate_limit):  # pylint: disable=un
     [("gateway", "gateway"), ("route", "route")],
     indirect=True,
 )
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_multiple_policies_merge_default_ba(client, global_rate_limit):
     """Test RateLimitPolicy with merge defaults being ignored due to age"""
     assert global_rate_limit.wait_until(

--- a/testsuite/tests/singlecluster/defaults/merge/rate_limit/test_default_merge.py
+++ b/testsuite/tests/singlecluster/defaults/merge/rate_limit/test_default_merge.py
@@ -23,6 +23,7 @@ def rate_limit(rate_limit):
     return rate_limit
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_gateway_default_merge(client, global_rate_limit, rate_limit):
     """Both policies are enforced and not being overridden"""
     assert global_rate_limit.wait_until(

--- a/testsuite/tests/singlecluster/defaults/merge/rate_limit/test_default_replace.py
+++ b/testsuite/tests/singlecluster/defaults/merge/rate_limit/test_default_replace.py
@@ -16,6 +16,7 @@ def rate_limit(rate_limit):
     return rate_limit
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_gateway_default_replace(client, global_rate_limit):
     """Test Gateway default policy being partially overridden when a policy with the same name is attached on a route"""
     assert global_rate_limit.wait_until(

--- a/testsuite/tests/singlecluster/defaults/test_basic_rate_limit.py
+++ b/testsuite/tests/singlecluster/defaults/test_basic_rate_limit.py
@@ -23,6 +23,7 @@ def rate_limit(rate_limit):
 
 
 @pytest.mark.parametrize("rate_limit", ["route", "gateway"], indirect=True)
+@pytest.mark.flaky(reruns=3, reruns_delay=10)
 def test_basic_rate_limit(rate_limit, route, client):
     """Test that default rate limit is applied successfully and shows affected status in the route"""
     route.refresh()

--- a/testsuite/tests/singlecluster/defaults/test_section_targeting.py
+++ b/testsuite/tests/singlecluster/defaults/test_section_targeting.py
@@ -48,6 +48,7 @@ def rate_limit(cluster, target, route, module_label, blame):  # pylint: disable=
     [pytest.param(("gateway", "api"), id="gateway"), pytest.param(("route", "rule-1"), id="route")],
     indirect=True,
 )
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_basic_listener(client, auth):
     """Test the defaults policies are correctly applied to the target section"""
     assert client.get("/get").status_code == 401

--- a/testsuite/tests/singlecluster/egress/test_egress.py
+++ b/testsuite/tests/singlecluster/egress/test_egress.py
@@ -65,6 +65,7 @@ def test_egress_authorization(client, auth):
     assert response.status_code == 200
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=10)
 def test_egress_ratelimit(client, auth):
     """Test that RateLimitPolicy is enforced on egress gateway traffic"""
     sleep(5 + 1)  # make sure request limit quota is reset before starting the test

--- a/testsuite/tests/singlecluster/extensions/plan_policy/test_plan_policy.py
+++ b/testsuite/tests/singlecluster/extensions/plan_policy/test_plan_policy.py
@@ -82,11 +82,15 @@ def commit(request, plan_policy, authorization):
 @pytest.mark.parametrize(
     "user_with_plan, allowed_requests",
     [
-        (tier, plan.limits["custom"][0]["limit"] if "custom" in plan.limits else list(plan.limits.values())[0])
-        for tier, plan in PLANS.items()
+        pytest.param("gold", 5, id="gold"),
+        pytest.param("silver", 3, id="silver"),
+        pytest.param("bronze", 2, id="bronze", marks=pytest.mark.flaky(reruns=0)),
     ],
     indirect=["user_with_plan"],
 )
+# 25s reruns_delay is enough for gold (10s) and silver (20s) windows to reset.
+# Bronze uses a daily limit, so reruns are disabled via param-level reruns=0.
+@pytest.mark.flaky(reruns=3, reruns_delay=25)
 def test_plan_policy(client, user_with_plan, allowed_requests):
     """
     Test PlanPolicy enforcement across different tiers and rate limits.

--- a/testsuite/tests/singlecluster/gateway/dnspolicy/test_dnspolicy_removal.py
+++ b/testsuite/tests/singlecluster/gateway/dnspolicy/test_dnspolicy_removal.py
@@ -28,6 +28,7 @@ def commit(request, route, dns_policy):  # pylint: disable=unused-argument
     dns_policy.wait_for_ready()
 
 
+@pytest.mark.flaky(reruns=0)
 def test_dnspolicy_removal(gateway, dns_policy, client):
     """
     Test that Gateway will behave properly after attached DNSPolicy is deleted

--- a/testsuite/tests/singlecluster/gateway/mtls/test_mtls_behaviour.py
+++ b/testsuite/tests/singlecluster/gateway/mtls/test_mtls_behaviour.py
@@ -35,6 +35,7 @@ def assert_request_behavior(component, client, authorization, auth, rate_limit):
 
 
 @pytest.mark.parametrize("component", component_cases, indirect=True)
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_requests_succeed_when_mtls_disabled(
     kuadrant, client, component, rate_limit, authorization, auth, configure_mtls
 ):  # pylint: disable=unused-argument
@@ -49,6 +50,7 @@ def test_requests_succeed_when_mtls_disabled(
 
 
 @pytest.mark.parametrize("component", component_cases, indirect=True)
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_requests_succeed_when_mtls_enabled(
     kuadrant, client, component, rate_limit, authorization, auth, reset_mtls, wait_for_status, configure_mtls
 ):  # pylint: disable=unused-argument
@@ -70,6 +72,7 @@ def test_requests_succeed_when_mtls_enabled(
 
 
 @pytest.mark.parametrize("component", component_cases, indirect=True)
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_requests_still_succeed_after_mtls_disabled_again(
     kuadrant, client, component, rate_limit, authorization, auth, wait_for_status, configure_mtls
 ):  # pylint: disable=unused-argument

--- a/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_authpolicy_target_ref.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_authpolicy_target_ref.py
@@ -17,6 +17,7 @@ def authorization(oidc_provider, gateway, cluster, blame, module_label, route): 
     return policy
 
 
+@pytest.mark.flaky(reruns=0)
 def test_update_auth_policy_target_ref(
     route2, gateway, gateway2, authorization, client, client2, auth, dns_policy, dns_policy2, change_target_ref
 ):  # pylint: disable=unused-argument

--- a/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_dnspolicy_target_ref.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_dnspolicy_target_ref.py
@@ -10,6 +10,7 @@ from testsuite.gateway import GatewayListener
 pytestmark = [pytest.mark.dnspolicy]
 
 
+@pytest.mark.flaky(reruns=0)
 def test_update_dns_policy_target_ref(
     gateway, gateway2, client, client2, dns_policy, change_target_ref
 ):  # pylint: disable=unused-argument

--- a/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_ratelimitpolicy_target_ref.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_ratelimitpolicy_target_ref.py
@@ -17,6 +17,7 @@ def rate_limit(cluster, blame, module_label, gateway, route):  # pylint: disable
     return policy
 
 
+@pytest.mark.flaky(reruns=0)
 def test_update_ratelimit_policy_target_ref(
     route2, gateway, gateway2, rate_limit, client, client2, dns_policy, dns_policy2, change_target_ref
 ):  # pylint: disable=unused-argument

--- a/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_tlspolicy_target_ref.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_tlspolicy_target_ref.py
@@ -58,6 +58,7 @@ def custom_client():
     return _client_new
 
 
+@pytest.mark.flaky(reruns=0)
 def test_update_tls_policy_target_ref(
     tls_policy, gateway, gateway2, dns_policy, dns_policy2, change_target_ref, custom_client, hostname, hostname2
 ):  # pylint: disable=unused-argument

--- a/testsuite/tests/singlecluster/gateway/reconciliation/listeners/test_gateway_basic_listeners.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/listeners/test_gateway_basic_listeners.py
@@ -15,6 +15,7 @@ pytestmark = [pytest.mark.dnspolicy, pytest.mark.tlspolicy]
 LISTENER_NAME = "api-second"
 
 
+@pytest.mark.flaky(reruns=0)
 def test_listeners(custom_client, check_ok_https, gateway, route, wildcard_domain, second_domain):
     """
     This test checks reconciliation of dns/tls policy on addition and removal of listeners in gateway and HTTPRoute.

--- a/testsuite/tests/singlecluster/gateway/reconciliation/listeners/test_gateway_listeners_dns.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/listeners/test_gateway_listeners_dns.py
@@ -12,6 +12,7 @@ DEFAULT_LISTENER_NAME = TLSGatewayListener.name
 
 
 @pytest.mark.issue("https://github.com/Kuadrant/kuadrant-operator/issues/794")
+@pytest.mark.flaky(reruns=0)
 def test_change_listener(custom_client, check_ok_https, gateway, route, second_domain, wildcard_domain):
     """
     This test checks if after change of listener hostname in a Gateway while having DNSPolicy applied, that

--- a/testsuite/tests/singlecluster/gateway/reconciliation/test_affected_by.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/test_affected_by.py
@@ -20,6 +20,7 @@ def rate_limit(cluster, blame, module_label, route):
 
 @pytest.mark.authorino
 @pytest.mark.limitador
+@pytest.mark.flaky(reruns=0)
 def test_route_status(route, rate_limit, authorization):
     """Tests affected by status for HTTPRoute"""
     route.refresh()
@@ -35,6 +36,7 @@ def test_route_status(route, rate_limit, authorization):
 
 @pytest.mark.dnspolicy
 @pytest.mark.tlspolicy
+@pytest.mark.flaky(reruns=0)
 def test_gateway_status(gateway, dns_policy, tls_policy):
     """Tests affected by status for Gateway"""
     gateway.refresh()

--- a/testsuite/tests/singlecluster/gateway/scaling/test_auto_scale_gateway.py
+++ b/testsuite/tests/singlecluster/gateway/scaling/test_auto_scale_gateway.py
@@ -52,6 +52,7 @@ def hpa(request, cluster, gateway, blame, backend, module_label):
     return hpa
 
 
+@pytest.mark.flaky(reruns=0)
 def test_auto_scale_gateway(
     gateway, hpa, backend, client, auth, custom_metrics_apiserver, cluster
 ):  # pylint: disable=unused-argument

--- a/testsuite/tests/singlecluster/gateway/scaling/test_manual_scale_gateway.py
+++ b/testsuite/tests/singlecluster/gateway/scaling/test_manual_scale_gateway.py
@@ -10,6 +10,7 @@ from testsuite.tests.singlecluster.gateway.scaling.conftest import LIMIT
 pytestmark = [pytest.mark.limitador, pytest.mark.authorino, pytest.mark.kuadrant_only]
 
 
+@pytest.mark.flaky(reruns=0)
 def test_scale_gateway(gateway, client, auth):
     """This test asserts that the policies are working as expected and this behavior does not change after scaling"""
     anon_auth_resp = client.get("/anything/auth")

--- a/testsuite/tests/singlecluster/identical_hostnames/auth/test_auth_on_gw_and_route.py
+++ b/testsuite/tests/singlecluster/identical_hostnames/auth/test_auth_on_gw_and_route.py
@@ -39,6 +39,7 @@ def commit(request, authorization, authorization2):
     )
 
 
+@pytest.mark.flaky(reruns=0)
 def test_identical_hostnames_auth_on_gw_and_route(client, authorization, authorization2):
     """
     Tests that Gateway-attached AuthPolicy affects on 'route2' even if both 'route' and 'route2' declare identical

--- a/testsuite/tests/singlecluster/identical_hostnames/auth/test_auth_on_routes.py
+++ b/testsuite/tests/singlecluster/identical_hostnames/auth/test_auth_on_routes.py
@@ -30,6 +30,7 @@ def commit(request, authorization, authorization2):
             auth.wait_for_ready()
 
 
+@pytest.mark.flaky(reruns=0)
 def test_identical_hostnames_auth_on_routes(client, authorization):
     """
     Validate that 2nd AuthPolicy is fully enforced on 'route2' declaring identical hostname as 'route' when another

--- a/testsuite/tests/singlecluster/identical_hostnames/rlp/test_rlp_on_gw_and_route.py
+++ b/testsuite/tests/singlecluster/identical_hostnames/rlp/test_rlp_on_gw_and_route.py
@@ -41,6 +41,7 @@ def commit(request, rate_limit, rate_limit2):
     ), f"'2pr10s' RLP did not reach expected record status, instead it was: {rate_limit2.model.status.condition}"
 
 
+@pytest.mark.flaky(reruns=0)
 def test_identical_hostnames_rlp_on_gw_and_route(client, rate_limit, rate_limit2):
     """
     Tests that Gateway-attached RateLimitPolicy is enforced on 'route2' if both 'route' and 'route2' declare

--- a/testsuite/tests/singlecluster/identical_hostnames/rlp/test_rlp_on_routes.py
+++ b/testsuite/tests/singlecluster/identical_hostnames/rlp/test_rlp_on_routes.py
@@ -33,6 +33,7 @@ def commit(request, rate_limit, rate_limit2):
             rlp.wait_for_ready()
 
 
+@pytest.mark.flaky(reruns=0)
 def test_identical_hostnames_rlp_on_routes(client, rate_limit2):
     """
     Validates that 1st RateLimitPolicy is still enforced on 'route' declaring identical hostname as 'route2' if another

--- a/testsuite/tests/singlecluster/limitador/collisions/test_collisions.py
+++ b/testsuite/tests/singlecluster/limitador/collisions/test_collisions.py
@@ -44,6 +44,7 @@ def commit(request, route, rate_limit, rate_limit2):
 
 
 @pytest.mark.parametrize("target", ["gateway", "route"], indirect=True)
+@pytest.mark.flaky(reruns=3, reruns_delay=10)
 def test_collision_rate_limit(client, rate_limit, rate_limit2):
     """Test first policy is being overridden when another policy with the same target is created."""
     assert rate_limit.wait_until(has_condition("Enforced", "False", "Overridden", "RateLimitPolicy is overridden"))

--- a/testsuite/tests/singlecluster/limitador/method/test_route_subset_method.py
+++ b/testsuite/tests/singlecluster/limitador/method/test_route_subset_method.py
@@ -33,6 +33,7 @@ def rate_limit(rate_limit):
 
 
 @pytest.mark.issue("https://github.com/Kuadrant/testsuite/issues/561")
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_route_subset_method(client):
     """Tests that RLP for a HTTPRouteRule doesn't apply to separate HTTPRouteRule with different method"""
     responses = client.get_many("/anything", 5)

--- a/testsuite/tests/singlecluster/limitador/section/test_listener.py
+++ b/testsuite/tests/singlecluster/limitador/section/test_listener.py
@@ -15,6 +15,7 @@ def rate_limit(cluster, blame, module_label, gateway):
     return rlp
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_limit_match_gateway_listener(client):
     """Tests that RLP correctly applies to the specific Gateway Listener"""
     responses = client.get_many("/get", 2)

--- a/testsuite/tests/singlecluster/limitador/section/test_multiple_rules.py
+++ b/testsuite/tests/singlecluster/limitador/section/test_multiple_rules.py
@@ -34,6 +34,7 @@ def commit(request, rate_limit, rate_limit2):
         policy.wait_for_ready()
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=10)
 def test_multiple_limits_targeting_different_route_rules(client):
     """Test targeting separate HTTPRoute Rules with different limits"""
     responses = client.get_many("/get", 3)

--- a/testsuite/tests/singlecluster/limitador/section/test_multiple_same_listener.py
+++ b/testsuite/tests/singlecluster/limitador/section/test_multiple_same_listener.py
@@ -18,6 +18,7 @@ def rate_limit(cluster, blame, module_label, gateway):
     return rate_limit
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_two_limits_targeting_one_gateway_listener(client):
     """Test that one limit ends up shadowing others"""
     responses = client.get_many("/get", 3)

--- a/testsuite/tests/singlecluster/limitador/section/test_multiple_same_rule.py
+++ b/testsuite/tests/singlecluster/limitador/section/test_multiple_same_rule.py
@@ -18,6 +18,7 @@ def rate_limit(cluster, blame, module_label, route):
     return rate_limit
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_two_limits_targeting_one_route_rule(client):
     """Test that one limit ends up shadowing others"""
     responses = client.get_many("/get", 3)

--- a/testsuite/tests/singlecluster/limitador/section/test_route_rule.py
+++ b/testsuite/tests/singlecluster/limitador/section/test_route_rule.py
@@ -15,6 +15,7 @@ def rate_limit(cluster, blame, module_label, route):
     return rlp
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_limit_match_route_rule(client):
     """Tests that RLP correctly applies to the specific HTTPRoute Rule"""
     responses = client.get_many("/get", 2)

--- a/testsuite/tests/singlecluster/limitador/storage/db/test_redis.py
+++ b/testsuite/tests/singlecluster/limitador/storage/db/test_redis.py
@@ -14,6 +14,7 @@ def storage(storage_secret):
     return Redis(storage_secret.name())
 
 
+@pytest.mark.flaky(reruns=0)
 def test_basic(client):
     """Tests that limits work normally in storage environment"""
     responses = client.get_many("/get", LIMIT.limit)
@@ -21,6 +22,7 @@ def test_basic(client):
     assert client.get("/get").status_code == 429
 
 
+@pytest.mark.flaky(reruns=0)
 def test_durability(client, limitador, rate_limit):
     """Basic test checking that after Limitador pod restart, counters are preserved."""
     responses = client.get_many("/get", LIMIT.limit)

--- a/testsuite/tests/singlecluster/limitador/storage/db/test_redis_cached.py
+++ b/testsuite/tests/singlecluster/limitador/storage/db/test_redis_cached.py
@@ -18,6 +18,7 @@ def storage(storage_secret):
     return RedisCached(storage_secret.name(), flush_period=1, batch_size=1, max_cached=1)
 
 
+@pytest.mark.flaky(reruns=0)
 def test_basic(client):
     """Tests that limits work normally in storage environment"""
     responses = client.get_many("/get", LIMIT.limit)
@@ -27,6 +28,7 @@ def test_basic(client):
 
 @pytest.mark.issue("https://github.com/Kuadrant/limitador-operator/issues/197")
 @pytest.mark.xfail(reason="https://github.com/Kuadrant/limitador-operator/issues/197")
+@pytest.mark.flaky(reruns=0)
 def test_durability(client, limitador, rate_limit):
     """Basic test checking that after Limitador pod restart, counters are preserved."""
     responses = client.get_many("/get", LIMIT.limit)

--- a/testsuite/tests/singlecluster/limitador/storage/disk/test_disk.py
+++ b/testsuite/tests/singlecluster/limitador/storage/disk/test_disk.py
@@ -14,6 +14,7 @@ def storage():
     return Disk()
 
 
+@pytest.mark.flaky(reruns=0)
 def test_basic(client):
     """Tests that limits work normally in storage environment"""
     responses = client.get_many("/get", LIMIT.limit)
@@ -21,6 +22,7 @@ def test_basic(client):
     assert client.get("/get").status_code == 429
 
 
+@pytest.mark.flaky(reruns=0)
 def test_durability(client, limitador, rate_limit):
     """
     Basic test checking that after Limitador pod restart, counters are preserved.

--- a/testsuite/tests/singlecluster/limitador/test_basic_limit.py
+++ b/testsuite/tests/singlecluster/limitador/test_basic_limit.py
@@ -30,6 +30,7 @@ def rate_limit(rate_limit, limit):
 
 
 @pytest.mark.parametrize("rate_limit", ["route", "gateway"], indirect=True)
+@pytest.mark.flaky(reruns=3, reruns_delay=20)
 def test_limit(client, limit):
     """Tests that simple limit is applied successfully"""
     responses = client.get_many("/get", limit.limit)

--- a/testsuite/tests/singlecluster/limitador/test_multiple_iterations.py
+++ b/testsuite/tests/singlecluster/limitador/test_multiple_iterations.py
@@ -19,6 +19,7 @@ def rate_limit(rate_limit):
 
 
 @pytest.mark.parametrize("rate_limit", ["route", "gateway"], indirect=True)
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_multiple_iterations(client):
     """Tests that simple limit is applied successfully and works for multiple iterations"""
     for _ in range(10):

--- a/testsuite/tests/singlecluster/limitador/tokens_rate_limit/basic/test_trlp.py
+++ b/testsuite/tests/singlecluster/limitador/tokens_rate_limit/basic/test_trlp.py
@@ -34,6 +34,7 @@ def test_missing_api_key(client):
     assert response.status_code == 401, f"Expected status code 401, but got {response.status_code}"
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=35)
 def test_trlp_limit_and_reset_free_user(client, free_user_auth):
     """Ensures free users are rate limited and limits reset correctly"""
     total_tokens = 0
@@ -71,6 +72,7 @@ def test_trlp_limit_and_reset_free_user(client, free_user_auth):
     assert response.status_code == 200, f"Expected 200 after reset, but got {response.status_code}"
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=65)
 def test_trlp_limit_and_reset_paid_user(client, paid_user_auth):
     """Ensures paid users are rate limited and limits reset correctly"""
     total_tokens = 0

--- a/testsuite/tests/singlecluster/limitador/tokens_rate_limit/basic/test_trlp_streaming.py
+++ b/testsuite/tests/singlecluster/limitador/tokens_rate_limit/basic/test_trlp_streaming.py
@@ -34,6 +34,7 @@ def parse_streaming_usage(response):
     return usage
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=35)
 def test_trlp_streaming_limit_and_reset(client, free_user_auth):
     """Ensures users are rate limited and limits reset correctly with streaming enabled"""
     total_tokens = 0

--- a/testsuite/tests/singlecluster/limitador/tokens_rate_limit/multiple_iterations/test_multiple_trlp_iterations.py
+++ b/testsuite/tests/singlecluster/limitador/tokens_rate_limit/multiple_iterations/test_multiple_trlp_iterations.py
@@ -18,6 +18,7 @@ basic_request = {
 }
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=25)
 def test_multiple_trlp_limit_iterations(client):
     """Ensures TRLP limit resets correctly over multiple iterations"""
     for i in range(10):

--- a/testsuite/tests/singlecluster/limitador/tokens_rate_limit/multiple_iterations/test_multiple_trlp_stream_iterations.py
+++ b/testsuite/tests/singlecluster/limitador/tokens_rate_limit/multiple_iterations/test_multiple_trlp_stream_iterations.py
@@ -45,6 +45,7 @@ def parse_streaming_usage(response):
     return usage
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=25)
 def test_multiple_trlp_streaming_iterations(client):
     """Ensures TRLP limit resets correctly over multiple iterations with streaming enabled"""
     for i in range(5):

--- a/testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics_lifecycle.py
+++ b/testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics_lifecycle.py
@@ -28,6 +28,7 @@ def _get_metric_value(prometheus, metric, policy_kind):
     return metrics.values[0] if metrics.values else 0
 
 
+@pytest.mark.flaky(reruns=0)
 def test_metric_policy_lifecycle(request, prometheus, cluster, blame, route, module_label):
     """Tests that policy metrics increment on create and decrement on delete"""
     initial_counts = {m: _get_metric_value(prometheus, m, "RateLimitPolicy") for m in POLICY_METRICS}

--- a/testsuite/tests/singlecluster/overrides/merge/rate_limit/same_target/test_ab_strategy.py
+++ b/testsuite/tests/singlecluster/overrides/merge/rate_limit/same_target/test_ab_strategy.py
@@ -22,6 +22,7 @@ def commit(request, route, rate_limit, global_rate_limit):  # pylint: disable=un
     [("gateway", "gateway"), ("route", "route")],
     indirect=True,
 )
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_multiple_policies_merge_default_ab(client, rate_limit, global_rate_limit):
     """Test RateLimitPolicy with merge overrides always being enforced"""
     assert rate_limit.wait_until(

--- a/testsuite/tests/singlecluster/overrides/merge/rate_limit/same_target/test_ba_startegy.py
+++ b/testsuite/tests/singlecluster/overrides/merge/rate_limit/same_target/test_ba_startegy.py
@@ -22,6 +22,7 @@ def commit(request, route, rate_limit, global_rate_limit):  # pylint: disable=un
     [("gateway", "gateway"), ("route", "route")],
     indirect=True,
 )
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_multiple_policies_merge_default_ba(client, rate_limit, global_rate_limit):
     """Test RateLimitPolicy with merge overrides always being enforced"""
     assert rate_limit.wait_until(

--- a/testsuite/tests/singlecluster/overrides/merge/rate_limit/test_override_merge.py
+++ b/testsuite/tests/singlecluster/overrides/merge/rate_limit/test_override_merge.py
@@ -17,6 +17,7 @@ def rate_limit(rate_limit):
     return rate_limit
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_gateway_override_merge(client, global_rate_limit, rate_limit):
     """Test RateLimitPolicy with an override and merge strategy overriding only a part of a new policy."""
     assert global_rate_limit.wait_until(

--- a/testsuite/tests/singlecluster/overrides/merge/rate_limit/test_override_replace.py
+++ b/testsuite/tests/singlecluster/overrides/merge/rate_limit/test_override_replace.py
@@ -16,6 +16,7 @@ def rate_limit(rate_limit):
     return rate_limit
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_gateway_override_replace(client, global_rate_limit, rate_limit):
     """Test RateLimitPolicy with an override and merge strategy overrides completely the lower level one"""
     assert rate_limit.wait_until(

--- a/testsuite/tests/singlecluster/overrides/test_basic_rate_limit.py
+++ b/testsuite/tests/singlecluster/overrides/test_basic_rate_limit.py
@@ -37,6 +37,7 @@ def rate_limit(rate_limit):
 
 
 @pytest.mark.parametrize("rate_limit", ["route", "gateway"], indirect=True)
+@pytest.mark.flaky(reruns=3, reruns_delay=10)
 def test_basic_rate_limit(rate_limit, rate_limit_route, route, client):
     """Test if rules inside overrides block of Gateway/HTTPRoute RateLimitPolicy are inherited by the HTTPRoute
     and override the rate limit targeting the route."""

--- a/testsuite/tests/singlecluster/overrides/test_multiple_rate_limit.py
+++ b/testsuite/tests/singlecluster/overrides/test_multiple_rate_limit.py
@@ -44,6 +44,7 @@ def commit(request, route, rate_limit, override_rate_limit):  # pylint: disable=
 
 
 @pytest.mark.parametrize("target", ["gateway", "route"], indirect=True)
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_multiple_policies_gateway_override(client):
     """Test RateLimitPolicy with an override overriding a default policy targeting the same gateway/route"""
     responses = client.get_many("/get", OVERRIDE_LIMIT.limit)

--- a/testsuite/tests/singlecluster/overrides/test_section_targeting.py
+++ b/testsuite/tests/singlecluster/overrides/test_section_targeting.py
@@ -50,6 +50,7 @@ def commit(request, route, rate_limit, override_rate_limit):  # pylint: disable=
     [pytest.param(("gateway", "api"), id="gateway"), pytest.param(("route", "rule-1"), id="route")],
     indirect=True,
 )
+@pytest.mark.flaky(reruns=3, reruns_delay=10)
 def test_multiple_policies_listener_override(client):
     """Test RateLimitPolicy with an override overriding a default policy targeting the same gateway/route section"""
     responses = client.get_many("/get", OVERRIDE_LIMIT.limit)

--- a/testsuite/tests/singlecluster/reconciliation/test_httproute_delete.py
+++ b/testsuite/tests/singlecluster/reconciliation/test_httproute_delete.py
@@ -8,6 +8,7 @@ pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only]
 
 
 @pytest.mark.issue("https://github.com/Kuadrant/kuadrant-operator/issues/124")
+@pytest.mark.flaky(reruns=0)
 def test_delete(client, route, hostname, authorization):
     """
     Tests that after deleting HTTPRoute, status.conditions shows it missing:

--- a/testsuite/tests/singlecluster/test_rate_limit_anonymous.py
+++ b/testsuite/tests/singlecluster/test_rate_limit_anonymous.py
@@ -46,6 +46,7 @@ def test_no_limit_for_auth_user(client, auth):
     responses.assert_all(status_code=200)
 
 
+@pytest.mark.flaky(reruns=3, reruns_delay=15)
 def test_limit_for_anonymous_identity(client, auth):
     """Test that an anonymous requests are correctly limited"""
     assert client.get("/get", auth=auth).status_code == 200

--- a/testsuite/tests/singlecluster/test_rate_limit_authz.py
+++ b/testsuite/tests/singlecluster/test_rate_limit_authz.py
@@ -42,6 +42,7 @@ def auth2(keycloak, blame):
 
 
 @pytest.mark.parametrize("rate_limit", ["route", "gateway"], indirect=True)
+@pytest.mark.flaky(reruns=3, reruns_delay=65)
 def test_authz_limit(client, auth, auth2):
     """Tests that rate limit is applied for two users independently"""
     responses = client.get_many("/get", 5, auth=auth)

--- a/testsuite/tests/singlecluster/tracing/control_plane/test_control_plane_errors.py
+++ b/testsuite/tests/singlecluster/tracing/control_plane/test_control_plane_errors.py
@@ -37,6 +37,7 @@ def orphan_test_policy(request, cluster, blame, orphan_test_route, module_label)
     return orphan_policy
 
 
+@pytest.mark.flaky(reruns=0)
 def test_orphaned_policy_reconciliation_traced(orphan_test_route, orphan_test_policy, tracing):
     """
     Validate traces when policy references deleted resources

--- a/testsuite/tests/singlecluster/tracing/control_plane/test_control_plane_lifecycle.py
+++ b/testsuite/tests/singlecluster/tracing/control_plane/test_control_plane_lifecycle.py
@@ -86,6 +86,7 @@ def temp_deletion_policy(request, cluster, blame, route, module_label):
 
 
 @pytest.mark.parametrize("temp_deletion_policy", ["auth", "rate_limit"], indirect=True)
+@pytest.mark.flaky(reruns=0)
 def test_policy_deletion_triggers_reconciliation_traces(temp_deletion_policy, tracing):
     """
     Validate that policy deletion triggers reconciliation traces.

--- a/testsuite/tests/singlecluster/ui/console_plugin/policies/dnstls/test_tls_policy.py
+++ b/testsuite/tests/singlecluster/ui/console_plugin/policies/dnstls/test_tls_policy.py
@@ -16,6 +16,7 @@ def remove_preexisting_tls(tls_policy):
 
 
 @pytest.mark.parametrize("tls_new_page", [TLSNewPageYaml, TLSNewPageForm])
+@pytest.mark.flaky(reruns=0)
 def test_tls_policy_ui(request, navigator, cluster, blame, gateway, cluster_issuer, tls_new_page, client):
     """Creates a TLSPolicy via the UI (form or YAML), verifies it appears, then deletes it via the UI"""
 

--- a/testsuite/tests/singlecluster/ui/console_plugin/policies/test_rate_limit_policy.py
+++ b/testsuite/tests/singlecluster/ui/console_plugin/policies/test_rate_limit_policy.py
@@ -7,6 +7,7 @@ from testsuite.page_objects.policies.rate_limit_policy import RateLimitNewPageYa
 pytestmark = [pytest.mark.ui]
 
 
+@pytest.mark.flaky(reruns=0)
 def test_rate_limit_policy_ui(request, navigator, cluster, blame, gateway, client):
     """Creates a RateLimitPolicy via the UI, verifies it appears, then deletes it via the UI"""
 

--- a/testsuite/tests/singlecluster/ui/console_plugin/policies/test_token_rate_limit_policy.py
+++ b/testsuite/tests/singlecluster/ui/console_plugin/policies/test_token_rate_limit_policy.py
@@ -10,6 +10,7 @@ pytestmark = [pytest.mark.ui]
 
 
 @pytest.mark.min_ocp_version((4, 20))
+@pytest.mark.flaky(reruns=0)
 def test_token_rate_limit_policy_ui(request, navigator, cluster, blame, gateway):
     """Creates a TokenRateLimitPolicy via the UI, verifies it appears, then deletes it via the UI
 


### PR DESCRIPTION
> [!IMPORTANT]
  > This PR modifies shared/core testsuite code that could potentially affect multiple test areas. 2 reviewers should review this PR to ensure adequate coverage.

  ## Description
  - Introduce `pytest-rerunfailures` plugin to automatically retry failed tests (default `--reruns 3`), reducing flaky test noise in CI
  - Annotate 60+ tests with `@pytest.mark.flaky` to either disable reruns (`reruns=0`) for tests that modify module-scoped fixtures, or add appropriate `reruns_delay` for rate limit tests
  - Record rerun metadata (attempt count, failure messages, captured output) as JUnit XML user properties for Report Portal integration
  - Make `KubernetesObject.commit()` resilient to reruns by falling back to `apply()` when a resource already exists

## Per-test rerun markers

  `pytest-rerunfailures` only reruns the **test function**, not module-scoped fixtures. Some tests need special handling:                                                                                                          
   
  - **`@pytest.mark.flaky(reruns=0)`** — disables reruns for tests that delete or modify module-scoped resources (e.g., delete a policy, change a targetRef, rollout a deployment). The fixture is not recreated between reruns, so
   the test cannot recover.
                                                                                                                                                                                                                                   
  - **`@pytest.mark.flaky(reruns=3, reruns_delay=X)`** — adds a delay between reruns for rate limit tests. When a test exhausts its counter and fails, the counter is still active in Limitador. A rerun that starts immediately   
  would hit `429` on the very first request. The delay is set to `window + 5s` so the counter fully resets before the next attempt.
  ## Changes

  ### New Plugin & Configuration
  - Added `pytest-rerunfailures` dependency in `pyproject.toml`
  - Added `--reruns 3` default to the `PYTEST` command in `Makefile`

  ### Core Infrastructure
  - Modified `KubernetesObject.commit()` in `testsuite/kubernetes/__init__.py` to catch `AlreadyExists` and fall back to `apply()`, so module-scoped resources survive reruns
  - Added `_format_failure_message()` helper in `testsuite/tests/conftest.py` that produces clean tracebacks by filtering out `site-packages` frames and extracting stderr from `OpenShiftPythonException`
  - Added `_collect_rerun_attempt()` and `_write_rerun_properties()` in `testsuite/tests/conftest.py` to record per-attempt failure messages and isolated captured output as `__rp_rerun_*` user properties at teardown
  - Extended `pytest_runtest_makereport` hook to call the new rerun helpers on `"call"/"setup"` failures and at `"teardown"`

### Bug Fix                                                                                                                                                                                                                      
  - Fixed image digest stripping in `testsuite/component_metadata.py` — `container.image.split("@", 1)[0]` now correctly removes the `@sha256:...` suffix                                                                          
                                                                                                                                                                                                                                   
  ### Documentation
  - Updated `CLAUDE.md` with guidelines for `@pytest.mark.flaky` usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default automatic test reruns enabled (3 attempts) and test reports now include per-attempt messages.

* **Documentation**
  * Added guidance for controlling reruns, recommended delays for rate-limit tests, and when to disable retries.

* **Tests**
  * Applied flaky/retry markers across the test suite with tailored rerun counts/delays; several tests explicitly disable retries where unsafe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->