### PR TITLE
feat: replace httpbin with mockserver as default backend

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -10,8 +10,6 @@ default:
     test_user:
       username: "testUser"
       password: "testPassword"
-  httpbin:
-    image: "quay.io/rhn_support_azgabur/httpbin:latest"
   llm_sim:
     image: "ghcr.io/llm-d/llm-d-inference-sim:v0.1.1"
   mockserver:

--- a/testsuite/backend/mockserver.py
+++ b/testsuite/backend/mockserver.py
@@ -33,11 +33,13 @@ class MockserverBackendConfig:
     @property
     def volumes(self):
         """Volumes to mount into the MockServer container"""
-        return [ConfigMapVolume(
-            config_map_name=self.config_map.name(),
-            items={k: k for k in self.data},
-            name="init-config",
-        )]
+        return [
+            ConfigMapVolume(
+                config_map_name=self.config_map.name(),
+                items={k: k for k in self.data},
+                name="init-config",
+            )
+        ]
 
     @property
     def volume_mounts(self):

--- a/testsuite/backend/mockserver.py
+++ b/testsuite/backend/mockserver.py
@@ -3,12 +3,67 @@
 from testsuite.config import settings
 from testsuite.backend import Backend
 from testsuite.kubernetes import Selector
-from testsuite.kubernetes.deployment import Deployment, ContainerResources
+from testsuite.kubernetes.config_map import ConfigMap
+from testsuite.kubernetes.deployment import Deployment, ContainerResources, ConfigMapVolume, VolumeMount
 from testsuite.kubernetes.service import Service, ServicePort
+
+INIT_JSON_MOUNT = "/config/mockserver"
+
+
+class MockserverBackendConfig:
+    """Initial configuration for MockServer loaded at startup via ConfigMap"""
+
+    def __init__(self, cluster, name, label, data: dict[str, str]):
+        self.cluster = cluster
+        self.name = name
+        self.label = label
+        self.data = data
+        self.config_map = None
+
+    def commit(self):
+        """Creates and commits the ConfigMap"""
+        self.config_map = ConfigMap.create_instance(
+            self.cluster,
+            self.name,
+            data=self.data,
+            labels={"app": self.label},
+        )
+        self.config_map.commit()
+
+    @property
+    def volumes(self):
+        """Volumes to mount into the MockServer container"""
+        return [ConfigMapVolume(
+            config_map_name=self.config_map.name(),
+            items={k: k for k in self.data},
+            name="init-config",
+        )]
+
+    @property
+    def volume_mounts(self):
+        """Volume mounts for the MockServer container"""
+        return [VolumeMount(mountPath=INIT_JSON_MOUNT, name="init-config", readOnly=True)]
+
+    @property
+    def env(self):
+        """Environment variables for the MockServer container"""
+        init_file = next(iter(self.data))
+        return {"MOCKSERVER_INITIALIZATION_JSON_PATH": f"{INIT_JSON_MOUNT}/{init_file}"}
+
+    def delete(self):
+        """Deletes the ConfigMap"""
+        if self.config_map:
+            self.config_map.delete(ignore_not_found=True)
+            self.config_map = None
 
 
 class MockserverBackend(Backend):
     """Mockserver deployed as backend in Kubernetes"""
+
+    def __init__(self, cluster, name, label, service_type="LoadBalancer", config=None):
+        super().__init__(cluster, name, label)
+        self.service_type = service_type
+        self.config = config
 
     def commit(self):
         match_labels = {"app": self.label, "deployment": self.name}
@@ -22,6 +77,9 @@ class MockserverBackend(Backend):
             labels={"app": self.label},
             resources=ContainerResources(limits_memory="2G"),
             lifecycle={"postStart": {"exec": {"command": ["/bin/sh", "init-mockserver"]}}},
+            volumes=self.config.volumes if self.config else None,
+            volume_mounts=self.config.volume_mounts if self.config else None,
+            env=self.config.env if self.config else None,
         )
         self.deployment.commit()
 
@@ -31,9 +89,15 @@ class MockserverBackend(Backend):
             selector=match_labels,
             ports=[ServicePort(name="http", port=8080, targetPort="api")],
             labels={"app": self.label},
-            service_type="LoadBalancer",
+            service_type=self.service_type,
         )
         self.service.commit()
+
+    def delete(self):
+        if self.config:
+            with self.cluster.context:
+                self.config.delete()
+        super().delete()
 
     def wait_for_ready(self, timeout=60 * 5):
         """Waits until Deployment and Service is marked as ready"""

--- a/testsuite/backend/mockserver.py
+++ b/testsuite/backend/mockserver.py
@@ -96,10 +96,12 @@ class MockserverBackend(Backend):
         self.service.commit()
 
     def delete(self):
