### PR TITLE
feat(egress): refactored credential injection test to use Vault

### DIFF
--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -27,6 +27,9 @@
 #  mockserver:
 #    url: "MOCKSERVER_URL"
 #    image: "MOCKSERVER_IMAGE"                  # Image to be used for self-deployed Mockserver
+#  vault:
+#    url: "http://vault.example.com:8200"               # External Vault URL (auto-fetched from tools-vault namespace LoadBalancer)
+#    token: "root"                                      # Vault root token (defaults to dev mode token)
 #  tracing:
 #    backend: "jaeger"                          # Tracing backend
 #    collector_url: "rpc://jaeger-collector.com:4317"  # Tracing collector URL (may be internal)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,14 @@ weakget = "*"
 pytest-playwright = "*"
 playwright = "1.57.0"
 pytest-rerunfailures = "*"
+hvac = "^2.4.0"
 
 [tool.poetry.group.dev.dependencies]
 mypy = "*"
 pylint = "*"
 types-PyYAML = "*"
 black = {version = "*", extras = ["d"]}
+types-hvac = "^2.4.0.20260408"
 
 
 # Black

--- a/testsuite/config/__init__.py
+++ b/testsuite/config/__init__.py
@@ -22,7 +22,7 @@ class DefaultValueValidator(Validator):
             },
             default=default,
             when=Validator(name, must_exist=False) | Validator(name, eq=None),
-            **kwargs
+            **kwargs,
         )
 
 
