### PR TITLE
feat: replace hardcoded MetalLB IP pool with Docker network discovery

### DIFF
--- a/make/dependencies.mk
+++ b/make/dependencies.mk
@@ -14,25 +14,9 @@ install-metallb: ## Install MetalLB for LoadBalancer services
 	kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/$(METALLB_VERSION)/config/manifests/metallb-native.yaml
 	kubectl wait --namespace metallb-system --for=condition=Available deployment/controller --timeout=$(METALLB_TIMEOUT)
 	kubectl wait --namespace metallb-system --for=condition=ready pod --selector=component=controller --timeout=$(METALLB_TIMEOUT)
-	@echo "Configuring MetalLB IP pool..."
-	@printf '%s\n' \
-		'apiVersion: metallb.io/v1beta1' \
-		'kind: IPAddressPool' \
-		'metadata:' \
-		'  name: default' \
-		'  namespace: metallb-system' \
-		'spec:' \
-		'  addresses:' \
-		'  - 172.18.255.200-172.18.255.250' \
-		| kubectl apply -f -
-	@printf '%s\n' \
-		'apiVersion: metallb.io/v1beta1' \
-		'kind: L2Advertisement' \
-		'metadata:' \
-		'  name: default' \
-		'  namespace: metallb-system' \
-		| kubectl apply -f -
-	@echo "MetalLB installed with IP pool 172.18.255.200-172.18.255.250"
+	@echo "Configuring MetalLB IP pool from Docker network..."
+	./utils/docker-network-ipaddresspool.sh kind | kubectl apply -n metallb-system -f -
+	@echo "MetalLB installed"
 
 .PHONY: gateway-api-install
 gateway-api-install: ## Install Gateway API CRDs

--- a/make/kind.mk
+++ b/make/kind.mk
@@ -4,7 +4,7 @@
 .PHONY: kind-create-cluster
 kind-create-cluster: ## Create kind cluster
 	@echo "Creating kind cluster '$(KIND_CLUSTER_NAME)'..."
-	@kind create cluster --name $(KIND_CLUSTER_NAME) || echo "Cluster already exists"
+	@KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) kind create cluster --name $(KIND_CLUSTER_NAME) || echo "Cluster already exists"
 
 .PHONY: kind-delete-cluster
 kind-delete-cluster: ## Delete kind cluster

--- a/make/vars.mk
+++ b/make/vars.mk
@@ -3,6 +3,7 @@
 
 # Kind cluster configuration
 KIND_CLUSTER_NAME ?= kuadrant-local
+CONTAINER_ENGINE ?= docker
 
 # Gateway provider (istio or envoygateway)
 GATEWAYAPI_PROVIDER ?= istio

--- a/utils/docker-network-ipaddresspool.sh
+++ b/utils/docker-network-ipaddresspool.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Generates a MetalLB IpAddressPool for the given docker network.
+# https://metallb.org/configuration/#defining-the-ips-to-assign-to-the-load-balancer-services
+#
+# Example:
+# ./utils/docker-network-ipaddresspool.sh kind | kubectl apply -n metallb-system -f -
+
+set -euo pipefail
+
+networkName=$1
+CONTAINER_ENGINE="${CONTAINER_ENGINE:-docker}"
+
+SUBNET=""
+set +e
+if [[ "$CONTAINER_ENGINE" == "podman" ]]; then
+  SUBNET=$(podman network inspect -f '{{range .Subnets}}{{if eq (len .Subnet.IP) 4}}{{.Subnet}}{{end}}{{end}}' $networkName)
+else
+  SUBNET=$(docker network inspect $networkName --format '{{json .IPAM.Config}}' | yq '.[] | select( .Subnet | test("^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}/\d+$")) | .Subnet')
+fi
+set -e
+
+if [[ -z "$SUBNET" ]]; then
+  echo "Error: parsing IPv4 network address for '$networkName' docker network"
+  exit 1
+fi
+
+network=$(echo $SUBNET | cut -d/ -f1)
+# shellcheck disable=SC2206
+octets=(${network//./ })
+
+address="${octets[0]}.${octets[1]}.${octets[2]}.0/28"
+
+echo "IPAddressPool address: '$address' (subnet: '$SUBNET')" >&2
+
+cat <<EOF | ADDRESS=$address yq '(select(.kind == "IPAddressPool") | .spec.addresses[0]) = env(ADDRESS)'
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: kuadrant-local
+spec:
+  addresses: []
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: empty
+EOF


### PR DESCRIPTION
## Summary

- Replaced the hardcoded `172.18.255.200-172.18.255.250` MetalLB IP address pool with dynamic Docker/Podman network discovery, matching how `kuadrant-operator` handles it
- Added `utils/docker-network-ipaddresspool.sh` which inspects the container network at runtime and calculates a valid IP range from the actual subnet
- Added `CONTAINER_ENGINE` variable (defaults to `docker`) and passed it to `kind create cluster` via `KIND_EXPERIMENTAL_PROVIDER`, enabling Podman support

### What changed

| File | Change |
|------|--------|
| `utils/docker-network-ipaddresspool.sh` | New script — discovers the Docker/Podman network subnet and generates MetalLB `IPAddressPool` + `L2Advertisement` YAML |
| `make/dependencies.mk` | `install-metallb` now calls the discovery script instead of applying a hardcoded IP range |
| `make/kind.mk` | `kind-create-cluster` passes `KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE)` for Docker/Podman support |
| `make/vars.mk` | Added `CONTAINER_ENGINE ?= docker` |

### Why

The hardcoded IP range `172.18.255.200-172.18.255.250` assumes the Kind Docker network always uses `172.18.0.0/16`, which breaks on Podman setups or non-default Docker bridge configurations. The `kuadrant-operator` repo already solved this with the same network inspection approach — this PR brings that pattern to the testsuite.

### Requires

`yq` must be installed locally (used by the discovery script to parse Docker network JSON and template the YAML).

## Test plan

- [ ] Run `make local-setup` on a fresh Kind cluster — MetalLB should discover IPs from the actual Docker network
- [ ] Verify with `kubectl get ipaddresspool -n metallb-system -o yaml` — addresses should reflect the discovered subnet
- [ ] Run `CONTAINER_ENGINE=podman make local-setup` on a Podman setup (if available)