### PR TITLE
refactor: add system_project fixture

### DIFF
--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -387,6 +387,12 @@ def cluster(testconfig):
 
 
 @pytest.fixture(scope="session")
+def system_project(testconfig, cluster):
+    """Kubernetes client for the Kuadrant system namespace"""
+    return cluster.change_project(testconfig["service_protection"]["system_project"])
+
+
+@pytest.fixture(scope="session")
 def exposer(request, testconfig, cluster) -> Exposer:
     """Exposer object instance"""
     exposer = testconfig["default_exposer"](cluster)

--- a/testsuite/tests/multicluster/coredns/three_clusters/conftest.py
+++ b/testsuite/tests/multicluster/coredns/three_clusters/conftest.py
@@ -22,9 +22,9 @@ def cluster3(testconfig):
 
 
 @pytest.fixture(scope="module")
-def set_delegate_mode(request, cluster3, testconfig):
+def set_delegate_mode(request, cluster3, system_project):
     """Configures cluster3 as a secondary cluster by patching dns-operator configmap with DELEGATION_ROLE: secondary"""
-    system_project = cluster3.change_project(testconfig["service_protection"]["system_project"])
+    system_project = cluster3.change_project(system_project.project)
 
     # add finalizer to remove the DELEGATION_ROLE patch and restart the controller, ORDER MATTERS
     dns_operator_controller = system_project.get_deployment("dns-operator-controller-manager")

--- a/testsuite/tests/multicluster/coredns/three_clusters/test_one_primary_two_secondary.py
+++ b/testsuite/tests/multicluster/coredns/three_clusters/test_one_primary_two_secondary.py
@@ -11,9 +11,9 @@ pytestmark = [pytest.mark.coredns_one_primary]
 
 
 @pytest.fixture(scope="module")
-def set_delegate_mode(request, set_delegate_mode, cluster2, testconfig):  # pylint: disable=unused-argument
+def set_delegate_mode(request, set_delegate_mode, cluster2, system_project):  # pylint: disable=unused-argument
     """Configures secondary cluster by patching dns-operator-controller-env configmap with DELEGATION_ROLE: secondary"""
-    system_project = cluster2.change_project(testconfig["service_protection"]["system_project"])
+    system_project = cluster2.change_project(system_project.project)
 
     # add finalizer to remove the DELEGATION_ROLE patch and restart the controller, ORDER MATTERS
     dns_operator_controller = system_project.get_deployment("dns-operator-controller-manager")
@@ -33,7 +33,7 @@ def set_delegate_mode(request, set_delegate_mode, cluster2, testconfig):  # pyli
 
 
 @pytest.fixture(scope="module")
-def kubeconfig_secrets(testconfig, cluster, cluster2, cluster3, blame, module_label):
+def kubeconfig_secrets(system_project, cluster2, cluster3, blame, module_label):
     """Creates Opaque secrets containing kubeconfigs for secondaries cluster2 and cluster3, on the primary cluster"""
     tools2 = cluster2.change_project("tools")
     coredns_sa2 = tools2.get_service_account("coredns")