-        if self.config:
-            with self.cluster.context:
-                self.config.delete()
-        super().delete()
+        try:
+            if self.config:
+                with self.cluster.context:
+                    self.config.delete()
+        finally:
+            super().delete()
 
     def wait_for_ready(self, timeout=60 * 5):
         """Waits until Deployment and Service is marked as ready"""

--- a/testsuite/kubernetes/deployment.py
+++ b/testsuite/kubernetes/deployment.py
@@ -92,6 +92,7 @@ class Deployment(KubernetesObject):
         readiness_probe: dict[str, Any] = None,
         resources: Optional[ContainerResources] = None,
         lifecycle: dict[str, Any] = None,
+        env: dict[str, str] = None,
     ):  # pylint: disable=too-many-locals
         """
         Creates new instance of Deployment
@@ -142,6 +143,9 @@ class Deployment(KubernetesObject):
 
         if lifecycle:
             container["lifecycle"] = lifecycle
+
+        if env:
+            container["env"] = [{"name": k, "value": v} for k, v in env.items()]
 
         return cls(model, context=cluster.context)
 

--- a/testsuite/resources/echo_expectation.json
+++ b/testsuite/resources/echo_expectation.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "echo",
+    "httpRequest": {},
+    "httpResponseTemplate": {
+      "templateType": "VELOCITY",
+      "template": "{'statusCode': 200, 'headers': {'content-type': ['application/json']}, 'body': {'headers': {#foreach($entry in $request.headers.entrySet())#if($foreach.count > 1),#end '$entry.key': '$entry.value.get(0)'#end}, 'method': '$request.method', 'url': '$request.path'}}"
+    },
+    "priority": -10
+  }
+]

--- a/testsuite/resources/echo_expectation.json
+++ b/testsuite/resources/echo_expectation.json
@@ -3,8 +3,8 @@
     "id": "echo",
     "httpRequest": {},
     "httpResponseTemplate": {
-      "templateType": "VELOCITY",
-      "template": "{'statusCode': 200, 'headers': {'content-type': ['application/json']}, 'body': {'headers': {#foreach($entry in $request.headers.entrySet())#if($foreach.count > 1),#end '$entry.key': '$entry.value.get(0)'#end}, 'method': '$request.method', 'url': '$request.path'}}"
+      "templateType": "JAVASCRIPT",
+      "template": "var headers = {}; for (var key in request.headers) { headers[key] = String(request.headers[key][0]); } return { statusCode: 200, headers: { 'content-type': ['application/json'] }, body: JSON.stringify({ headers: headers, method: request.method, url: request.path }) };"
     },
     "priority": -10
   }

--- a/testsuite/resources/echo_expectation.json
+++ b/testsuite/resources/echo_expectation.json
@@ -1,5 +1,14 @@
 [
   {
+    "id": "not-found",
+    "httpRequest": {
+      "path": "/unknown-endpoint"
+    },
+    "httpResponse": {
+      "statusCode": 404
+    }
+  },
+  {
     "id": "echo",
     "httpRequest": {},
     "httpResponseTemplate": {

--- a/testsuite/tests/multicluster/conftest.py
+++ b/testsuite/tests/multicluster/conftest.py
@@ -5,7 +5,7 @@ from importlib import resources
 import pytest
 from dynaconf import ValidationError
 
-from testsuite.backend.httpbin import Httpbin
+from testsuite.backend.mockserver import MockserverBackend, MockserverBackendConfig
 from testsuite.certificates import Certificate
 from testsuite.gateway import Exposer, Hostname
 from testsuite.gateway import TLSGatewayListener
@@ -69,16 +69,22 @@ def wildcard_domain(base_domain):
 
 
 @pytest.fixture(scope="session")
-def backends(request, cluster, cluster2, blame, label, testconfig) -> list[Httpbin]:
-    """Deploys Backend to each Kubernetes cluster"""
+def backends(request, cluster, cluster2, blame, label):
+    """Deploys MockServer backend to each Kubernetes cluster"""
     backends = []
-    name = blame("httpbin")
-    image = testconfig["httpbin"]["image"]
-    for client in [cluster, cluster2]:
-        httpbin = Httpbin(client, name, label, image)
-        request.addfinalizer(httpbin.delete)
-        httpbin.commit()
-        backends.append(httpbin)
+    name = blame("mockserver")
+    echo_json = resources.files("testsuite.resources").joinpath("echo_expectation.json").read_text()
+    for cluster_client in [cluster, cluster2]:
+        config = MockserverBackendConfig(
+            cluster_client, name + "-config", label,
+            data={"echo_expectation.json": echo_json},
+        )
+        config.commit()
+        mockserver = MockserverBackend(cluster_client, name, label, service_type="ClusterIP", config=config)
+        request.addfinalizer(mockserver.delete)
+        mockserver.commit()
+        mockserver.wait_for_ready()
+        backends.append(mockserver)
     return backends
 
 

--- a/testsuite/tests/multicluster/conftest.py
+++ b/testsuite/tests/multicluster/conftest.py
@@ -76,7 +76,9 @@ def backends(request, cluster, cluster2, blame, label):
     echo_json = resources.files("testsuite.resources").joinpath("echo_expectation.json").read_text()
     for cluster_client in [cluster, cluster2]:
         config = MockserverBackendConfig(
-            cluster_client, name + "-config", label,
+            cluster_client,
+            name + "-config",
+            label,
             data={"echo_expectation.json": echo_json},
         )
         config.commit()

--- a/testsuite/tests/singlecluster/authorino/authorization/opa/test_authorization_services.py
+++ b/testsuite/tests/singlecluster/authorino/authorization/opa/test_authorization_services.py
@@ -166,7 +166,7 @@ def test_user_managed_access(client, resource_owner_auth, requester_auth, protec
     assert response.status_code == 200
 
     # Extract the RPT from the response
-    rpt = json.loads(response.json()["headers"]["X-Keycloak"])["rpt"]
+    rpt = json.loads(response.json()["headers"]["x-keycloak"])["rpt"]
 
     # Access the protected resource by requester using RPT (type of JWT)
     response = client.get("/anything/1", headers={"Authorization": f"Bearer {rpt}"})

--- a/testsuite/tests/singlecluster/authorino/conditions/section_conditions/test_response_condition.py
+++ b/testsuite/tests/singlecluster/authorino/conditions/section_conditions/test_response_condition.py
@@ -26,7 +26,7 @@ def test_skip_response(client, auth):
     assert response.status_code == 200
 
     # verify that response was not returned on a GET request
-    assert "Simple" not in response.json()["headers"]
+    assert "simple" not in response.json()["headers"]
 
     response = client.post("/post", auth=auth)
     assert response.status_code == 200

--- a/testsuite/tests/singlecluster/authorino/identity/keycloak/test_keycloak_context.py
+++ b/testsuite/tests/singlecluster/authorino/identity/keycloak/test_keycloak_context.py
@@ -40,7 +40,7 @@ def test_keycloak_context(client, auth, keycloak, realm_role):
     """
     response = client.get("get", auth=auth)
     assert response.status_code == 200
