### PR TITLE
fix: update wasm config tracing test for renamed route span tags

### DIFF
--- a/testsuite/tests/singlecluster/tracing/control_plane/test_wasm_config_tracing.py
+++ b/testsuite/tests/singlecluster/tracing/control_plane/test_wasm_config_tracing.py
@@ -79,8 +79,9 @@ def test_wasm_config_matches_topology(wasm_config_span, cluster, gateway, route)
 
     assert span.get_tag("gateway.name") == gateway.name()
     assert span.get_tag("gateway.namespace") == cluster.project
-    assert span.get_tag("httproute.name") == route.name()
-    assert span.get_tag("httproute.namespace") == cluster.project
+    assert span.get_tag("route.name") == route.name()
+    assert span.get_tag("route.namespace") == cluster.project
+    assert span.get_tag("route_type") == "HTTP"
     assert span.get_tag("listener.name") == "api"
     assert span.has_tag("path_id")
 


### PR DESCRIPTION
 ## Description                                                                                                                                                                                                                   
  - Update `test_wasm_config_matches_topology` to align with span attribute changes from [kuadrant-operator#1855](https://github.com/Kuadrant/kuadrant-operator/pull/1855)
  - The operator renamed span tags from `httproute.name`/`httproute.namespace` to `route.name`/`route.namespace` and added a new `route_type` attribute

 ## Verification steps                                                                                                                                                                                                            
  ```bash                                                                                                                                                                                                                          
  poetry run pytest -vv testsuite/tests/singlecluster/tracing/control_plane/test_wasm_config_tracing.py::test_wasm_config_matches_topology
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Tests**
* Updated WASM configuration tracing assertions to reflect changes in tag naming conventions and added validation for route type identification in trace data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->