### PR TITLE
fix(metrics): scrape server-metrics after sending a request.

### DIFF
--- a/testsuite/page_objects/navigator.py
+++ b/testsuite/page_objects/navigator.py
@@ -9,7 +9,7 @@ from playwright.sync_api import Page, TimeoutError as PlaywrightTimeoutError, Er
 
 NAV_META = "nav_meta"
 NAV_KWARGS = "nav_kwargs"
-step_tree = {}
+step_tree: dict = {}
 
 
 def step(cls, **kwargs):

--- a/testsuite/tests/singlecluster/authorino/metrics/test_metrics.py
+++ b/testsuite/tests/singlecluster/authorino/metrics/test_metrics.py
@@ -45,10 +45,11 @@ def metrics_keys(authorino, service_monitor, prometheus, client, auth):
     return all metrics defined for the Authorino metrics service
     """
     prometheus.wait_for_scrape(service_monitor, "/metrics")
-    prometheus.wait_for_scrape(service_monitor, "/server-metrics")
 
     response = client.get("/get", auth=auth)
     assert response.status_code == 200
+
+    prometheus.wait_for_scrape(service_monitor, "/server-metrics")
 
     return prometheus.get_metrics(labels={"service": authorino.metrics_service.name()}).names
 


### PR DESCRIPTION
## Description

Was scraping the server metrics before sending the request. This was introduced by commit trying to address that sending the request before the scrape will result in the same error on kind as it is way too fast for the scraping to be effective. Now we assert for the metrics that do not require request first and scrape only after the first request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated metrics validation tests to ensure proper sequencing of metrics data collection, improving test reliability for authenticated traffic scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->