-    auth_json = json.loads(response.json()["headers"]["Auth-Json"])
+    auth_json = json.loads(response.json()["headers"]["auth-json"])
     identity = auth_json["auth"]
     now = time.time()
     assert keycloak.well_known["issuer"] == identity["iss"]

--- a/testsuite/tests/singlecluster/authorino/operator/clusterwide/test_wildcard_collision.py
+++ b/testsuite/tests/singlecluster/authorino/operator/clusterwide/test_wildcard_collision.py
@@ -55,7 +55,7 @@ def test_wildcard_first_authorization(client, authorization, wildcard_domain):
     """
     response = client.get("/get")
     assert response.status_code == 200
-    assert response.json()["headers"]["Header"] == '{"anything":"one"}'
+    assert response.json()["headers"]["header"] == '{"anything":"one"}'
 
     assert authorization.model.status.summary.hostsReady == [wildcard_domain]
 
@@ -83,6 +83,6 @@ def test_wildcard_second_authorization(client2, authorization2):
 
     response = client2.get("/get")
     assert response.status_code == 200
-    assert response.json()["headers"]["Header"] == '{"anything":"one"}'
+    assert response.json()["headers"]["header"] == '{"anything":"one"}'
 
     assert authorization2.model.status.summary.hostsReady == []

--- a/testsuite/tests/singlecluster/authorino/operator/sharding/test_preexisting_auth.py
+++ b/testsuite/tests/singlecluster/authorino/operator/sharding/test_preexisting_auth.py
@@ -43,4 +43,4 @@ def test_preexisting_auth(
     ), f"Host {hostname.hostname} not found, model: {auth.model}"
     response = hostname.client().get("/get")
     assert response.status_code == 200
-    assert response.json()["headers"]["Header"] == '{"anything":"B"}'
+    assert response.json()["headers"]["header"] == '{"anything":"B"}'

--- a/testsuite/tests/singlecluster/authorino/response/test_auth_json.py
+++ b/testsuite/tests/singlecluster/authorino/response/test_auth_json.py
@@ -42,8 +42,8 @@ def test_auth_json_path(auth, client, path_and_value):
     _, value = path_and_value
     response = client.get("/get", auth=auth)
     assert response.status_code == 200
-    data = response.json()["headers"].get("Header", None)
-    assert data is not None, "Header from response (Header) is missing"
+    data = response.json()["headers"].get("header", None)
+    assert data is not None, "Header from response (header) is missing"
 
     extra_data = json.loads(data)
     assert extra_data["anything"] == value

--- a/testsuite/tests/singlecluster/authorino/response/test_base64.py
+++ b/testsuite/tests/singlecluster/authorino/response/test_base64.py
@@ -30,7 +30,7 @@ def test_base64(auth, client, string):
     response = client.get("/get", auth=auth, headers={"test": encoded})
     assert response.status_code == 200
 
-    data = response.json()["headers"].get("Header")
+    data = response.json()["headers"].get("header")
     assert data
 
     assert json.loads(data)["anything"] == string

--- a/testsuite/tests/singlecluster/authorino/response/test_headers.py
+++ b/testsuite/tests/singlecluster/authorino/response/test_headers.py
@@ -27,8 +27,8 @@ def test_headers(auth, client, header_name):
     """Tests that value in correct Header"""
     response = client.get("/get", auth=auth)
     assert response.status_code == 200
-    data = response.json()["headers"].get(header_name.capitalize(), None)
-    assert data is not None, f"Headers from response ({header_name.capitalize()}) is missing"
+    data = response.json()["headers"].get(header_name.lower(), None)
+    assert data is not None, f"Headers from response ({header_name.lower()}) is missing"
 
     extra_data = json.loads(data)
     assert extra_data["anything"] == "one"

--- a/testsuite/tests/singlecluster/authorino/response/test_multiple_responses.py
+++ b/testsuite/tests/singlecluster/authorino/response/test_multiple_responses.py
@@ -22,14 +22,14 @@ def test_multiple_responses(auth, client):
     response = client.get("/get", auth=auth)
 
     assert response.status_code == 200
-    data = response.json()["headers"].get("Header", None)
-    assert data is not None, "Headers from first response (Header) is missing"
+    data = response.json()["headers"].get("header", None)
+    assert data is not None, "Headers from first response (header) is missing"
 
     extra_data = json.loads(data)
     assert extra_data["anything"] == "one"
 
-    data = response.json()["headers"].get("X-Test", None)
-    assert data is not None, "Headers from second response (X-Test) is missing"
+    data = response.json()["headers"].get("x-test", None)
+    assert data is not None, "Headers from second response (x-test) is missing"
 
     extra_data = json.loads(data)
     assert extra_data["anything"] == "two"

--- a/testsuite/tests/singlecluster/authorino/response/test_simple_response.py
+++ b/testsuite/tests/singlecluster/authorino/response/test_simple_response.py
@@ -20,8 +20,8 @@ def test_simple_response_with(auth, client):
     """Tests simple response"""
     response = client.get("/get", auth=auth)
     assert response.status_code == 200
-    data = response.json()["headers"].get("Header", None)
-    assert data is not None, "Header from response (Header) is missing"
+    data = response.json()["headers"].get("header", None)
+    assert data is not None, "Header from response (header) is missing"
 
     extra_data = json.loads(data)
     assert extra_data["anything"] == "one"

--- a/testsuite/tests/singlecluster/conftest.py
+++ b/testsuite/tests/singlecluster/conftest.py
@@ -89,11 +89,13 @@ def kuadrant(request, testconfig):
 
 
 @pytest.fixture(scope="session")
-def mockserver_config(request, cluster, blame, label):
+def mockserver_config(cluster, blame, label):
     """Initial MockServer configuration with echo expectation"""
     echo_json = resources.files("testsuite.resources").joinpath("echo_expectation.json").read_text()
     config = MockserverBackendConfig(
-        cluster, blame("mockserver-config"), label,
+        cluster,
+        blame("mockserver-config"),
+        label,
         data={"echo_expectation.json": echo_json},
     )
     config.commit()

--- a/testsuite/tests/singlecluster/conftest.py
+++ b/testsuite/tests/singlecluster/conftest.py
@@ -1,10 +1,12 @@
 """Configure all the components through Kuadrant,
 all methods are placeholders for now since we do not work with Kuadrant"""
 
+from importlib import resources
+
 import pytest
 from openshift_client import selector
 
-from testsuite.backend.httpbin import Httpbin
+from testsuite.backend.mockserver import MockserverBackend, MockserverBackendConfig
 from testsuite.gateway import GatewayRoute, Gateway, Hostname, GatewayListener
 from testsuite.gateway.envoy import Envoy
 from testsuite.gateway.envoy.route import EnvoyVirtualRoute
@@ -87,13 +89,27 @@ def kuadrant(request, testconfig):
 
 
 @pytest.fixture(scope="session")
-def backend(request, cluster, blame, label, testconfig):
-    """Deploys Httpbin backend"""
-    image = testconfig["httpbin"]["image"]
-    httpbin = Httpbin(cluster, blame("httpbin"), label, image)
-    request.addfinalizer(httpbin.delete)
-    httpbin.commit()
-    return httpbin
+def mockserver_config(request, cluster, blame, label):
+    """Initial MockServer configuration with echo expectation"""
+    echo_json = resources.files("testsuite.resources").joinpath("echo_expectation.json").read_text()
+    config = MockserverBackendConfig(
+        cluster, blame("mockserver-config"), label,
+        data={"echo_expectation.json": echo_json},
+    )
+    config.commit()
+    return config
+
+
+@pytest.fixture(scope="session")
+def backend(request, cluster, blame, label, mockserver_config):
+    """Deploys MockServer backend"""
+    mockserver = MockserverBackend(
+        cluster, blame("mockserver"), label, service_type="ClusterIP", config=mockserver_config
+    )
+    request.addfinalizer(mockserver.delete)
+    mockserver.commit()
+    mockserver.wait_for_ready()
+    return mockserver
 
 
 @pytest.fixture(scope="session")

--- a/testsuite/utils.py
+++ b/testsuite/utils.py
@@ -114,7 +114,7 @@ def create_csv_file(rows: list) -> StringIO:
     return file
 
 
-def extract_response(response, header="Simple", key="data"):
+def extract_response(response, header="simple", key="data"):
     """
     Extracts response added by Authorino from header
     :param key: Response key section


