### PR TITLE
fix: add missing waits for httproute

### DIFF
--- a/testsuite/tests/singlecluster/grpc/conftest.py
+++ b/testsuite/tests/singlecluster/grpc/conftest.py
@@ -26,6 +26,7 @@ def route(request, gateway, blame, hostname, backend, module_label):
     route.add_backend(backend)
     request.addfinalizer(route.delete)
     route.commit()
+    route.wait_for_ready()
     return route
 
 

--- a/testsuite/tests/singlecluster/grpc/test_grpcroute_rule_targeting.py
+++ b/testsuite/tests/singlecluster/grpc/test_grpcroute_rule_targeting.py
@@ -27,6 +27,7 @@ def route(request, gateway, blame, hostname, backend, module_label):
     route.add_rule(backend, GRPCRouteMatch(method=GRPCMethodMatch(type="Exact", method="DummyUnary")))  # rule-2
     request.addfinalizer(route.delete)
     route.commit()
+    route.wait_for_ready()
     return route
 
 

--- a/testsuite/tests/singlecluster/identical_hostnames/conftest.py
+++ b/testsuite/tests/singlecluster/identical_hostnames/conftest.py
@@ -22,4 +22,5 @@ def route2(request, gateway, blame, hostname, backend, module_label) -> GatewayR
     route.add_backend(backend, "/anything/route2")
     request.addfinalizer(route.delete)
     route.commit()
+    route.wait_for_ready()
     return route

--- a/testsuite/tests/singlecluster/tracing/control_plane/test_control_plane_errors.py
+++ b/testsuite/tests/singlecluster/tracing/control_plane/test_control_plane_errors.py
@@ -23,6 +23,7 @@ def orphan_test_route(request, cluster, blame, gateway, module_label, backend):
     orphan_route.add_backend(backend)
     request.addfinalizer(orphan_route.delete)
     orphan_route.commit()
+    orphan_route.wait_for_ready()
     return orphan_route
 
 

--- a/testsuite/tests/singlecluster/ui/console_plugin/overview/test_overview.py
+++ b/testsuite/tests/singlecluster/ui/console_plugin/overview/test_overview.py
@@ -97,10 +97,12 @@ def test_resources_appear_in_sections(request, navigator, cluster, blame, module
     route.add_backend(backend)
     request.addfinalizer(route.delete)
     route.commit()
+    route.wait_for_ready()
 
     grpc_route = GRPCRoute.create_instance(cluster, blame("grpc"), gateway)
     request.addfinalizer(grpc_route.delete)
     grpc_route.commit()
+    grpc_route.wait_for_ready()
 
     policy_name = blame("policy")
     policy = AuthPolicy.create_instance(cluster, policy_name, gateway)

--- a/testsuite/tests/singlecluster/ui/console_plugin/topology/conftest.py
+++ b/testsuite/tests/singlecluster/ui/console_plugin/topology/conftest.py
@@ -27,6 +27,7 @@ def grpc_route(request, gateway, cluster, blame, module_label):
     grpc_route = GRPCRoute.create_instance(cluster, blame("grpc"), gateway, {"app": module_label})
     request.addfinalizer(grpc_route.delete)
     grpc_route.commit()
+    grpc_route.wait_for_ready()
     return grpc_route
 
 


### PR DESCRIPTION
## Summary

Add missing waits for httproute. Adding the missing wait on the route fixture in singlecluster's conftest triggered a few sporadic testsuite failures, so I made a follow-up issue for it: #984


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added explicit readiness checks for newly created routes across multiple test suites (gRPC, HTTP and UI tests). Tests now wait for routes to be fully ready before proceeding, improving stability and reducing intermittent failures caused by race conditions during test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->