### PR TITLE
fix: fix test_token_introspect for Keycloak 26.4.12+

### DIFF
--- a/testsuite/oidc/keycloak/objects.py
+++ b/testsuite/oidc/keycloak/objects.py
@@ -123,6 +123,20 @@ class Client:
             resource["ownerManagedAccess"] = True
         return self.admin.create_client_authz_resource(self.client_id, resource)
 
+    def add_audience_mapper(self, audience_client_id):
+        """Adds an audience mapper that includes the specified client in the token's aud claim"""
+        mapper_config = {
+            "name": f"{audience_client_id}-audience-mapper",
+            "protocol": "openid-connect",
+            "protocolMapper": "oidc-audience-mapper",
+            "config": {
+                "included.client.audience": audience_client_id,
+                "id.token.claim": "false",
+                "access.token.claim": "true",
+            },
+        }
+        return self.admin.add_mapper_to_client(self.client_id, mapper_config)
+
     def add_user_attribute_mapper(
         self, attribute_name, token_claim_name, add_to_access_token=True, add_to_id_token=True
     ):

--- a/testsuite/tests/singlecluster/authorino/metadata/test_token_introspect.py
+++ b/testsuite/tests/singlecluster/authorino/metadata/test_token_introspect.py
@@ -29,6 +29,7 @@ def authorization(client_secret, authorization, keycloak):
     endpoint. It's credentials are referenced from the secret created before.
     """
     authorization.identity.add_oauth2_introspection("default", keycloak, client_secret)
+    keycloak.client.add_audience_mapper(keycloak.client.auth_id)
     return authorization
 
 


### PR DESCRIPTION
 ## Description
  - Keycloak 26.4.12+ introduced a security fix ([CVE-2026-37979](https://github.com/keycloak/keycloak/issues/49113)) that requires the introspecting client to be present in the token's `aud` (audience) claim. Without this, the introspection endpoint returns `{"active": false}`.
  - `test_token_introspect` was failing with `"token is not active"` because the token's audience only contained `"account"`, not the `base-client` used for introspection.
  - Added `add_audience_mapper()` to the Keycloak `Client` class and used it in the test to include the client in the token's `aud` claim, following the [recommended migration path](https://www.keycloak.org/docs/latest/upgrading/index.html#migrating-to-26-6-2).

  ## Changes
  
  ### Bug Fixes
  - Added `add_audience_mapper()` method to `Client` in `testsuite/oidc/keycloak/objects.py` — adds an `oidc-audience-mapper` protocol mapper that includes a specified client in the token's `aud` claim
  - Updated `authorization` fixture in `test_token_introspect.py` to call `keycloak.client.add_audience_mapper(keycloak.client.auth_id)` so the introspection audience check passes

  ## Verification steps
  ```bash
  poetry run pytest -vv testsuite/tests/singlecluster/authorino/metadata/test_token_introspect.py
  ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced OAuth2 token introspection testing with improved audience mapper configuration for client authentication validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/testsuite/pull/986?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->