### PR TITLE
fix: wait for metric to be 0 before lifecycle test

### DIFF
--- a/testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics_lifecycle.py
+++ b/testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics_lifecycle.py
@@ -31,7 +31,10 @@ def _get_metric_value(prometheus, metric, policy_kind):
 @pytest.mark.flaky(reruns=0)
 def test_metric_policy_lifecycle(request, prometheus, cluster, blame, route, module_label):
     """Tests that policy metrics increment on create and decrement on delete"""
-    initial_counts = {m: _get_metric_value(prometheus, m, "RateLimitPolicy") for m in POLICY_METRICS}
+    for metric in POLICY_METRICS:
+        assert prometheus.wait_for_metric(
+            metric, 0, labels=_metric_labels(metric, "RateLimitPolicy")
+        ), f"Expected '{metric}' to be 0 before test, got {_get_metric_value(prometheus, metric, 'RateLimitPolicy')}"
 
     policy = RateLimitPolicy.create_instance(cluster, blame("rlp-lc"), route, labels={"testRun": module_label})
     request.addfinalizer(policy.delete)
@@ -42,10 +45,10 @@ def test_metric_policy_lifecycle(request, prometheus, cluster, blame, route, mod
     for metric in POLICY_METRICS:
         assert prometheus.wait_for_metric(
             metric,
-            initial_counts[metric] + 1,
+            1,
             labels=_metric_labels(metric, "RateLimitPolicy"),
         ), (
-            f"Expected '{metric}' to be {initial_counts[metric] + 1} on policy creation,"
+            f"Expected '{metric}' to be 1 on policy creation,"
             f" got {_get_metric_value(prometheus, metric, 'RateLimitPolicy')}"
         )
 
@@ -54,9 +57,9 @@ def test_metric_policy_lifecycle(request, prometheus, cluster, blame, route, mod
     for metric in POLICY_METRICS:
         assert prometheus.wait_for_metric(
             metric,
-            initial_counts[metric],
+            0,
             labels=_metric_labels(metric, "RateLimitPolicy"),
         ), (
-            f"Expected '{metric}' to be {initial_counts[metric]} on policy deletion,"
+            f"Expected '{metric}' to be 0 on policy deletion,"
             f" got {_get_metric_value(prometheus, metric, 'RateLimitPolicy')}"
         )


### PR DESCRIPTION
## Description                                                                                                                                                                                                                   
  - Fix flaky `test_metric_policy_lifecycle` failing in nightly runs due to stale metric state from previous test modules                                                                                                          
  - The disruptive test could race with finalizers from earlier test modules that were still decrementing the `kuadrant_policies_total` gauge, causing the captured baseline to be incorrect                                                                                                                                                                                                                        
                                                                                                                                                                                                                                   
  ## Changes                                                                                                                                                                                                                       
  ### Bug Fixes                                                                                                                                                                                                                    
  - Replace dynamic `initial_counts` baseline capture with an explicit `wait_for_metric` call that waits for the gauge to reach 0 before starting the lifecycle test                                                               
  - Use fixed expected values (0 → 1 → 0) instead of relative offsets from a potentially stale baseline                                                                                                                            
                                                                                                                                                                                                                                   
  ## Verification steps                                                                                                                                                                                                            
  ```bash                                                                                                                                                                                                                          
  poetry run pytest -vv testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics_lifecycle.py                                                                                                                      
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced policy metrics lifecycle test validation to verify metrics initialise at zero before policy creation, increment to one upon commit, and return to zero following deletion. Updated corresponding assertions and failure messages for improved test clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->