### PR TITLE
fix: return bool instead of tuple in HTTPRoute _ready

### DIFF
--- a/testsuite/gateway/gateway_api/route.py
+++ b/testsuite/gateway/gateway_api/route.py
@@ -131,7 +131,7 @@ class HTTPRoute(KubernetesObject, GatewayRoute):
                     condition_set.controllerName in expected_controllers
                     or "gateway-controller" in condition_set.controllerName  # fallback
                 ):
-                    return (all(x.status == "True" for x in condition_set.conditions),)
+                    return all(x.status == "True" for x in condition_set.conditions)
             return False
 
         success = self.wait_until(_ready, timelimit=10)


### PR DESCRIPTION
## Description
While working on #980 , I found a bug in `route.py`. The `_ready` function in `HTTPRoute.wait_for_ready()` returns a tuple instead of a bool due to a trailing comma.
## Changes
Removed the trailing comma and outer parentheses so _ready returns a plain bool.

## Verification

No behavioral change for the happy path. Fixes the edge case where `False` conditions were incorrectly treated as ready.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected route readiness validation to accurately reflect controller status conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/testsuite/pull/981)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->