@@ -47,7 +47,7 @@ def kubeconfig_secrets(testconfig, cluster, cluster2, cluster3, blame, module_la
     for k in [kubeconfig2, kubeconfig3]:
         secrets.append(
             Secret.create_instance(
-                cluster.change_project(testconfig["service_protection"]["system_project"]),
+                system_project,
                 blame("kubecfg"),
                 {"kubeconfig": k},
                 secret_type="Opaque",

--- a/testsuite/tests/multicluster/coredns/three_clusters/test_two_primary_one_secondary.py
+++ b/testsuite/tests/multicluster/coredns/three_clusters/test_two_primary_one_secondary.py
@@ -11,7 +11,9 @@ pytestmark = [pytest.mark.coredns_two_primaries]
 
 
 @pytest.fixture(scope="module")
-def kubeconfig_secrets(testconfig, blame, module_label, cluster, cluster2, cluster3):  # pylint: disable=too-many-locals
+def kubeconfig_secrets(
+    system_project, blame, module_label, cluster, cluster2, cluster3
+):  # pylint: disable=too-many-locals
     """Creates Opaque secrets containing kubeconfig for primaries, and secondary cluster3 on the both primaries"""
     tools = cluster.change_project("tools")
     coredns_sa = tools.get_service_account("coredns")
@@ -29,7 +31,7 @@ def kubeconfig_secrets(testconfig, blame, module_label, cluster, cluster2, clust
     for c, k in [(cluster, kubeconfig2), (cluster, kubeconfig3), (cluster2, kubeconfig), (cluster2, kubeconfig3)]:
         kubeconfig_secrets.append(
             Secret.create_instance(
-                c.change_project(testconfig["service_protection"]["system_project"]),
+                c.change_project(system_project.project),
                 blame("kubecfg"),
                 {"kubeconfig": k},
                 secret_type="Opaque",

--- a/testsuite/tests/multicluster/coredns/two_clusters/conftest.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/conftest.py
@@ -4,9 +4,9 @@ import pytest
 
 
 @pytest.fixture(scope="module")
-def set_delegate_mode(request, cluster2, testconfig):
+def set_delegate_mode(request, cluster2, system_project):
     """Configures secondary cluster by patching dns-operator-controller-env configmap with DELEGATION_ROLE: secondary"""
-    system_project = cluster2.change_project(testconfig["service_protection"]["system_project"])
+    system_project = cluster2.change_project(system_project.project)
 
     # add finalizer to remove the DELEGATION_ROLE patch and restart the controller, ORDER MATTERS
     dns_operator_controller = system_project.get_deployment("dns-operator-controller-manager")

--- a/testsuite/tests/multicluster/coredns/two_clusters/kubectl_dns/test_secret_generation.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/kubectl_dns/test_secret_generation.py
@@ -21,12 +21,11 @@ def kubectl_dns(testconfig, skip_or_fail):
 
 
 @pytest.fixture(scope="module")
-def kubeconfig_secrets(request, testconfig, cluster, cluster2, kubectl_dns, blame):
+def kubeconfig_secrets(request, system_project, cluster, cluster2, kubectl_dns, blame):
     """Run add-cluster-secret command on merged kubeconfig to generate kubeconfig secret for the secondary cluster"""
-    system_project = testconfig["service_protection"]["system_project"]
     secret_name = blame("kubecfg")
     request.addfinalizer(
-        lambda: cluster.do_action("delete", "secret", secret_name, "-n", system_project, "--ignore-not-found")
+        lambda: cluster.do_action("delete", "secret", secret_name, "-n", system_project.project, "--ignore-not-found")
     )
 
     merged_kubeconfig = cluster.create_merged_kubeconfig(cluster2)
@@ -37,7 +36,7 @@ def kubeconfig_secrets(request, testconfig, cluster, cluster2, kubectl_dns, blam
         "--context",
         cluster2.current_context_name,
         "--namespace",
-        system_project,
+        system_project.project,
         "--service-account",
         "coredns",
         env={"KUBECONFIG": merged_kubeconfig},

--- a/testsuite/tests/multicluster/coredns/two_clusters/metrics/conftest.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/metrics/conftest.py
@@ -10,7 +10,7 @@ pytestmark = [pytest.mark.multicluster, pytest.mark.disruptive]
 
 
 @pytest.fixture(scope="module")
-def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
+def kubeconfig_secrets(system_project, cluster2, blame, module_label):
     """Creates Opaque secrets containing kubeconfig for the secondary cluster2 on primary cluster"""
     tools2 = cluster2.change_project("tools")
     coredns_sa2 = tools2.get_service_account("coredns")
@@ -18,7 +18,7 @@ def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
 
     return [
         Secret.create_instance(
-            cluster.change_project(testconfig["service_protection"]["system_project"]),
+            system_project,
             blame("kubecfg"),
             {"kubeconfig": kubeconfig2},
             secret_type="Opaque",
@@ -28,9 +28,8 @@ def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
 
 
 @pytest.fixture(scope="package")
-def service_monitor(cluster, request, testconfig, blame):
+def service_monitor(system_project, request, blame):
     """Create ServiceMonitor object to follow DNS Operator controller /metrics endpoint"""
-    system_project = cluster.change_project(testconfig["service_protection"]["system_project"])
     endpoints = [MetricsEndpoint("/metrics", "metrics")]
     match_labels = {"control-plane": "dns-operator-controller-manager"}
     monitor = ServiceMonitor.create_instance(system_project, blame("sm"), endpoints, match_labels=match_labels)

--- a/testsuite/tests/multicluster/coredns/two_clusters/test_authoritative_record_removal.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/test_authoritative_record_removal.py
@@ -12,7 +12,7 @@ pytestmark = [pytest.mark.coredns_one_primary]
 
 
 @pytest.fixture(scope="module")
-def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
+def kubeconfig_secrets(system_project, cluster2, blame, module_label):
     """Creates Opaque secrets containing kubeconfigs for the secondary cluster2 on the primary cluster"""
     tools2 = cluster2.change_project("tools")
     coredns_sa2 = tools2.get_service_account("coredns")
@@ -20,7 +20,7 @@ def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
 
     return [
         Secret.create_instance(
-            cluster.change_project(testconfig["service_protection"]["system_project"]),
+            system_project,
             blame("kubecfg"),
             {"kubeconfig": kubeconfig2},
             secret_type="Opaque",

--- a/testsuite/tests/multicluster/coredns/two_clusters/test_delegate_false.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/test_delegate_false.py
@@ -18,7 +18,7 @@ pytestmark = [pytest.mark.coredns_one_primary]
 
 
 @pytest.fixture(scope="module")
-def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
+def kubeconfig_secrets(system_project, cluster2, blame, module_label):
     """Creates Opaque secrets containing kubeconfigs for the secondary cluster2 on the primary cluster"""
     tools2 = cluster2.change_project("tools")
     coredns_sa2 = tools2.get_service_account("coredns")
@@ -26,7 +26,7 @@ def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
 
     return [
         Secret.create_instance(
-            cluster.change_project(testconfig["service_protection"]["system_project"]),
+            system_project,
             blame("kubecfg"),
             {"kubeconfig": kubeconfig2},
             secret_type="Opaque",

--- a/testsuite/tests/multicluster/coredns/two_clusters/test_one_primary_one_secondary.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/test_one_primary_one_secondary.py
@@ -10,7 +10,7 @@ pytestmark = [pytest.mark.coredns_one_primary]
 
 
 @pytest.fixture(scope="module")
-def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
+def kubeconfig_secrets(system_project, cluster2, blame, module_label):
     """Creates Opaque secrets containing kubeconfigs for secondaries cluster2 and cluster3, on the primary cluster"""
     tools2 = cluster2.change_project("tools")
     coredns_sa2 = tools2.get_service_account("coredns")
@@ -18,7 +18,7 @@ def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
 
     return [
         Secret.create_instance(
-            cluster.change_project(testconfig["service_protection"]["system_project"]),
+            system_project,
             blame("kubecfg"),
             {"kubeconfig": kubeconfig2},
             secret_type="Opaque",

--- a/testsuite/tests/multicluster/coredns/two_clusters/test_two_primary.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/test_two_primary.py
@@ -15,7 +15,7 @@ def set_delegate_mode():
 
 
 @pytest.fixture(scope="module")
-def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
+def kubeconfig_secrets(system_project, cluster, cluster2, blame, module_label):
     """Creates Opaque secret containing kubeconfigs for both primary clusters on each other"""
     tools = cluster.change_project("tools")
     coredns_sa = tools.get_service_account("coredns")
@@ -29,7 +29,7 @@ def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
     for c, k in [(cluster, kubeconfig2), (cluster2, kubeconfig)]:
         secrets.append(
             Secret.create_instance(
-                c.change_project(testconfig["service_protection"]["system_project"]),
+                c.change_project(system_project.project),
                 blame("kubecfg"),
                 {"kubeconfig": k},
                 secret_type="Opaque",

--- a/testsuite/tests/multicluster/coredns/two_clusters/test_update_secondary.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/test_update_secondary.py
@@ -13,7 +13,7 @@ pytestmark = [pytest.mark.coredns_one_primary]
 
 
 @pytest.fixture(scope="module")
-def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
+def kubeconfig_secrets(system_project, cluster2, blame, module_label):
     """Creates Opaque secrets containing kubeconfigs for the secondary cluster2 on the primary cluster"""
     tools2 = cluster2.change_project("tools")
     coredns_sa2 = tools2.get_service_account("coredns")
@@ -21,7 +21,7 @@ def kubeconfig_secrets(testconfig, cluster, cluster2, blame, module_label):
 
     return [
         Secret.create_instance(
-            cluster.change_project(testconfig["service_protection"]["system_project"]),
+            system_project,
             blame("kubecfg"),
             {"kubeconfig": kubeconfig2},
             secret_type="Opaque",

--- a/testsuite/tests/multicluster/global_rate_limiting/conftest.py
+++ b/testsuite/tests/multicluster/global_rate_limiting/conftest.py
@@ -13,23 +13,17 @@ from testsuite.gateway.gateway_api.gateway import KuadrantGateway
 
 
 @pytest.fixture(scope="session")
-def kuadrant1(testconfig, cluster):
+def kuadrant1(system_project):
     """Returns the existing Kuadrant instance from the first cluster."""
-    project = testconfig["service_protection"]["system_project"]
-    kuadrant_cluster = cluster.change_project(project)
-
-    with kuadrant_cluster.context:
+    with system_project.context:
         kuadrant = selector("kuadrant").object(cls=KuadrantCR)
     return kuadrant
 
 
 @pytest.fixture(scope="session")
-def kuadrant2(testconfig, cluster2):
+def kuadrant2(system_project, cluster2):
     """Returns the existing Kuadrant instance from the second cluster."""
-    project = testconfig["service_protection"]["system_project"]
-    kuadrant_cluster = cluster2.change_project(project)
-
-    with kuadrant_cluster.context:
+    with cluster2.change_project(system_project.project).context:
         kuadrant = selector("kuadrant").object(cls=KuadrantCR)
     return kuadrant
 
@@ -57,10 +51,8 @@ def storage_service(testconfig, request, skip_or_fail):
 
 
 @pytest.fixture(scope="module")
-def storage_secret1(testconfig, cluster, blame, request, storage_service):
+def storage_secret1(system_project, blame, request, storage_service):
     """Creates the Secret for Limitador in the first cluster."""
-    system_project = cluster.change_project(testconfig["service_protection"]["system_project"])
-
     secret = Secret.create_instance(system_project, blame("storage-secret"), {"URL": storage_service})
     request.addfinalizer(secret.delete)
     secret.commit()
@@ -68,11 +60,10 @@ def storage_secret1(testconfig, cluster, blame, request, storage_service):
 
 
 @pytest.fixture(scope="module")
-def storage_secret2(testconfig, cluster2, blame, request, storage_service):
+def storage_secret2(system_project, cluster2, blame, request, storage_service):
     """Creates the Secret for Limitador in the second cluster."""
-    system_project = cluster2.change_project(testconfig["service_protection"]["system_project"])
-
-    secret = Secret.create_instance(system_project, blame("storage-secret-cl2"), {"URL": storage_service})
+    cluster2_system = cluster2.change_project(system_project.project)
+    secret = Secret.create_instance(cluster2_system, blame("storage-secret-cl2"), {"URL": storage_service})
     request.addfinalizer(secret.delete)
     secret.commit()
     return secret

--- a/testsuite/tests/singlecluster/authorino/authorization/spicedb/test_spicedb.py
+++ b/testsuite/tests/singlecluster/authorino/authorization/spicedb/test_spicedb.py
@@ -78,14 +78,14 @@ def spicedb_route(exposer, request, spicedb, blame, cluster):
 
 
 @pytest.fixture(scope="module")
-def secret_name(request, cluster, module_label, kuadrant, blame, testconfig, spicedb):
+def secret_name(request, cluster, module_label, kuadrant, blame, system_project, spicedb):
     """
     Creates a secret containing the SpiceDB preshared key for Authorino to use.
     The secret is created in Authorino's namespace.
     """
     secret_name = blame("spicedb")
     if kuadrant:
-        cluster = cluster.change_project(testconfig["service_protection"]["system_project"])
+        cluster = system_project
     secret = Secret.create_instance(
         cluster,
         secret_name,

--- a/testsuite/tests/singlecluster/authorino/identity/x509/conftest.py
+++ b/testsuite/tests/singlecluster/authorino/identity/x509/conftest.py
@@ -62,12 +62,11 @@ def certificate_selector_labels(blame):
 
 
 @pytest.fixture(scope="module")
-def create_secret(blame, request, testconfig, cluster):
+def create_secret(blame, request, system_project):
     """Factory for creating Secrets in the system namespace"""
 
     def _create_secret(name, string_data, labels=None):
-        sys_proj = cluster.change_project(testconfig["service_protection"]["system_project"])
-        secret = Secret.create_instance(sys_proj, blame(name), stringData=string_data, labels=labels)
+        secret = Secret.create_instance(system_project, blame(name), stringData=string_data, labels=labels)
         request.addfinalizer(secret.delete)
         secret.commit()
         return secret

--- a/testsuite/tests/singlecluster/conftest.py
+++ b/testsuite/tests/singlecluster/conftest.py
@@ -71,16 +71,12 @@ def commit(request, authorization, rate_limit):
 
 
 @pytest.fixture(scope="session")
-def kuadrant(request, testconfig):
+def kuadrant(request, system_project):
     """Returns Kuadrant instance if exists, or None"""
     if request.config.getoption("--standalone"):
         return None
 
-    ocp = testconfig["control_plane"]["cluster"]
-    project = testconfig["service_protection"]["system_project"]
-    kuadrant_openshift = ocp.change_project(project)
-
-    with kuadrant_openshift.context:
+    with system_project.context:
         kuadrant = selector("kuadrant").object(cls=KuadrantCR)
 
     return kuadrant

--- a/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection_by_destination.py
+++ b/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection_by_destination.py
@@ -82,9 +82,8 @@ def service2_api_secret(request, cluster, blame, module_label):
 
 
 @pytest.fixture(scope="module")
-def sa_token_secret(request, testconfig, cluster, blame, module_label):
+def sa_token_secret(request, system_project, blame, module_label):
     """Opaque Secret containing a token from Authorino's ServiceAccount for K8s API auth"""
-    system_project = cluster.change_project(testconfig["service_protection"]["system_project"])
     authorino_sa = system_project.get_service_account("authorino-authorino")
     token = authorino_sa.get_auth_token()
     secret = Secret.create_instance(

--- a/testsuite/tests/singlecluster/extensions/telemetry_policy/conftest.py
+++ b/testsuite/tests/singlecluster/extensions/telemetry_policy/conftest.py
@@ -11,9 +11,8 @@ from testsuite.kubernetes.monitoring.service_monitor import ServiceMonitor
 
 
 @pytest.fixture(scope="package")
-def service_monitor(cluster, request, testconfig, blame, kuadrant):
+def service_monitor(system_project, request, blame, kuadrant):
     """Create ServiceMonitor object to follow limitador-limitador service on /metrics endpoint"""
-    system_project = cluster.change_project(testconfig["service_protection"]["system_project"])
     endpoints = [MetricsEndpoint("/metrics", "http")]
     match_labels = {"app": kuadrant.limitador.name()}
     monitor = ServiceMonitor.create_instance(system_project, blame("sm"), endpoints, match_labels=match_labels)

--- a/testsuite/tests/singlecluster/gateway/mtls/conftest.py
+++ b/testsuite/tests/singlecluster/gateway/mtls/conftest.py
@@ -54,13 +54,12 @@ def wait_for_status(kuadrant):
 
 
 @pytest.fixture(scope="module")
-def wait_for_injected_pod(cluster, testconfig):
+def wait_for_injected_pod(system_project):
     """Waits for a sidecar-injected pod (Authorino or Limitador)"""
 
     @backoff.on_predicate(backoff.fibo, lambda result: result is None, max_tries=7, jitter=None)
     def _wait(component_label):
-        project = cluster.change_project(testconfig["service_protection"]["system_project"])
-        with project.context:
+        with system_project.context:
             pods = selector("pods", labels={f"{component_label}-resource": component_label}).objects()
             for pod in pods:
                 labels = pod.model.metadata.labels

--- a/testsuite/tests/singlecluster/gateway/mtls/test_mtls_configuration.py
+++ b/testsuite/tests/singlecluster/gateway/mtls/test_mtls_configuration.py
@@ -16,7 +16,7 @@ component_cases = [
 
 @pytest.mark.parametrize("component", component_cases, indirect=True)
 def test_peer_authentication_resource_applied(
-    kuadrant, cluster, component, wait_for_status, reset_mtls, testconfig, rate_limit, authorization, configure_mtls
+    kuadrant, component, wait_for_status, reset_mtls, system_project, rate_limit, authorization, configure_mtls
 ):  # pylint: disable=unused-argument
     """Verify PeerAuthentication with STRICT mode is created when mTLS is enabled"""
     configure_mtls(True)
@@ -24,8 +24,7 @@ def test_peer_authentication_resource_applied(
     for comp in component:
         wait_for_status(expected=True, component=comp)
 
-    project = cluster.change_project(testconfig["service_protection"]["system_project"])
-    with project.context:
+    with system_project.context:
         peer_auths = selector("peerauthentication").objects()
         assert peer_auths, "No PeerAuthentication resources found"
 

--- a/testsuite/tests/singlecluster/limitador/metrics/conftest.py
+++ b/testsuite/tests/singlecluster/limitador/metrics/conftest.py
@@ -7,12 +7,10 @@ from testsuite.kubernetes.monitoring.pod_monitor import PodMonitor
 
 
 @pytest.fixture(scope="module")
-def pod_monitor(cluster, testconfig, request, blame, limitador):
+def pod_monitor(system_project, request, blame, limitador):
     """Creates Pod Monitor object to watch over '/metrics' endpoint of limitador pod"""
-    project = cluster.change_project(testconfig["service_protection"]["system_project"])
-
     endpoints = [MetricsEndpoint("/metrics", "http")]
-    monitor = PodMonitor.create_instance(project, blame("pd"), endpoints, match_labels={"app": limitador.name()})
+    monitor = PodMonitor.create_instance(system_project, blame("pd"), endpoints, match_labels={"app": limitador.name()})
     request.addfinalizer(monitor.delete)
     monitor.commit()
     return monitor

--- a/testsuite/tests/singlecluster/limitador/storage/db/conftest.py
+++ b/testsuite/tests/singlecluster/limitador/storage/db/conftest.py
@@ -17,9 +17,8 @@ def storage_service(testconfig, request, skip_or_fail):
 
 
 @pytest.fixture(scope="package")
-def storage_secret(testconfig, cluster, blame, request, storage_service):
+def storage_secret(system_project, blame, request, storage_service):
     """Secret created in system_project for use by LimitadorCR"""
-    system_project = cluster.change_project(testconfig["service_protection"]["system_project"])
     secret = Secret.create_instance(system_project, blame("storage-secret"), {"URL": storage_service})
     request.addfinalizer(secret.delete)
     secret.commit()

--- a/testsuite/tests/singlecluster/observability/conftest.py
+++ b/testsuite/tests/singlecluster/observability/conftest.py
@@ -4,7 +4,6 @@ import backoff
 import pytest
 from openshift_client import selector
 
-from testsuite.config import settings
 from testsuite.kubernetes.monitoring.pod_monitor import PodMonitor
 from testsuite.kubernetes.monitoring.service_monitor import ServiceMonitor
 
@@ -35,9 +34,9 @@ def require_observability_enabled(kuadrant, skip_or_fail):
 
 
 @pytest.fixture(scope="module")
-def service_monitors(cluster, testconfig):
+def service_monitors(system_project):
     """Return all 5 expected ServiceMonitors created when observability is enabled"""
-    context = cluster.change_project(testconfig["service_protection"]["system_project"]).context
+    context = system_project.context
 
     @backoff.on_predicate(backoff.constant, lambda x: len(x) == 5, interval=5, max_tries=12, jitter=None)
     def wait_for_monitors():
@@ -105,9 +104,7 @@ def kuadrant_service_monitor(service_monitors):
 
 
 @pytest.fixture(scope="module")
-def kuadrant_operator_metrics(prometheus, kuadrant_service_monitor):
+def kuadrant_operator_metrics(prometheus, kuadrant_service_monitor, system_project):
     """Return all metrics from the Kuadrant operator metrics endpoint"""
     prometheus.wait_for_scrape(kuadrant_service_monitor, "/metrics")
-    return prometheus.get_metrics(
-        labels={"service": "kuadrant-operator-metrics", "namespace": settings["service_protection"]["system_project"]}
-    )
+    return prometheus.get_metrics(labels={"service": "kuadrant-operator-metrics", "namespace": system_project.project})

--- a/testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics.py
+++ b/testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics.py
@@ -4,7 +4,6 @@ import operator
 
 import pytest
 
-from testsuite.config import settings
 from testsuite.gateway import Exposer, TLSGatewayListener
 from testsuite.prometheus import has_label
 from testsuite.gateway.gateway_api.gateway import KuadrantGateway
@@ -118,11 +117,11 @@ def test_metric_kuadrant_policies_total(kuadrant_operator_metrics, policy_kind):
 
 
 @pytest.mark.parametrize("policy_kind", POLICY_KINDS)
-def test_metric_kuadrant_policies_enforced(prometheus, policy_kind):
+def test_metric_kuadrant_policies_enforced(prometheus, policy_kind, system_project):
     """Tests that kuadrant_policies_enforced metric has value >= 1 for each enforced policy kind"""
     labels = {
         "service": "kuadrant-operator-metrics",
-        "namespace": settings["service_protection"]["system_project"],
+        "namespace": system_project.project,
         "kind": policy_kind,
         "status": "true",
     }

--- a/testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics_lifecycle.py
+++ b/testsuite/tests/singlecluster/observability/test_kuadrant_policy_metrics_lifecycle.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from testsuite.config import settings
 from testsuite.kuadrant.policy.rate_limit import RateLimitPolicy, Limit
 
 pytestmark = [pytest.mark.observability, pytest.mark.disruptive]
@@ -10,31 +9,33 @@ pytestmark = [pytest.mark.observability, pytest.mark.disruptive]
 POLICY_METRICS = ["kuadrant_policies_total", "kuadrant_policies_enforced"]
 
 
-def _metric_labels(metric, policy_kind):
+def _metric_labels(metric, policy_kind, namespace):
     """Return Prometheus query labels for a given metric and policy kind"""
     labels = {
         "service": "kuadrant-operator-metrics",
         "kind": policy_kind,
-        "namespace": settings["service_protection"]["system_project"],
+        "namespace": namespace,
     }
     if metric == "kuadrant_policies_enforced":
         labels["status"] = "true"
     return labels
 
 
-def _get_metric_value(prometheus, metric, policy_kind):
+def _get_metric_value(prometheus, metric, policy_kind, namespace):
     """Helper to get current metric value for a given policy kind"""
-    metrics = prometheus.get_metrics(key=metric, labels=_metric_labels(metric, policy_kind))
+    metrics = prometheus.get_metrics(key=metric, labels=_metric_labels(metric, policy_kind, namespace))
     return metrics.values[0] if metrics.values else 0
 
 
 @pytest.mark.flaky(reruns=0)
-def test_metric_policy_lifecycle(request, prometheus, cluster, blame, route, module_label):
+def test_metric_policy_lifecycle(request, prometheus, cluster, blame, route, module_label, system_project):
     """Tests that policy metrics increment on create and decrement on delete"""
+    namespace = system_project.project
     for metric in POLICY_METRICS:
-        assert prometheus.wait_for_metric(
-            metric, 0, labels=_metric_labels(metric, "RateLimitPolicy")
-        ), f"Expected '{metric}' to be 0 before test, got {_get_metric_value(prometheus, metric, 'RateLimitPolicy')}"
+        assert prometheus.wait_for_metric(metric, 0, labels=_metric_labels(metric, "RateLimitPolicy", namespace)), (
+            f"Expected '{metric}' to be 0 before test,"
+            f" got {_get_metric_value(prometheus, metric, 'RateLimitPolicy', namespace)}"
+        )
 
     policy = RateLimitPolicy.create_instance(cluster, blame("rlp-lc"), route, labels={"testRun": module_label})
     request.addfinalizer(policy.delete)
@@ -46,10 +47,10 @@ def test_metric_policy_lifecycle(request, prometheus, cluster, blame, route, mod
         assert prometheus.wait_for_metric(
             metric,
             1,
-            labels=_metric_labels(metric, "RateLimitPolicy"),
+            labels=_metric_labels(metric, "RateLimitPolicy", namespace),
         ), (
             f"Expected '{metric}' to be 1 on policy creation,"
-            f" got {_get_metric_value(prometheus, metric, 'RateLimitPolicy')}"
+            f" got {_get_metric_value(prometheus, metric, 'RateLimitPolicy', namespace)}"
         )
 
     policy.delete()
@@ -58,8 +59,8 @@ def test_metric_policy_lifecycle(request, prometheus, cluster, blame, route, mod
         assert prometheus.wait_for_metric(
             metric,
             0,
-            labels=_metric_labels(metric, "RateLimitPolicy"),
+            labels=_metric_labels(metric, "RateLimitPolicy", namespace),
         ), (
             f"Expected '{metric}' to be 0 on policy deletion,"
-            f" got {_get_metric_value(prometheus, metric, 'RateLimitPolicy')}"
+            f" got {_get_metric_value(prometheus, metric, 'RateLimitPolicy', namespace)}"
         )

--- a/testsuite/tests/singlecluster/tracing/control_plane/conftest.py
+++ b/testsuite/tests/singlecluster/tracing/control_plane/conftest.py
@@ -3,24 +3,20 @@
 import pytest
 import openshift_client as oc
 
-from testsuite.config import settings
 from testsuite.tracing.models import Trace
 
 
 @pytest.fixture(scope="module", autouse=True)
-def require_tracing_enabled(cluster, skip_or_fail):
+def require_tracing_enabled(system_project, skip_or_fail):
     """Skip or fail tests if control plane tracing is not enabled on kuadrant-operator"""
-    namespace = settings["service_protection"]["system_project"]
     deployment_name = "kuadrant-operator-controller-manager"
 
     try:
-        namespace_client = cluster.change_project(namespace)
-
-        with namespace_client.context:
+        with system_project.context:
             deployment = oc.selector(f"deployment/{deployment_name}").object()
 
             if not deployment.exists():
-                skip_or_fail(f"Deployment {deployment_name} not found in namespace {namespace}")
+                skip_or_fail(f"Deployment {deployment_name} not found in namespace {system_project.project}")
 
             selector_labels = deployment.model.spec.selector.matchLabels
             if not selector_labels:


### PR DESCRIPTION
## Summary 
  - Added a session-scoped `system_project` fixture in root conftest that exposes a `KubernetesClient` for the
   Kuadrant system namespace                                                                                  
  - Replaced all `cluster.change_project(testconfig["service_protection"]["system_project"])` instances with the new fixture                                                                   

  ## Verification steps                                                                                            
  Verify the testsuite works after the changes:
```
make kuadrant
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Test infrastructure refactored to streamline fixture management and reduce configuration boilerplate across test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->