### PR TITLE
refactor: change mtls identity method name to x509

### DIFF
--- a/testsuite/kuadrant/policy/authorization/sections.py
+++ b/testsuite/kuadrant/policy/authorization/sections.py
@@ -111,8 +111,8 @@ class IdentitySection(Section):
         super().add_item(name, value, **common_features)
 
     @modify
-    def add_mtls(self, name: str, selector: Selector, *, source: X509Source = None, **common_features):
-        """Adds mTLS identity
+    def add_x509(self, name: str, selector: Selector, *, source: X509Source = None, **common_features):
+        """Adds x509 identity
         Args:
             :param name: name of the identity
             :param selector: selector to match

--- a/testsuite/tests/singlecluster/authorino/identity/x509/conftest.py
+++ b/testsuite/tests/singlecluster/authorino/identity/x509/conftest.py
@@ -84,7 +84,7 @@ def client_ca_secret(create_secret, client_ca, certificate_selector_labels):
 @pytest.fixture(scope="module")
 def authorization(authorization, certificate_selector_labels, client_ca_secret):  # pylint: disable=unused-argument
     """AuthPolicy with x509 identity configured, matching certificates secrets selected by the label"""
-    authorization.identity.add_mtls(
+    authorization.identity.add_x509(
         "x509", Selector(matchLabels=certificate_selector_labels), source=X509Source(xfccHeader=XFCC_HEADER_NAME)
     )
     return authorization

--- a/testsuite/tests/singlecluster/authorino/identity/x509/gateway_validation/test_multi_ca_trust.py
+++ b/testsuite/tests/singlecluster/authorino/identity/x509/gateway_validation/test_multi_ca_trust.py
@@ -83,7 +83,7 @@ def ca_secret_team_b(create_secret, certificates, certificate_selector_labels):
 def authorization(authorization, certificate_selector_labels):
     """AuthPolicy with x509 identity selecting multiple CA secrets by label"""
     authorization.identity.clear_all()
-    authorization.identity.add_mtls(
+    authorization.identity.add_x509(
         "x509",
         Selector(matchLabels=certificate_selector_labels),
         source=X509Source(xfccHeader=XFCC_HEADER_NAME),

--- a/testsuite/tests/singlecluster/authorino/identity/x509/test_cel_expression.py
+++ b/testsuite/tests/singlecluster/authorino/identity/x509/test_cel_expression.py
@@ -19,7 +19,7 @@ CERT_HEADER_NAME = "pem-encoded-client-cert"
 def authorization(authorization, certificate_selector_labels, client_ca_secret):  # pylint: disable=unused-argument
     """AuthPolicy with x509 identity configured to extract certificate via CEL expression"""
     authorization.identity.clear_all()
-    authorization.identity.add_mtls(
+    authorization.identity.add_x509(
         "x509",
         Selector(matchLabels=certificate_selector_labels),
         source=X509Source(expression=f'request.headers["{CERT_HEADER_NAME}"]'),

--- a/testsuite/tests/singlecluster/authorino/identity/x509/test_client_cert_header.py
+++ b/testsuite/tests/singlecluster/authorino/identity/x509/test_client_cert_header.py
@@ -20,7 +20,7 @@ CLIENT_CERT_HEADER_NAME = "Client-Cert"
 def authorization(authorization, certificate_selector_labels, client_ca_secret):  # pylint: disable=unused-argument
     """AuthPolicy with x509 identity configured to read from Client-Cert header"""
     authorization.identity.clear_all()
-    authorization.identity.add_mtls(
+    authorization.identity.add_x509(
         "x509",
         Selector(matchLabels=certificate_selector_labels),
         source=X509Source(clientCertHeader=CLIENT_CERT_HEADER_NAME),

--- a/testsuite/tests/singlecluster/authorino/operator/x509/gateway_validation/conftest.py
+++ b/testsuite/tests/singlecluster/authorino/operator/x509/gateway_validation/conftest.py
@@ -10,7 +10,7 @@ from testsuite.kuadrant.policy.authorization import Pattern
 @pytest.fixture(scope="module", autouse=True)
 def authorization(authorization, blame, selector, cert_attributes):
     """Create AuthConfig with x509 identity and pattern matching rule"""
-    authorization.identity.add_mtls(blame("x509"), selector=selector)
+    authorization.identity.add_x509(blame("x509"), selector=selector)
 
     rule_organization = Pattern("auth.identity.Organization", "incl", cert_attributes["O"])
     authorization.authorization.add_auth_rules(blame("redhat"), [rule_organization])
@@ -20,7 +20,7 @@ def authorization(authorization, blame, selector, cert_attributes):
 
 @pytest.fixture(scope="module")
 def certificates(cfssl, authorino_domain, wildcard_domain, cert_attributes, cert_attributes_other):
-    """Certificate hierarchy used for the mTLS tests"""
+    """Certificate hierarchy used for the x509 tests"""
     chain = {
         "envoy_ca": CertInfo(
             children={

--- a/testsuite/tests/singlecluster/authorino/operator/x509/gateway_validation/test_x509_cel_source.py
+++ b/testsuite/tests/singlecluster/authorino/operator/x509/gateway_validation/test_x509_cel_source.py
@@ -10,7 +10,7 @@ pytestmark = [pytest.mark.authorino, pytest.mark.standalone_only]
 @pytest.fixture(scope="module", autouse=True)
 def authorization(authorization, blame, selector):
     """AuthConfig with x509 identity using CEL expression for certificate source"""
-    authorization.identity.add_mtls(
+    authorization.identity.add_x509(
         blame("x509"), selector=selector, source=X509Source(expression="source.certificate")
     )
     return authorization


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                       
  Renamed `add_mtls` method to `add_x509` in the `IdentitySection` class and updated all call sites to align naming
                                                                                                                                                                                                                                   
  ## Verification steps                                                                                                                                                                                                                     
  Existing x509 identity tests should pass
  ```
 make testsuite/tests/singlecluster/authorino/identity/x509/
 make testsuite/tests/singlecluster/authorino/operator/x509/ flags=--standalone
 ```