### PR DESCRIPTION
> [!IMPORTANT]
> This PR modifies shared/core testsuite code that could potentially affect multiple test areas. 2 reviewers should review this PR to ensure adequate coverage.

## Description
- Replaces `Httpbin` with `MockserverBackend` as the default echo backend for both singlecluster and multicluster tests
- Uses a JAVASCRIPT template in MockServer for proper JSON escaping of header values (fixes issues with base64-decoded JSON in headers)
- Adjusts all test assertions to use lowercase header names, matching HTTP/2 reality (Envoy/Istio forwards headers lowercase)

Closes #946

## Changes

### Backend Migration
- `testsuite/tests/singlecluster/conftest.py`: Replaced `Httpbin` backend fixture with `MockserverBackend` using `ClusterIP` service type and `MockserverBackendConfig` for echo expectation
- `testsuite/tests/multicluster/conftest.py`: Same migration for multicluster backends
- `testsuite/resources/echo_expectation.json`: New JAVASCRIPT template that echoes request headers, method, and path with proper JSON escaping via `JSON.stringify()`

### MockServer Enhancements
- `testsuite/backend/mockserver.py`: Added `MockserverBackendConfig` class for ConfigMap-based initialization, configurable `service_type`, and volume/env support
- `testsuite/kubernetes/deployment.py`: Added `env` parameter to `Deployment.create_instance()` for setting container environment variables

