### PR TITLE
fix: add global 2s rerun delay to prevent flaky test failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ else
 resultsdir ?= .
 endif
 
-PYTEST = poetry run python -m pytest --tb=$(TB) --reruns 3 -o cache_dir=$(resultsdir)/.pytest_cache.$(@F)
+PYTEST = poetry run python -m pytest --tb=$(TB) --reruns 3 --reruns-delay 2 -o cache_dir=$(resultsdir)/.pytest_cache.$(@F)
 RUNSCRIPT = poetry run ./scripts/
 
 ifdef junit


### PR DESCRIPTION
## Description
 - Adds a global `--reruns-delay 2` to the `PYTEST` command in the `Makefile` to introduce a 2-second pause between test rerun attempts
  - Aims to mitigate flaky failures observed in nightly test runs by giving resources time to settle before retrying