### PR TITLE
fix(oidcpolicy): increase timeout to 10sec after the enforcement

### DIFF
--- a/testsuite/kuadrant/extensions/oidc_policy.py
+++ b/testsuite/kuadrant/extensions/oidc_policy.py
@@ -63,4 +63,4 @@ class OIDCPolicy(Policy):
         """Wait for OIDCPolicy to be enforced"""
         super().wait_for_ready()
         # Even after enforced condition OIDCPolicy requires a short sleep
-        time.sleep(5)  # https://github.com/Kuadrant/testsuite/issues/884
+        time.sleep(10)  # https://github.com/Kuadrant/testsuite/issues/884


### PR DESCRIPTION
most tests still fail with 5 seconds timeout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved OIDC policy test reliability by adjusting timing tolerances to accommodate known environmental delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->