### Header Casing Fixes
- Updated 11 test files to use lowercase header names (`header` instead of `Header`, `x-test` instead of `X-Test`, etc.) — HTTP/2 mandates lowercase headers, and MockServer preserves the original casing unlike httpbin which title-cased them
- `testsuite/utils.py`: Updated `extract_response` default header from `Simple` to `simple`

## Verification steps
```bash
poetry run pytest -vv -n4 \
  testsuite/tests/singlecluster/authorino/response/ \
  testsuite/tests/singlecluster/authorino/conditions/section_conditions/test_response_condition.py \
  testsuite/tests/singlecluster/authorino/identity/keycloak/test_keycloak_context.py \
  testsuite/tests/singlecluster/authorino/authorization/opa/test_authorization_services.py \
  testsuite/tests/singlecluster/authorino/operator/clusterwide/test_wildcard_collision.py \
  testsuite/tests/singlecluster/authorino/operator/sharding/test_preexisting_auth.py
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MockServer backend supports ConfigMap-driven startup configuration and selectable service type.
  * Deployments can include injected environment variables.

* **Bug Fixes**
  * Normalised test expectations to use lowercase response header keys.

* **Tests**
  * Session fixtures updated to deploy and manage the MockServer backend and its initialization data.
  * Added JSON test resource providing an echo expectation.

* **Chores**
  * Removed default Httpbin configuration from settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->