@@ -71,6 +71,10 @@ settings = Dynaconf(
         DefaultValueValidator("keycloak.url", default=fetch_service_ip("keycloak", protocol="http", port=8080)),
         DefaultValueValidator("keycloak.password", default=fetch_secret("credential-sso", "ADMIN_PASSWORD")),
         DefaultValueValidator("mockserver.url", default=fetch_service_ip("mockserver", protocol="http", port=1080)),
+        DefaultValueValidator(
+            "vault.url", default=fetch_service_ip("vault", protocol="http", port=8200, namespace="tools-vault")
+        ),
+        DefaultValueValidator("vault.token", default="root"),
         DefaultValueValidator("redis.url", default=fetch_service_ip("redis", protocol="redis", port=6379)),
         DefaultValueValidator("dragonfly.url", default=fetch_service_ip("dragonfly", protocol="redis", port=6379)),
         DefaultValueValidator("valkey.url", default=fetch_service_ip("valkey", protocol="redis", port=6379)),

--- a/testsuite/config/tools.py
+++ b/testsuite/config/tools.py
@@ -52,12 +52,14 @@ def fetch_service(name, protocol: str = None, port: int = None):
     return _fetcher
 
 
-def fetch_service_ip(name, port: int, protocol: str = "http"):
+def fetch_service_ip(name, port: int, protocol: str = "http", namespace: str = None):
     """Fetched load balanced ip for LoadBalancer service"""
 
     def _fetcher(settings, _):
         try:
             cluster = settings["tools"]
+            if namespace:
+                cluster = cluster.change_project(namespace)
             with cluster.context:
                 ip = selector(f"service/{name}").object(cls=Service).external_ip
                 return f"{protocol}://{ip}:{port}"

--- a/testsuite/kuadrant/policy/authorization/__init__.py
+++ b/testsuite/kuadrant/policy/authorization/__init__.py
@@ -4,7 +4,7 @@ import abc
 from dataclasses import dataclass
 from typing import Literal, Optional
 from testsuite.utils import asdict, JSONValues
-from testsuite.kuadrant.policy import CelExpression
+from testsuite.kuadrant.policy import CelExpression, CelPredicate
 
 # pylint: disable=invalid-name
 
@@ -63,7 +63,7 @@ class PatternRef:
     patternRef: str
 
 
-Rule = Pattern | AnyPattern | AllPattern | PatternRef
+Rule = Pattern | AnyPattern | AllPattern | PatternRef | CelPredicate
 
 
 @dataclass
@@ -89,6 +89,28 @@ class ValueFrom(ABCValue):
 
 
 @dataclass
+class ValueOrSelector:
+    """Dataclass matching Authorino's ValueOrSelector: static value, selector path, or CEL expression"""
+
+    source: Value | ValueFrom | CelExpression
+
+    def asdict(self):
+        """Serializes the source value to dict"""
+        return asdict(self.source)
+
+
+@dataclass
+class NamedValueOrSelector(ValueOrSelector):
+    """Named ValueOrSelector entry, serializes as {name: {value/selector/expression}}"""
+
+    name: str
+
+    def asdict(self):
+        """Serializes as {name: {value/selector/expression}}"""
+        return {self.name: super().asdict()}
+
+
+@dataclass
 class JsonResponse:
     """Response item as JSON injection."""
 
@@ -106,7 +128,7 @@ class JsonResponse:
 class PlainResponse:
     """Response item as plain text value."""
 
-    plain: ABCValue
+    plain: ABCValue | CelExpression
 
 
 @dataclass(kw_only=True)

--- a/testsuite/kuadrant/policy/authorization/sections.py
+++ b/testsuite/kuadrant/policy/authorization/sections.py
@@ -8,6 +8,8 @@ from testsuite.kuadrant.policy.authorization import (
     Pattern,
     ABCValue,
     ValueFrom,
+    ValueOrSelector,
+    NamedValueOrSelector,
     JsonResponse,
     PlainResponse,
     WristbandResponse,
@@ -201,18 +203,33 @@ class MetadataSection(Section):
     def add_http(
         self,
         name,
-        endpoint,
-        method: Literal["GET", "POST"],
+        endpoint=None,
+        method: Literal["GET", "POST"] = "GET",
         credentials: Credentials = None,
         shared_secret_ref: dict[str, str] = None,
+        *,
+        url_expression: str = None,
+        content_type: Literal["application/x-www-form-urlencoded", "application/json"] = None,
+        body: ValueOrSelector = None,
+        headers: list[NamedValueOrSelector] = None,
         **common_features,
     ):
         """Set metadata http external auth feature"""
-        http_config: dict = {
-            "url": endpoint,
-            "method": method,
-            "headers": {"Accept": {"value": "application/json"}},
-        }
+        if not bool(endpoint) ^ bool(url_expression):
+            raise ValueError("Exactly one of 'endpoint' or 'url_expression' must be provided")
+
+        http_config: dict = {"method": method, "headers": {"Accept": {"value": "application/json"}}}
+        if endpoint:
+            http_config["url"] = endpoint
+        if url_expression:
+            http_config["urlExpression"] = url_expression
+        if content_type:
+            http_config["contentType"] = content_type
+        if body:
+            http_config["body"] = asdict(body)
+        if headers:
+            for h in headers:
+                http_config["headers"].update(asdict(h))
         if credentials:
             http_config["credentials"] = asdict(credentials)
         if shared_secret_ref:

--- a/testsuite/kubernetes/vault.py
+++ b/testsuite/kubernetes/vault.py
@@ -1,0 +1,43 @@
+"""HashiCorp Vault client for managing per-test credentials via hvac."""
+
+import hvac
+
+
+class Vault:
+    """Manages Vault resources (secrets, policies, roles) for credential injection testing"""
+
+    def __init__(self, url: str, token: str):
+        self.url = url
+        self._client = hvac.Client(url=url, token=token)
+
+    def create_policy(self, name: str, path: str):
+        """Create a read-only Vault policy for the given path"""
+        self._client.sys.create_or_update_policy(name, f'path "{path}" {{ capabilities = ["read"] }}')
+
+    def delete_policy(self, name: str):
+        """Delete a Vault policy"""
+        self._client.sys.delete_policy(name)
+
+    def create_role(self, name: str, sa_names: list[str], sa_namespaces: list[str], policies: list[str]):
+        """Create a Kubernetes auth role binding service accounts to policies"""
+        self._client.auth.kubernetes.create_role(
+            name,
+            bound_service_account_names=sa_names,
+            bound_service_account_namespaces=sa_namespaces,
+            policies=policies,
+            ttl="1h",
+        )
+
+    def delete_role(self, name: str):
+        """Delete a Kubernetes auth role"""
+        self._client.auth.kubernetes.delete_role(name)
+
+    def store_secret(self, path: str, **data: str):
+        """Store a KV v2 secret at the given path"""
+        mount, _, secret_path = path.partition("/")
+        self._client.secrets.kv.v2.create_or_update_secret(secret_path, secret=data, mount_point=mount)
+
+    def delete_secret(self, path: str):
+        """Delete a KV v2 secret and all its versions"""
+        mount, _, secret_path = path.partition("/")
+        self._client.secrets.kv.v2.delete_metadata_and_all_versions(secret_path, mount_point=mount)

--- a/testsuite/tests/singlecluster/egress/credentials_injection/conftest.py
+++ b/testsuite/tests/singlecluster/egress/credentials_injection/conftest.py
@@ -1,19 +1,13 @@
 """Shared fixtures for egress credential injection tests.
 
-Provides MockServer backend, Authorino SA token for K8s API auth,
-and common credential injection fixtures (service1 secret, mockserver backend, mockserver expectation, authorization).
+Provides MockServer backend and common infrastructure for all credential injection tests.
 """
 
 import pytest
 
 from testsuite.backend.mockserver import MockserverBackend
 from testsuite.httpx import KuadrantClient
-from testsuite.kuadrant.policy.authorization import Credentials, Pattern, PlainResponse, ValueFrom
-from testsuite.kuadrant.policy.authorization.auth_policy import AuthPolicy
-from testsuite.kubernetes.secret import Secret
 from testsuite.mockserver import Mockserver
-
-SERVICE1_API_KEY = "pretty-random-api-key-to-use-for-egress-test-41894726"
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -38,71 +32,6 @@ def backend(request, cluster, blame, label):
 def mockserver_client(backend):
     """Mockserver client for creating expectations and direct requests"""
     return Mockserver(KuadrantClient(base_url=f"http://{backend.service.refresh().external_ip}:8080"))
-
-
-@pytest.fixture(scope="module")
-def mockserver_expectation(mockserver_client, module_label):
-    """MockServer expectation: 200 if Authorization: Bearer <service1-key>, 401 otherwise"""
-    template = """
-    {
-      "statusCode": #if($request.headers['authorization']
-        && $request.headers['authorization'].contains("Bearer %s")) 200 #else 401 #end,
-      "headers": { "Content-Type": ["application/json"] }
-    }
-    """ % SERVICE1_API_KEY
-    mockserver_client.create_template_expectation(module_label, template, "VELOCITY")
-    return f"/{module_label}"
-
-
-@pytest.fixture(scope="module")
-def service1_api_secret(request, cluster, blame, module_label):
-    """Secret containing a fake API key for service 1"""
-    secret = Secret.create_instance(
-        cluster,
-        blame("svc1-key"),
-        stringData={"api_key": SERVICE1_API_KEY},
-        labels={"app": module_label},
-    )
-    request.addfinalizer(secret.delete)
-    secret.commit()
-    return secret
-
-
-@pytest.fixture(scope="module")
-def sa_token_secret(request, testconfig, cluster, blame, module_label):
-    """Opaque Secret containing a token from Authorino's ServiceAccount for K8s API auth"""
-    system_project = cluster.change_project(testconfig["service_protection"]["system_project"])
-    authorino_sa = system_project.get_service_account("authorino-authorino")
-    token = authorino_sa.get_auth_token()
-    secret = Secret.create_instance(
-        system_project,
-        blame("authorino-k8s-auth"),
-        stringData={"token": token},
-        labels={"app": module_label},
-    )
-    request.addfinalizer(secret.delete)
-    secret.commit()
-    return secret
-
-
-@pytest.fixture(scope="module")
-def authorization(cluster, route, blame, module_label, service1_api_secret, sa_token_secret):
-    """AuthPolicy injecting the service 1 API key as an Authorization header"""
-    auth = AuthPolicy.create_instance(cluster, blame("authz"), route, labels={"app": module_label})
-    auth.identity.add_anonymous("anonymous")
-    auth.metadata.add_http(
-        "credential_fetch",
-        f"https://kubernetes.default.svc/api/v1/namespaces/{cluster.project}/secrets/{service1_api_secret.name()}",
-        "GET",
-        credentials=Credentials("authorizationHeader", "Bearer"),
-        shared_secret_ref={"name": sa_token_secret.name(), "key": "token"},
-    )
-    auth.responses.add_success_header(
-        "authorization",
-        PlainResponse(plain=ValueFrom("Bearer {auth.metadata.credential_fetch.data.api_key.@base64:decode}")),
-        when=[Pattern("context.request.http.headers.@keys", "excl", "dont-inject")],
-    )
-    return auth
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection.py
+++ b/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection.py
@@ -1,20 +1,107 @@
-"""Test: AuthPolicy reads a K8s Secret via metadata.http and injects it as a request header.
+"""Test: AuthPolicy fetches credentials from Vault and injects them into egress requests.
 
-Based on https://github.com/Kuadrant/architecture/issues/148
-Pattern: metadata.http fetches credential from K8s API, response.success.headers injects it upstream.
-Uses MockServer as the backend to validate injected credentials:
-  - Correct Authorization header -> 200
-  - Wrong or missing header -> 401
+Replicates the deployment from the user guide:
+https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/user-guides/egress/credential-injection.md
 """
 
 import pytest
+from dynaconf import ValidationError
 
 from testsuite.gateway import CustomReference, URLRewriteFilter
 from testsuite.gateway.gateway_api.route import HTTPRoute
+from testsuite.kuadrant.policy import CelExpression, CelPredicate
+from testsuite.kuadrant.policy.authorization import NamedValueOrSelector, PlainResponse, ValueOrSelector
+from testsuite.kuadrant.policy.authorization.auth_policy import AuthPolicy
+from testsuite.kubernetes.service_account import ServiceAccount
+from testsuite.kubernetes.vault import Vault
 
 from ..conftest import EGRESS_HOSTNAME
 
 pytestmark = [pytest.mark.kuadrant_only, pytest.mark.egress_gateway]
+
+VAULT_API_KEY = "pretty-random-api-key-to-use-for-egress-credential-injection-test-41894726"
+K8S_TOKEN_AUDIENCE = "https://kubernetes.default.svc.cluster.local"
+
+
+@pytest.fixture(scope="module")
+def service_account(request, cluster, blame, module_label):
+    """Unique ServiceAccount per test run for Vault isolation"""
+    sa = ServiceAccount.create_instance(cluster, blame("egress-sa"), labels={"app": module_label})
+    request.addfinalizer(sa.delete)
+    sa.commit()
+    return sa
+
+
+@pytest.fixture(scope="module")
+def vault_role(blame):
+    """Role name for Vault Kubernetes auth"""
+    return blame("egress-wl")
+
+
+@pytest.fixture(scope="module")
+def vault(request, testconfig, cluster, blame, vault_role, service_account, skip_or_fail):
+    """Vault client with per-test policy, role, and secret"""
+    try:
+        testconfig.validators.validate(only="vault")
+    except (KeyError, ValidationError) as exc:
+        skip_or_fail(f"Vault configuration is missing: {exc}")
+    vault = Vault(testconfig["vault"]["url"], testconfig["vault"]["token"])
+
+    policy_name = blame("egress-read")
+    vault.create_policy(policy_name, "secret/data/egress/*")
+    request.addfinalizer(lambda: vault.delete_policy(policy_name))
+
+    vault.create_role(
+        vault_role,
+        sa_names=[service_account.name()],
+        sa_namespaces=[cluster.project],
+        policies=[policy_name],
+    )
+    request.addfinalizer(lambda: vault.delete_role(vault_role))
+
+    secret_path = f"secret/egress/{cluster.project}/{service_account.name()}"
+    vault.store_secret(secret_path, api_key=VAULT_API_KEY)
+    request.addfinalizer(lambda: vault.delete_secret(secret_path))
+
+    return vault
+
+
+@pytest.fixture(scope="module")
+def service_account2(request, second_namespace, blame, module_label):
+    """ServiceAccount in a different namespace, unauthorized by the Vault role"""
+    sa = ServiceAccount.create_instance(second_namespace, blame("egress-sa2"), labels={"app": module_label})
+    request.addfinalizer(sa.delete)
+    sa.commit()
+    return sa
+
+
+@pytest.fixture(scope="module")
+def sa_token(service_account):
+    """Service account token with Vault-compatible audience"""
+    return service_account.get_auth_token(audiences=[K8S_TOKEN_AUDIENCE])
+
+
+@pytest.fixture(scope="module")
+def sa_token2(service_account2):
+    """Token from an unauthorized namespace"""
+    return service_account2.get_auth_token(audiences=[K8S_TOKEN_AUDIENCE])
+
+
+@pytest.fixture(scope="module")
+def mockserver_expectation(mockserver_client, module_label):
+    """MockServer template: validates Authorization header and echoes it back in a response header"""
+    template = """
+    {
+      "statusCode": #if($request.headers['authorization']
+        && $request.headers['authorization'].contains("Bearer %s")) 200 #else 401 #end,
+      "headers": {
+        "Content-Type": ["text/plain"],
+        "authorization": ["$!{request.headers['authorization'].get(0)}"]
+      }
+    }
+    """ % VAULT_API_KEY
+    mockserver_client.create_template_expectation(module_label, template, "VELOCITY")
+    return f"/{module_label}"
 
 
 @pytest.fixture(scope="module")
@@ -33,18 +120,72 @@ def route(request, gateway, cluster, blame, hostname, module_label, service_entr
     return route
 
 
-@pytest.fixture(scope="module", autouse=True)
-def commit(request, authorization):
-    """Commit the AuthPolicy and wait for it to be enforced"""
-    request.addfinalizer(authorization.delete)
-    authorization.commit()
-    authorization.wait_for_ready()
+@pytest.fixture(scope="module")
+def authorization(cluster, route, blame, module_label, vault, vault_role):
+    """AuthPolicy using Vault for credential injection, replicating the credential-injection user guide"""
+    auth = AuthPolicy.create_instance(cluster, blame("authz"), route, labels={"app": module_label})
+
+    auth.identity.add_kubernetes("workload-identity", audiences=[K8S_TOKEN_AUDIENCE])
+
+    auth.metadata.add_http(
+        "vault_login",
+        f"{vault.url}/v1/auth/kubernetes/login",
+        "POST",
+        content_type="application/json",
+        body=ValueOrSelector(
+            CelExpression(
+                '"{\\"jwt\\": \\"" + request.headers.authorization.substring(7) + '
+                f'"\\", \\"role\\": \\"{vault_role}\\"}}"'
+            )
+        ),  # CEL produces: '{"jwt": "<token>", "role": "<role>"}'
+        priority=0,
+    )
+    auth.metadata.add_http(
+        "vault_secret",
+        method="GET",
+        url_expression=(
+            f'"{vault.url}/v1/secret/data/egress/"'
+            " + auth.metadata.vault_login.auth.metadata.service_account_namespace"
+            ' + "/" + auth.metadata.vault_login.auth.metadata.service_account_name'
+        ),
+        headers=[
+            NamedValueOrSelector(CelExpression("auth.metadata.vault_login.auth.client_token"), name="X-Vault-Token")
+        ],
+        priority=1,
+    )
+
+    auth.authorization.add_auth_rules(
+        "vault_credential_check",
+        [CelPredicate("has(auth.metadata.vault_secret.data)")],
+    )
+
+    auth.responses.add_success_header(
+        "authorization",
+        PlainResponse(plain=CelExpression('"Bearer " + auth.metadata.vault_secret.data.data.api_key')),
+    )
+    return auth
 
 
-def test_egress_credential_injection(client, mockserver_expectation):
-    """Test that the correct credential is accepted (200) and that no injected credential results in rejection (401)"""
-    response = client.get(mockserver_expectation)
+def test_egress_credential_injection_via_vault(client, sa_token, mockserver_expectation):
+    """Test that Vault credential is injected and the overwritten header reaches the backend"""
+    response = client.get(mockserver_expectation, headers={"Authorization": f"Bearer {sa_token}"})
     assert response.status_code == 200
+    assert response.headers["authorization"] == f"Bearer {VAULT_API_KEY}"
 
-    response = client.get(mockserver_expectation, headers={"dont-inject": "true"})
+
+def test_egress_unauthorized_namespace_rejected(client, sa_token2, mockserver_expectation):
+    """Test that a valid SA token from an unauthorized namespace is rejected by Vault"""
+    response = client.get(mockserver_expectation, headers={"Authorization": f"Bearer {sa_token2}"})
+    assert response.status_code == 403
+
+
+def test_egress_invalid_token_rejected(client, mockserver_expectation):
+    """Test that requests with an invalid SA token are rejected"""
+    response = client.get(mockserver_expectation, headers={"Authorization": "Bearer xyz"})
+    assert response.status_code == 401
+
+
+def test_egress_no_token_rejected(client, mockserver_expectation):
+    """Test that requests without a valid SA token are rejected"""
+    response = client.get(mockserver_expectation)
     assert response.status_code == 401

--- a/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection_by_destination.py
+++ b/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection_by_destination.py
@@ -5,6 +5,7 @@ Two HTTPRoutes (/service1, /service2) with separate AuthPolicies inject differen
   - /service1 -> Authorization: Bearer <service1-key>
   - /service2 -> X-Api-Key: <service2-key>
 Uses MockServer to validate each route receives the correct credential.
+Credentials are fetched from Kubernetes Secrets via metadata.http.
 """
 
 import pytest
@@ -19,7 +20,22 @@ from ..conftest import EGRESS_HOSTNAME
 
 pytestmark = [pytest.mark.kuadrant_only, pytest.mark.egress_gateway]
 
+SERVICE1_API_KEY = "pretty-random-api-key-to-use-for-egress-test-41894726"
 SERVICE2_API_KEY = "sk-fake-service2-key-for-egress-test-9876543210"
+
+
+@pytest.fixture(scope="module")
+def mockserver_expectation(mockserver_client, module_label):
+    """MockServer expectation: 200 if Authorization: Bearer <service1-key>, 401 otherwise"""
+    template = """
+    {
+      "statusCode": #if($request.headers['authorization']
+        && $request.headers['authorization'].contains("Bearer %s")) 200 #else 401 #end,
+      "headers": { "Content-Type": ["application/json"] }
+    }
+    """ % SERVICE1_API_KEY
+    mockserver_client.create_template_expectation(module_label, template, "VELOCITY")
+    return f"/{module_label}"
 
 
 @pytest.fixture(scope="module")
@@ -38,12 +54,43 @@ def service2_expectation(mockserver_client, blame):
 
 
 @pytest.fixture(scope="module")
+def service1_api_secret(request, cluster, blame, module_label):
+    """Secret containing a fake API key for service 1"""
+    secret = Secret.create_instance(
+        cluster,
+        blame("svc1-key"),
+        stringData={"api_key": SERVICE1_API_KEY},
+        labels={"app": module_label},
+    )
+    request.addfinalizer(secret.delete)
+    secret.commit()
+    return secret
+
+
+@pytest.fixture(scope="module")
 def service2_api_secret(request, cluster, blame, module_label):
     """Secret containing a fake API key for service 2"""
     secret = Secret.create_instance(
         cluster,
         blame("svc2-key"),
         stringData={"api_key": SERVICE2_API_KEY},
+        labels={"app": module_label},
+    )
+    request.addfinalizer(secret.delete)
+    secret.commit()
+    return secret
+
+
+@pytest.fixture(scope="module")
+def sa_token_secret(request, testconfig, cluster, blame, module_label):
+    """Opaque Secret containing a token from Authorino's ServiceAccount for K8s API auth"""
+    system_project = cluster.change_project(testconfig["service_protection"]["system_project"])
+    authorino_sa = system_project.get_service_account("authorino-authorino")
+    token = authorino_sa.get_auth_token()
+    secret = Secret.create_instance(
+        system_project,
+        blame("authorino-k8s-auth"),
+        stringData={"token": token},
         labels={"app": module_label},
     )
     request.addfinalizer(secret.delete)
@@ -85,6 +132,26 @@ def route2(
     route.commit()
     route.wait_for_ready()
     return route
+
+
+@pytest.fixture(scope="module")
+def authorization(cluster, route, blame, module_label, service1_api_secret, sa_token_secret):
+    """AuthPolicy injecting the service 1 API key as an Authorization header"""
+    auth = AuthPolicy.create_instance(cluster, blame("svc1-authz"), route, labels={"app": module_label})
+    auth.identity.add_anonymous("anonymous")
+    auth.metadata.add_http(
+        "credential_fetch",
+        f"https://kubernetes.default.svc/api/v1/namespaces/{cluster.project}/secrets/{service1_api_secret.name()}",
+        "GET",
+        credentials=Credentials("authorizationHeader", "Bearer"),
+        shared_secret_ref={"name": sa_token_secret.name(), "key": "token"},
+    )
+    auth.responses.add_success_header(
+        "authorization",
+        PlainResponse(plain=ValueFrom("Bearer {auth.metadata.credential_fetch.data.api_key.@base64:decode}")),
+        when=[Pattern("context.request.http.headers.@keys", "excl", "dont-inject")],
+    )
+    return auth
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
  > [!NOTE]
  > Requires https://github.com/Kuadrant/helm-charts-olm/pull/86 to be merged first (Vault deployment in `tools-vault` namespace).

  Closes https://github.com/Kuadrant/testsuite/issues/949

  ## Description
  - Rewrites the egress credential injection test to use HashiCorp Vault with Kubernetes auth, replicating the [credential-injection user guide](https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/user-guides/egress/credential-injection.md)
  - Adds `hvac` Python client for Vault management instead of `kubectl exec` into the Vault pod
  - Introduces `ValueOrSelector` and `NamedValueOrSelector` dataclasses matching Authorino's API spec for typed metadata HTTP configuration
  - Extends `fetch_service_ip` to support cross-namespace service discovery for Vault in `tools-vault` namespace

  ## Changes

  ### New Features
  - `testsuite/kubernetes/vault.py` — New `Vault` class using `hvac` library for managing policies, Kubernetes auth roles, and KV v2 secrets
  - `ValueOrSelector` dataclass wrapping `Value | ValueFrom | CelExpression` to match Authorino's `ValueOrSelector` spec
  - `NamedValueOrSelector` extending `ValueOrSelector` with a `name` field, serializing as `{name: {value/selector/expression}}`
  - `CelPredicate` added to the `Rule` type union for CEL-based pattern matching
  - `PlainResponse.plain` now accepts `CelExpression` in addition to `ABCValue`

  ### Refactoring
  - `MetadataSection.add_http()` — Extended with keyword-only parameters: `url_expression: str`, `content_type: Literal[...]`, `body: ValueOrSelector`, `headers:
  list[NamedValueOrSelector]`; `endpoint` and `method` are now optional
  - `fetch_service_ip()` — Added optional `namespace` parameter for cross-namespace LoadBalancer lookups
  - Shared fixtures (`mockserver_expectation`, `service1_api_secret`, `sa_token_secret`, `authorization`) moved from `conftest.py` into their respective test files to
  decouple the Vault-based and K8s-Secret-based credential injection tests

  ### Tests
  - `test_credential_injection.py` — Rewritten to use Vault Kubernetes auth flow: creates a `ServiceAccount`, configures Vault policy/role/secret, builds `AuthPolicy` with
  `vault_login` + `vault_secret` metadata steps, and validates credential injection via MockServer
  - Three test cases: successful injection with valid SA token, rejection with invalid token, rejection without token
  - `test_credential_injection_by_destination.py` — Now self-contained with its own fixtures (previously shared from conftest)

  ### Configuration
  - `config/settings.local.yaml.tpl` — Added `vault.url` and `vault.token` settings template
  - `testsuite/config/__init__.py` — Added `DefaultValueValidator` entries for `vault.url` (auto-fetched from `tools-vault` namespace) and `vault.token` (defaults to
  `"root"`)
  - `pyproject.toml` — Added `hvac` to main dependencies, `types-hvac` to dev dependencies

  ## Verification steps
  ```bash
  poetry run pytest -vv -n2 testsuite/tests/singlecluster/egress/credentials_injection/
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Authorization rules now accept CEL predicates for richer policy expressions
  - HTTP metadata configuration accepts URL expressions, custom headers, request bodies and content-type options
  - Vault integration for credential management with a commented local template including dev-mode defaults

* **Tests**
  - Expanded credential-injection tests covering Vault-backed flows, namespace/token failure cases and metadata-based secret fetching

* **Chores**
  - Added a Vault client runtime dependency and corresponding dev typing stubs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->