### PR TITLE
refactor: replace magic numbers with named constants in tests

### DIFF
--- a/testsuite/tests/multicluster/load_balanced/test_change_default_geo.py
+++ b/testsuite/tests/multicluster/load_balanced/test_change_default_geo.py
@@ -5,6 +5,7 @@ from time import sleep
 import pytest
 import dns.resolver
 from testsuite.config import settings
+from testsuite.utils.constants import DNS_PROPAGATION_WAIT
 
 pytestmark = [pytest.mark.multicluster]
 
@@ -29,5 +30,5 @@ def test_change_default_geo(hostname, gateway, gateway2, dns_policy, dns_policy2
     dns_policy2.apply()
     dns_policy2.wait_for_ready()
 
-    sleep(300)  # wait for DNS propagation on providers
+    sleep(DNS_PROPAGATION_WAIT)  # wait for DNS propagation on providers
     assert resolver.resolve(hostname.hostname)[0].address == gateway2.external_ip().split(":")[0]

--- a/testsuite/tests/multicluster/load_balanced/test_change_strategy.py
+++ b/testsuite/tests/multicluster/load_balanced/test_change_strategy.py
@@ -6,6 +6,7 @@ import pytest
 import dns.resolver
 
 from testsuite.kuadrant.policy.dns import has_record_condition
+from testsuite.utils.constants import DNS_PROPAGATION_WAIT
 
 pytestmark = [pytest.mark.multicluster]
 
@@ -32,5 +33,5 @@ def test_change_lb_strategy(hostname, gateway, gateway2, dns_policy2, dns_server
         )
     ), f"DNSPolicy did not reach expected record status, instead it was: {dns_policy2.model.status.recordConditions}"
 
-    sleep(300)  # wait for DNS propagation on providers
+    sleep(DNS_PROPAGATION_WAIT)  # wait for DNS propagation on providers
     assert resolver.resolve(hostname.hostname)[0].address == gateway.external_ip().split(":")[0]

--- a/testsuite/tests/singlecluster/authorino/authorization/opa/external_registry/test_cache.py
+++ b/testsuite/tests/singlecluster/authorino/authorization/opa/external_registry/test_cache.py
@@ -8,6 +8,7 @@ from time import sleep
 import pytest
 
 from testsuite.utils import rego_allow_header
+from testsuite.utils.constants import OPA_CACHE_TTL_WAIT
 
 pytestmark = [pytest.mark.authorino]
 
@@ -20,7 +21,7 @@ VALUE = "test-value"
 def reset_expectation(mockserver, module_label):
     """Updates Expectation with updated header"""
     mockserver.create_response_expectation(module_label, rego_allow_header(KEY, VALUE))
-    sleep(2)  # waits for cache to reset because of ttl=1
+    sleep(OPA_CACHE_TTL_WAIT)  # waits for cache to reset because of ttl=1
 
 
 def test_caching(client, auth, mockserver, blame, module_label):
@@ -40,7 +41,7 @@ def test_cache_refresh(client, auth, mockserver, blame, module_label):
     assert response.status_code == 200
 
     mockserver.create_response_expectation(module_label, rego_allow_header(blame(KEY), blame(VALUE)))
-    sleep(2)
+    sleep(OPA_CACHE_TTL_WAIT)
 
     response = client.get("/get", auth=auth, headers={KEY: VALUE})
     assert response.status_code == 403

--- a/testsuite/tests/singlecluster/authorino/identity/plain/test_jwt_user_story.py
+++ b/testsuite/tests/singlecluster/authorino/identity/plain/test_jwt_user_story.py
@@ -9,6 +9,7 @@ import pytest
 
 from testsuite.kuadrant.policy.authorization import Pattern, ValueFrom, DenyResponse
 from testsuite.gateway.envoy.jwt_plain_identity import JwtEnvoy
+from testsuite.utils.constants import JWT_STARTUP_MAX_RETRIES
 
 logger = logging.getLogger(__name__)
 
@@ -115,7 +116,7 @@ def test_jwt_user_story(client, auth, auth2):
     # Temporary retry loop: keep sending requests until we get a 200 response
     # or reach the maximum attempts. Remove this once the underlying issue is fixed
     # and the test passes without retries.
-    max_attempts = 20
+    max_attempts = JWT_STARTUP_MAX_RETRIES
     response = client.get("/get", auth=auth, headers={"x-country": "GB"})
     if response.status_code == 500:
         start = time.perf_counter()

--- a/testsuite/tests/singlecluster/authorino/identity/x509/gateway_validation/test_multi_ca_trust.py
+++ b/testsuite/tests/singlecluster/authorino/identity/x509/gateway_validation/test_multi_ca_trust.py
@@ -13,6 +13,7 @@ from testsuite.certificates import CertInfo
 from testsuite.utils import cert_builder
 from testsuite.kubernetes import Selector
 from testsuite.kuadrant.policy.authorization import X509Source
+from testsuite.utils.constants import WASM_PLUGIN_SYNC_WAIT
 from ..conftest import XFCC_HEADER_NAME
 
 pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only, pytest.mark.gateway_api_version((1, 5, 0))]
@@ -98,7 +99,9 @@ def commit(request, tls_policy, authorization, ca_secret_team_a, ca_secret_team_
         request.addfinalizer(component.delete)
         component.commit()
         component.wait_for_ready()
-    time.sleep(15)  # Kind workaround before https://github.com/envoyproxy/envoy/pull/43928 is released in istio 1.30
+    time.sleep(
+        WASM_PLUGIN_SYNC_WAIT
+    )  # Kind workaround before https://github.com/envoyproxy/envoy/pull/43928 is released in istio 1.30
 
 
 def test_multi_ca_trust(hostname, server_ca, cert_team_a, cert_team_b, cert_untrusted):

--- a/testsuite/tests/singlecluster/authorino/wristband/conftest.py
+++ b/testsuite/tests/singlecluster/authorino/wristband/conftest.py
@@ -8,6 +8,7 @@ from testsuite.kuadrant.policy.authorization.auth_config import AuthConfig
 from testsuite.gateway.envoy.route import EnvoyVirtualRoute
 from testsuite.kubernetes.secret import TLSSecret
 from testsuite.utils import cert_builder
+from testsuite.utils.constants import AUTHORINO_OIDC_PORT
 
 
 @pytest.fixture(scope="session")
@@ -46,7 +47,7 @@ def wristband_name(blame):
 @pytest.fixture(scope="module")
 def wristband_endpoint(cluster, authorino, wristband_name):
     """Authorino oidc wristband endpoint"""
-    return f"http://{authorino.oidc_url}:8083/{cluster.project}/{wristband_name}/wristband"
+    return f"http://{authorino.oidc_url}:{AUTHORINO_OIDC_PORT}/{cluster.project}/{wristband_name}/wristband"
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/singlecluster/egress/credentials_injection/conftest.py
+++ b/testsuite/tests/singlecluster/egress/credentials_injection/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from testsuite.backend.mockserver import MockserverBackend
 from testsuite.httpx import KuadrantClient
 from testsuite.mockserver import Mockserver
+from testsuite.utils.constants import HTTP_API_PORT
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -31,7 +32,7 @@ def backend(request, cluster, blame, label):
 @pytest.fixture(scope="module")
 def mockserver_client(backend):
     """Mockserver client for creating expectations and direct requests"""
-    return Mockserver(KuadrantClient(base_url=f"http://{backend.service.refresh().external_ip}:8080"))
+    return Mockserver(KuadrantClient(base_url=f"http://{backend.service.refresh().external_ip}:{HTTP_API_PORT}"))
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/singlecluster/egress/test_egress.py
+++ b/testsuite/tests/singlecluster/egress/test_egress.py
@@ -14,6 +14,7 @@ from testsuite.gateway import CustomReference, URLRewriteFilter
 from testsuite.gateway.gateway_api.route import HTTPRoute
 from testsuite.httpx.auth import HttpxOidcClientAuth
 from testsuite.kuadrant.policy.rate_limit import Limit
+from testsuite.utils.constants import RLP_WINDOW_RESET_WAIT_BUFFERED
 from .conftest import EGRESS_HOSTNAME
 
 pytestmark = [pytest.mark.kuadrant_only, pytest.mark.egress_gateway]
@@ -68,7 +69,7 @@ def test_egress_authorization(client, auth):
 @pytest.mark.flaky(reruns=3, reruns_delay=10)
 def test_egress_ratelimit(client, auth):
     """Test that RateLimitPolicy is enforced on egress gateway traffic"""
-    sleep(5 + 1)  # make sure request limit quota is reset before starting the test
+    sleep(RLP_WINDOW_RESET_WAIT_BUFFERED)  # make sure request limit quota is reset before starting the test
 
     responses = client.get_many("/get", LIMIT.limit, auth=auth)
     responses.assert_all(status_code=200)

--- a/testsuite/tests/singlecluster/gateway/dnspolicy/health_check/test_additional_headers.py
+++ b/testsuite/tests/singlecluster/gateway/dnspolicy/health_check/test_additional_headers.py
@@ -9,6 +9,7 @@ from testsuite.gateway.gateway_api.gateway import KuadrantGateway
 from testsuite.kubernetes.secret import Secret
 from testsuite.kuadrant.policy.dns import HealthCheck, AdditionalHeadersRef
 from testsuite.backend.mockserver import MockserverBackend
+from testsuite.utils.constants import HTTP_PORT, HTTP_API_PORT
 
 pytestmark = [pytest.mark.dnspolicy]
 
@@ -24,7 +25,7 @@ def health_check(headers_secret, module_label):
         path=f"/{module_label}",
         interval="5s",
         protocol="HTTP",
-        port=80,
+        port=HTTP_PORT,
     )
 
 
@@ -62,7 +63,7 @@ def headers_secret(request, cluster, blame):
 @pytest.fixture(scope="module")
 def mockserver_client(backend):
     """Returns Mockserver client from load-balanced service IP"""
-    return Mockserver(KuadrantClient(base_url=f"http://{backend.service.refresh().external_ip}:8080"))
+    return Mockserver(KuadrantClient(base_url=f"http://{backend.service.refresh().external_ip}:{HTTP_API_PORT}"))
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/singlecluster/gateway/dnspolicy/health_check/test_remove_endpoint.py
+++ b/testsuite/tests/singlecluster/gateway/dnspolicy/health_check/test_remove_endpoint.py
@@ -4,6 +4,7 @@ import pytest
 
 from testsuite.kuadrant.policy import has_condition
 from testsuite.kuadrant.policy.dns import HealthCheck, has_record_condition
+from testsuite.utils.constants import DNS_HEALTH_CHECK_TIMEOUT, HTTPS_PORT
 
 pytestmark = [pytest.mark.dnspolicy, pytest.mark.tlspolicy]
 
@@ -15,7 +16,7 @@ def health_check():
         path="/get",
         interval="5s",
         protocol="HTTPS",
-        port=443,
+        port=HTTPS_PORT,
     )
 
 
@@ -26,7 +27,7 @@ def test_remove_endpoint(backend, hostname, dns_policy, dns_health_probe, client
     assert response.status_code == 200
 
     backend.deployment.self_selector().scale(0)
-    assert dns_policy.wait_until(has_condition("SubResourcesHealthy", "False"), timelimit=120)
+    assert dns_policy.wait_until(has_condition("SubResourcesHealthy", "False"), timelimit=DNS_HEALTH_CHECK_TIMEOUT)
     assert dns_policy.wait_until(
         has_record_condition("Healthy", "False", "HealthChecksFailed", "Not healthy addresses:")
     )
@@ -37,7 +38,7 @@ def test_remove_endpoint(backend, hostname, dns_policy, dns_health_probe, client
         assert response.status_code == 503
 
     backend.deployment.self_selector().scale(1)
-    assert dns_policy.wait_until(has_condition("SubResourcesHealthy", "True"), timelimit=120)
+    assert dns_policy.wait_until(has_condition("SubResourcesHealthy", "True"), timelimit=DNS_HEALTH_CHECK_TIMEOUT)
 
     assert dns_health_probe.wait_until(lambda obj: obj.is_healthy())
     response = client.get("/get", auth=auth)

--- a/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/conftest.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/conftest.py
@@ -12,6 +12,7 @@ from testsuite.gateway.gateway_api.hostname import DNSPolicyExposer
 from testsuite.gateway.gateway_api.route import HTTPRoute
 from testsuite.kuadrant.policy.dns import DNSPolicy, has_record_condition
 from testsuite.utils import is_nxdomain
+from testsuite.utils.constants import DNS_POLICY_ENFORCEMENT_TIMEOUT, RLP_WINDOW_RESET_WAIT
 
 
 @pytest.fixture(scope="module")
@@ -103,7 +104,7 @@ def dns_policy2(blame, gateway2, module_label, dns_provider_secret, request, hos
     policy.commit()
     policy.wait_for_ready()
     policy.wait_until(has_record_condition("Ready", "True"))
-    policy.wait_until(lambda _: not is_nxdomain(hostname2.hostname), timelimit=300)
+    policy.wait_until(lambda _: not is_nxdomain(hostname2.hostname), timelimit=DNS_POLICY_ENFORCEMENT_TIMEOUT)
 
     return policy
 
@@ -123,6 +124,8 @@ def change_target_ref():
         policy.model.spec.targetRef = gateway.reference
         policy.apply()
         policy.wait_for_ready()
-        time.sleep(5)  # Extra wait to avoid inconsistent DNS issues, wait_for_ready isn't always enough
+        time.sleep(
+            RLP_WINDOW_RESET_WAIT
+        )  # Extra wait to avoid inconsistent DNS issues, wait_for_ready isn't always enough
 
     return _change_targetref

--- a/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_tlspolicy_target_ref.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_tlspolicy_target_ref.py
@@ -10,6 +10,7 @@ from testsuite.gateway import TLSGatewayListener
 from testsuite.gateway.gateway_api.gateway import KuadrantGateway
 from testsuite.gateway.gateway_api.hostname import StaticHostname
 from testsuite.httpx import KuadrantClient
+from testsuite.utils.constants import TLS_SECRET_PROPAGATION_WAIT
 
 pytestmark = [pytest.mark.dnspolicy, pytest.mark.tlspolicy]
 
@@ -85,7 +86,7 @@ def test_update_tls_policy_target_ref(
     # Delete TLS secret to verify gateway1 no longer serves valid TLS traffic
     tls_secret = gateway.get_tls_secret(hostname.hostname)
     tls_secret.delete()
-    time.sleep(10)  # Allow extra time for secret deletion to propagate
+    time.sleep(TLS_SECRET_PROPAGATION_WAIT)  # Allow extra time for secret deletion to propagate
 
     response = KuadrantClient(base_url=f"https://{hostname.hostname}", verify=False).get("/get")
     assert response.has_tls_error()

--- a/testsuite/tests/singlecluster/gateway/reconciliation/test_gw_doesnt_exist.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/test_gw_doesnt_exist.py
@@ -6,6 +6,7 @@ from testsuite.gateway import CustomReference
 from testsuite.kuadrant.policy.tls import TLSPolicy
 from testsuite.kuadrant.policy.dns import DNSPolicy
 from testsuite.kuadrant.policy import has_condition
+from testsuite.utils.constants import POLICY_CONDITION_TIMEOUT
 
 
 @pytest.fixture(scope="module")
@@ -37,5 +38,6 @@ def test_no_gw(request, policy_cr, issuer_or_secret, cluster, blame, module_labe
     policy.commit()
 
     assert policy.wait_until(
-        has_condition("Accepted", "False", "TargetNotFound", "target does-not-exist was not found"), timelimit=20
+        has_condition("Accepted", "False", "TargetNotFound", "target does-not-exist was not found"),
+        timelimit=POLICY_CONDITION_TIMEOUT,
     ), f"Policy did not reach expected status, instead it was: {policy.refresh().model.status.conditions}"

--- a/testsuite/tests/singlecluster/gateway/reconciliation/test_invalid_issuer_reference.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/test_invalid_issuer_reference.py
@@ -5,6 +5,7 @@ import pytest
 from testsuite.gateway import CustomReference
 from testsuite.kuadrant.policy.tls import TLSPolicy
 from testsuite.kuadrant.policy import has_condition
+from testsuite.utils.constants import POLICY_CONDITION_TIMEOUT
 
 pytestmark = [pytest.mark.tlspolicy]
 
@@ -57,5 +58,5 @@ def test_non_existing_issuer(request, gateway, cluster, blame, module_label):
 
     assert policy.wait_until(
         has_condition("Accepted", "False", "Invalid", "TLSPolicy target is invalid: unable to find issuer"),
-        timelimit=20,
+        timelimit=POLICY_CONDITION_TIMEOUT,
     ), f"Policy did not reach expected status, instead it was: {policy.refresh().model.status.conditions}"

--- a/testsuite/tests/singlecluster/gateway/reconciliation/test_same_target.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/test_same_target.py
@@ -5,6 +5,7 @@ import pytest
 from testsuite.kuadrant.policy.tls import TLSPolicy
 from testsuite.kuadrant.policy.dns import DNSPolicy
 from testsuite.kuadrant.policy import has_condition
+from testsuite.utils.constants import POLICY_CONDITION_TIMEOUT
 
 pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only]
 
@@ -45,7 +46,7 @@ def test_two_policies_one_gw(
             "Conflicted",
             f"{policy_new.model.kind} is conflicted by {policy.namespace()}/{policy.name()}: conflicting policy",
         ),
-        timelimit=20,
+        timelimit=POLICY_CONDITION_TIMEOUT,
     ), f"Policy did not reach expected status, instead it was: {policy_new.refresh().model.status.conditions}"
 
     # Test that the original policy still works

--- a/testsuite/tests/singlecluster/gateway/scaling/test_auto_scale_gateway.py
+++ b/testsuite/tests/singlecluster/gateway/scaling/test_auto_scale_gateway.py
@@ -6,8 +6,8 @@ import time
 
 import pytest
 
-
 from testsuite.kubernetes.horizontal_pod_autoscaler import HorizontalPodAutoscaler
+from testsuite.utils.constants import RLP_WINDOW_RESET_WAIT
 from testsuite.tests.singlecluster.gateway.scaling.conftest import LIMIT
 
 pytestmark = [pytest.mark.limitador, pytest.mark.authorino, pytest.mark.kuadrant_only]
@@ -70,7 +70,7 @@ def test_auto_scale_gateway(
 
     assert client.get("/anything/limit", auth=auth).status_code == 429
 
-    time.sleep(5)  # sleep in order to reset the rate limit policy time limit.
+    time.sleep(RLP_WINDOW_RESET_WAIT)  # sleep in order to reset the rate limit policy time limit.
 
     # Write the metric to the custom metrics apiserver and trigger the scaling
     assert (

--- a/testsuite/tests/singlecluster/gateway/scaling/test_manual_scale_gateway.py
+++ b/testsuite/tests/singlecluster/gateway/scaling/test_manual_scale_gateway.py
@@ -5,6 +5,8 @@ This module contains tests for scaling the gateway deployment by manually increa
 import time
 import pytest
 
+from testsuite.utils.constants import RLP_WINDOW_RESET_WAIT
+
 from testsuite.tests.singlecluster.gateway.scaling.conftest import LIMIT
 
 pytestmark = [pytest.mark.limitador, pytest.mark.authorino, pytest.mark.kuadrant_only]
@@ -25,7 +27,7 @@ def test_scale_gateway(gateway, client, auth):
     gateway.deployment.set_replicas(2)
     gateway.deployment.wait_for_ready()
 
-    time.sleep(5)  # sleep in order to reset the rate limit policy time limit.
+    time.sleep(RLP_WINDOW_RESET_WAIT)  # sleep in order to reset the rate limit policy time limit.
 
     anon_auth_resp = client.get("/anything/auth")
     assert anon_auth_resp is not None

--- a/testsuite/tests/singlecluster/grpc/test_grpcroute.py
+++ b/testsuite/tests/singlecluster/grpc/test_grpcroute.py
@@ -7,6 +7,7 @@ from grpc import StatusCode
 
 from testsuite.httpx.auth import HttpxOidcClientAuth
 from testsuite.kuadrant.policy.rate_limit import Limit
+from testsuite.utils.constants import RLP_WINDOW_RESET_WAIT_BUFFERED
 
 pytestmark = [pytest.mark.authorino, pytest.mark.limitador, pytest.mark.kuadrant_only]
 
@@ -49,5 +50,5 @@ def test_grpcroute(client, auth):
     responses.assert_all(status_code=StatusCode.OK)
     assert client.call("/HeadersUnary", auth=auth).status_code == StatusCode.UNAVAILABLE
 
-    time.sleep(5 + 1)
+    time.sleep(RLP_WINDOW_RESET_WAIT_BUFFERED)
     assert client.call("/HeadersUnary", auth=auth).status_code == StatusCode.OK

--- a/testsuite/tests/singlecluster/identical_hostnames/rlp/test_rlp_on_gw_and_route.py
+++ b/testsuite/tests/singlecluster/identical_hostnames/rlp/test_rlp_on_gw_and_route.py
@@ -10,6 +10,7 @@ import pytest
 
 from testsuite.kuadrant.policy import has_condition
 from testsuite.kuadrant.policy.rate_limit import RateLimitPolicy, Limit
+from testsuite.utils.constants import RLP_COUNTER_RESET_WAIT
 
 pytestmark = [pytest.mark.limitador]
 
@@ -78,7 +79,7 @@ def test_identical_hostnames_rlp_on_gw_and_route(client, rate_limit, rate_limit2
     rate_limit2.wait_for_ready()
 
     # Wait for 15 seconds to make sure counter is reset
-    sleep(15)
+    sleep(RLP_COUNTER_RESET_WAIT)
 
     responses = client.get_many("/anything/route1/get", LIMIT.limit)
     responses.assert_all(status_code=200)

--- a/testsuite/tests/singlecluster/identical_hostnames/rlp/test_rlp_on_routes.py
+++ b/testsuite/tests/singlecluster/identical_hostnames/rlp/test_rlp_on_routes.py
@@ -9,6 +9,7 @@ from time import sleep
 import pytest
 
 from testsuite.kuadrant.policy.rate_limit import RateLimitPolicy, Limit
+from testsuite.utils.constants import RLP_COUNTER_RESET_WAIT
 
 pytestmark = [pytest.mark.limitador]
 
@@ -19,7 +20,7 @@ LIMIT = Limit(2, "10s")
 def rate_limit2(route2, blame, cluster, label):
     """2nd RateLimitPolicy allowing 2 requests per 10 seconds (a.k.a. '2rp10s' RateLimitPolicy)"""
     rlp = RateLimitPolicy.create_instance(cluster, blame("2rp10s"), route2, labels={"testRun": label})
-    rlp.add_limit("2rp10m", [LIMIT])
+    rlp.add_limit("2rp10s", [LIMIT])
     return rlp
 
 
@@ -40,8 +41,8 @@ def test_identical_hostnames_rlp_on_routes(client, rate_limit2):
     RateLimitPolicy got successfully enforced on 'route2' in the interim.
     Setup:
         - Two HTTPRoutes declaring identical hostnames but different paths: '/anything/route1' and '/anything/route2'
-        - '1rp10m' RateLimitPolicy enforced on the '/anything/route1' HTTPRoute
-        - '2rp10m' RateLimitPolicy (created after '1rp10s' RateLimitPolicy) enforced on the '/anything/route2' HTTPRoute
+        - '1rp10s' RateLimitPolicy enforced on the '/anything/route1' HTTPRoute
+        - '2rp10s' RateLimitPolicy (created after '1rp10s' RateLimitPolicy) enforced on the '/anything/route2' HTTPRoute
     Test:
         - Send a request via 'route' and assert that no 429s (Too Many Requests) are returned
         - Send a request via 'route2' and assert that no 429s (Too Many Requests) are returned
@@ -63,12 +64,12 @@ def test_identical_hostnames_rlp_on_routes(client, rate_limit2):
     response = client.get("/anything/route2/get")
     assert response.status_code == 429
 
-    # Deletion of '2rp10m' RateLimitPolicy
+    # Deletion of '2rp10s' RateLimitPolicy
     rate_limit2.delete()
 
     # Access via 'route' should now be still limited via '1rp10s' RateLimitPolicy
     # Wait for 15s to make sure the counter is reset
-    sleep(15)
+    sleep(RLP_COUNTER_RESET_WAIT)
     response = client.get("/anything/route1/get")
     assert response.status_code == 200
     response = client.get("/anything/route1/get")

--- a/testsuite/tests/singlecluster/limitador/test_multiple_iterations.py
+++ b/testsuite/tests/singlecluster/limitador/test_multiple_iterations.py
@@ -7,6 +7,7 @@ from time import sleep
 import pytest
 
 from testsuite.kuadrant.policy.rate_limit import Limit
+from testsuite.utils.constants import RLP_ITERATION_WINDOW_RESET_WAIT
 
 pytestmark = [pytest.mark.limitador]
 
@@ -26,4 +27,4 @@ def test_multiple_iterations(client):
         responses = client.get_many("/get", 5)
         responses.assert_all(status_code=200)
         assert client.get("/get").status_code == 429
-        sleep(10)
+        sleep(RLP_ITERATION_WINDOW_RESET_WAIT)

--- a/testsuite/tests/singlecluster/limitador/tokens_rate_limit/basic/test_trlp.py
+++ b/testsuite/tests/singlecluster/limitador/tokens_rate_limit/basic/test_trlp.py
@@ -9,6 +9,7 @@ from time import sleep
 
 import pytest
 
+from testsuite.utils.constants import TRLP_FREE_USER_RESET_WAIT, TRLP_PAID_USER_RESET_WAIT
 from .conftest import FREE_USER_LIMIT, PAID_USER_LIMIT
 
 pytestmark = [pytest.mark.limitador, pytest.mark.authorino, pytest.mark.kuadrant_only]
@@ -67,7 +68,7 @@ def test_trlp_limit_and_reset_free_user(client, free_user_auth):
     ), f"Expected 429 after {total_tokens}/{FREE_USER_LIMIT.limit} tokens, but got {response.status_code}"
 
     # Assert quota resets after wait period
-    sleep(30)
+    sleep(TRLP_FREE_USER_RESET_WAIT)
     response = client.post("/v1/chat/completions", auth=free_user_auth, json={**basic_request})
     assert response.status_code == 200, f"Expected 200 after reset, but got {response.status_code}"
 
@@ -101,6 +102,6 @@ def test_trlp_limit_and_reset_paid_user(client, paid_user_auth):
         response.status_code == 429
     ), f"Expected 429 after {total_tokens}/{PAID_USER_LIMIT.limit} tokens, but got {response.status_code}"
 
-    sleep(60)
+    sleep(TRLP_PAID_USER_RESET_WAIT)
     response = client.post("/v1/chat/completions", auth=paid_user_auth, json={**basic_request})
     assert response.status_code == 200, f"Expected 200 after reset, but got {response.status_code}"

--- a/testsuite/tests/singlecluster/limitador/tokens_rate_limit/basic/test_trlp_streaming.py
+++ b/testsuite/tests/singlecluster/limitador/tokens_rate_limit/basic/test_trlp_streaming.py
@@ -7,6 +7,7 @@ from time import sleep
 
 import pytest
 
+from testsuite.utils.constants import TRLP_FREE_USER_RESET_WAIT
 from .conftest import FREE_USER_LIMIT
 
 pytestmark = [pytest.mark.limitador, pytest.mark.authorino, pytest.mark.kuadrant_only]
@@ -63,6 +64,6 @@ def test_trlp_streaming_limit_and_reset(client, free_user_auth):
     ), f"Expected 429 after {total_tokens}/{FREE_USER_LIMIT.limit} tokens, but got {response.status_code}"
 
     # Assert quota resets after wait period
-    sleep(30)
+    sleep(TRLP_FREE_USER_RESET_WAIT)
     response = client.post("/v1/chat/completions", auth=free_user_auth, json={**streaming_request})
     assert response.status_code == 200, f"Expected 200 after reset, but got {response.status_code}"

--- a/testsuite/tests/singlecluster/limitador/tokens_rate_limit/multiple_iterations/test_multiple_trlp_iterations.py
+++ b/testsuite/tests/singlecluster/limitador/tokens_rate_limit/multiple_iterations/test_multiple_trlp_iterations.py
@@ -5,6 +5,7 @@ Tests that a TokenRateLimitPolicy limit is enforced and resets as expected over 
 from time import sleep
 import pytest
 
+from testsuite.utils.constants import TRLP_ITERATION_RESET_WAIT
 from .conftest import LIMIT
 
 pytestmark = [pytest.mark.limitador]
@@ -41,7 +42,7 @@ def test_multiple_trlp_limit_iterations(client):
             response.status_code == 429
         ), f"Iteration {i+1}/10: Expected 429 after {total_tokens}/{LIMIT.limit} tokens, but got {response.status_code}"
 
-        sleep(20)
+        sleep(TRLP_ITERATION_RESET_WAIT)
         response = client.post("/v1/chat/completions", json={**basic_request})
         assert (
             response.status_code == 200

--- a/testsuite/tests/singlecluster/limitador/tokens_rate_limit/multiple_iterations/test_multiple_trlp_stream_iterations.py
+++ b/testsuite/tests/singlecluster/limitador/tokens_rate_limit/multiple_iterations/test_multiple_trlp_stream_iterations.py
@@ -8,6 +8,7 @@ from time import sleep
 
 import pytest
 
+from testsuite.utils.constants import TRLP_ITERATION_RESET_WAIT
 from .conftest import LIMIT
 
 pytestmark = [pytest.mark.limitador]
@@ -69,7 +70,7 @@ def test_multiple_trlp_streaming_iterations(client):
             response.status_code == 429
         ), f"Iteration {i+1}/5: Expected 429 after {total_tokens}/{LIMIT.limit} tokens, but got {response.status_code}"
 
-        sleep(20)
+        sleep(TRLP_ITERATION_RESET_WAIT)
         response = client.post("/v1/chat/completions", json={**streaming_request})
         assert (
             response.status_code == 200

--- a/testsuite/tests/singlecluster/observability/conftest.py
+++ b/testsuite/tests/singlecluster/observability/conftest.py
@@ -6,6 +6,7 @@ from openshift_client import selector
 
 from testsuite.kubernetes.monitoring.pod_monitor import PodMonitor
 from testsuite.kubernetes.monitoring.service_monitor import ServiceMonitor
+from testsuite.utils.constants import OBSERVABILITY_MONITOR_POLL_INTERVAL, OBSERVABILITY_MONITOR_MAX_RETRIES
 
 SERVICE_MONITOR_SERVICES = [
     "kuadrant-operator-metrics",
@@ -35,10 +36,17 @@ def require_observability_enabled(kuadrant, skip_or_fail):
 
 @pytest.fixture(scope="module")
 def service_monitors(system_project):
-    """Return all 5 expected ServiceMonitors created when observability is enabled"""
+    """Return expected ServiceMonitors created when observability is enabled"""
     context = system_project.context
 
-    @backoff.on_predicate(backoff.constant, lambda x: len(x) == 5, interval=5, max_tries=12, jitter=None)
+    # Return until all 5 expected ServiceMonitors are found
+    @backoff.on_predicate(
+        backoff.constant,
+        lambda x: len(x) != 5,
+        interval=OBSERVABILITY_MONITOR_POLL_INTERVAL,
+        max_tries=OBSERVABILITY_MONITOR_MAX_RETRIES,
+        jitter=None,
+    )
     def wait_for_monitors():
         return selector("ServiceMonitor", labels={"kuadrant.io/observability": "true"}, static_context=context).objects(
             cls=ServiceMonitor
@@ -54,7 +62,13 @@ def service_monitors(system_project):
 def pod_monitor(cluster):
     """Return PodMonitor created when observability is enabled"""
 
-    @backoff.on_predicate(backoff.constant, lambda x: len(x) == 1, interval=5, max_tries=12, jitter=None)
+    @backoff.on_predicate(
+        backoff.constant,
+        lambda x: len(x) != 1,
+        interval=OBSERVABILITY_MONITOR_POLL_INTERVAL,
+        max_tries=OBSERVABILITY_MONITOR_MAX_RETRIES,
+        jitter=None,
+    )
     def wait_for_monitor():
         return selector(
             "PodMonitor", labels={"kuadrant.io/observability": "true"}, static_context=cluster.context

--- a/testsuite/tests/singlecluster/tracing/control_plane/test_control_plane_errors.py
+++ b/testsuite/tests/singlecluster/tracing/control_plane/test_control_plane_errors.py
@@ -9,6 +9,7 @@ import pytest
 from testsuite.gateway.gateway_api.route import HTTPRoute
 from testsuite.kuadrant.policy.authorization.auth_policy import AuthPolicy
 from testsuite.kubernetes import Selector
+from testsuite.utils.constants import OBJECT_DELETION_TIMEOUT
 
 pytestmark = [pytest.mark.observability, pytest.mark.limitador, pytest.mark.authorino, pytest.mark.kuadrant_only]
 
@@ -44,7 +45,7 @@ def test_orphaned_policy_reconciliation_traced(orphan_test_route, orphan_test_po
     """
     # Delete the route (orphaning the policy)
     orphan_test_route.delete()
-    orphan_test_route.wait_until(lambda obj: not obj.exists(), timelimit=30)
+    orphan_test_route.wait_until(lambda obj: not obj.exists(), timelimit=OBJECT_DELETION_TIMEOUT)
 
     # Look for traces with error indicators or warnings
     policy_traces = tracing.get_traces(

--- a/testsuite/tests/singlecluster/tracing/control_plane/test_control_plane_lifecycle.py
+++ b/testsuite/tests/singlecluster/tracing/control_plane/test_control_plane_lifecycle.py
@@ -12,6 +12,7 @@ from testsuite.kuadrant.policy.authorization import Pattern
 from testsuite.kuadrant.policy.authorization.auth_policy import AuthPolicy
 from testsuite.kuadrant.policy.rate_limit import Limit, RateLimitPolicy
 from testsuite.kubernetes import Selector
+from testsuite.utils.constants import OBJECT_DELETION_TIMEOUT
 
 pytestmark = [pytest.mark.observability, pytest.mark.limitador, pytest.mark.authorino, pytest.mark.kuadrant_only]
 
@@ -102,7 +103,7 @@ def test_policy_deletion_triggers_reconciliation_traces(temp_deletion_policy, tr
     span_ids_before = {span.span_id for trace in all_traces_before for span in trace.spans}
 
     temp_deletion_policy.delete()
-    temp_deletion_policy.wait_until(lambda obj: not obj.exists(), timelimit=30)
+    temp_deletion_policy.wait_until(lambda obj: not obj.exists(), timelimit=OBJECT_DELETION_TIMEOUT)
 
     all_traces = tracing.get_traces(service="kuadrant-operator")
 

--- a/testsuite/utils/constants.py
+++ b/testsuite/utils/constants.py
@@ -37,10 +37,42 @@ DNS_POLICY_ENFORCEMENT_TIMEOUT = 300  # 5 minutes
 # TLSPolicy enforcement timeout (includes ACME challenge time).
 TLS_POLICY_ENFORCEMENT_TIMEOUT = 450  # 7.5 minutes
 
+# Policy condition check timeout.
+POLICY_CONDITION_TIMEOUT = 20
+
+# Object deletion check timeout.
+OBJECT_DELETION_TIMEOUT = 30
+
+# DNS health check timeout.
+DNS_HEALTH_CHECK_TIMEOUT = 120  # 2 minutes
+
 # --- Rate Limiting (seconds) ---
 
 # Wait after RateLimitPolicy enforcement (enforcer sync delay).
 RLP_POST_ENFORCEMENT_WAIT = 5
+
+# Wait for RLP window reset.
+RLP_WINDOW_RESET_WAIT = 5
+
+# Wait for RLP window reset with safety buffer.
+RLP_WINDOW_RESET_WAIT_BUFFERED = 6
+
+# Wait for RLP counter reset.
+RLP_COUNTER_RESET_WAIT = 15
+
+# Wait for RLP iteration window to reset.
+RLP_ITERATION_WINDOW_RESET_WAIT = 10
+
+# --- Token Rate Limiting (seconds) ---
+
+# Wait for TRLP free user quota reset.
+TRLP_FREE_USER_RESET_WAIT = 30
+
+# Wait for TRLP paid user quota reset.
+TRLP_PAID_USER_RESET_WAIT = 60
+
+# Wait for TRLP iteration reset.
+TRLP_ITERATION_RESET_WAIT = 20
 
 # --- Prometheus & Observability ---
 
@@ -64,6 +96,10 @@ TRACING_MAX_RETRIES = 7
 # HTTPX request retry (fibonacci backoff, 8 attempts).
 HTTP_BACKOFF_MAX_RETRIES = 8
 
+# Observability ServiceMonitor/PodMonitor readiness polling (~60s total).
+OBSERVABILITY_MONITOR_POLL_INTERVAL = 5
+OBSERVABILITY_MONITOR_MAX_RETRIES = 12
+
 # --- SpiceDB ---
 
 # HTTP client timeout for SpiceDB API calls (seconds).
@@ -74,6 +110,12 @@ SPICEDB_RETRY_INTERVAL = 5
 SPICEDB_MAX_RETRIES = 3
 
 # --- Service Ports ---
+
+# Standard HTTP port.
+HTTP_PORT = 80
+
+# Standard HTTPS port.
+HTTPS_PORT = 443
 
 # Standard HTTP API port (shared across multiple services).
 HTTP_API_PORT = 8080
@@ -99,6 +141,9 @@ SPICEDB_GRPC_PORT = 50051
 # SpiceDB HTTP/TLS.
 SPICEDB_HTTP_PORT = 8443
 
+# Authorino OIDC wristband endpoint.
+AUTHORINO_OIDC_PORT = 8083
+
 # --- gRPC ---
 
 # Default timeout for individual gRPC unary calls (seconds).
@@ -106,7 +151,7 @@ GRPC_CALL_TIMEOUT = 10
 
 # --- Envoy Workarounds (seconds) ---
 
-# Extra wait after envoy rollout (wait_for_ready alone is insufficient).
+# Wait after Envoy rollout (wait_for_ready alone is insufficient).
 ENVOY_STARTUP_SETTLE = 3
 
 # Envoy readiness probe initial delay.
@@ -115,7 +160,24 @@ ENVOY_READINESS_INITIAL_DELAY = 3
 # Envoy readiness probe period.
 ENVOY_READINESS_PERIOD = 4
 
+# --- DNS Propagation (seconds) ---
+
+# DNS propagation wait.
+DNS_PROPAGATION_WAIT = 300  # 5 minutes
+
 # --- Miscellaneous Workarounds (seconds) ---
 
 # Workaround for https://github.com/Kuadrant/testsuite/issues/884 — remove when fixed
 OIDC_POST_ENFORCEMENT_WAIT = 10
+
+# Wait for OPA external registry cache TTL to expire (TTL + buffer).
+OPA_CACHE_TTL_WAIT = 2
+
+# Wait for TLS secret deletion to propagate.
+TLS_SECRET_PROPAGATION_WAIT = 10
+
+# Kind workaround: wait for WasmPlugin sync before https://github.com/envoyproxy/envoy/pull/43928 is released.
+WASM_PLUGIN_SYNC_WAIT = 15
+
+# Max retry attempts for JWT test startup.
+JWT_STARTUP_MAX_RETRIES = 20


### PR DESCRIPTION
## Description
Replaces all hardcoded magic numbers in test files with named constants from `testsuite/utils/constants.py`.

Closes #930 

## Changes
### Refactored Files (28)
<details> <summary>Files</summary>

- testsuite/tests/singlecluster/gateway/scaling/test_manual_scale_gateway.py
- testsuite/tests/singlecluster/gateway/scaling/test_auto_scale_gateway.py
- testsuite/tests/singlecluster/grpc/test_grpcroute.py
- testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/test_update_tlspolicy_target_ref.py
- testsuite/tests/singlecluster/gateway/reconciliation/change_targetref/conftest.py
- testsuite/tests/singlecluster/authorino/identity/x509/gateway_validation/test_multi_ca_trust.py
- testsuite/tests/singlecluster/identical_hostnames/rlp/test_rlp_on_routes.py
- testsuite/tests/singlecluster/identical_hostnames/rlp/test_rlp_on_gw_and_route.py
- testsuite/tests/singlecluster/limitador/test_multiple_iterations.py
- testsuite/tests/singlecluster/limitador/tokens_rate_limit/basic/test_trlp.py
- testsuite/tests/singlecluster/limitador/tokens_rate_limit/basic/test_trlp_streaming.py
- testsuite/tests/singlecluster/limitador/tokens_rate_limit/multiple_iterations/test_multiple_trlp_iterations.py
- testsuite/tests/singlecluster/limitador/tokens_rate_limit/multiple_iterations/test_multiple_trlp_stream_iterations.py
- testsuite/tests/singlecluster/egress/test_egress.py
- testsuite/tests/singlecluster/authorino/authorization/opa/external_registry/test_cache.py
- testsuite/tests/multicluster/load_balanced/test_change_default_geo.py
- testsuite/tests/multicluster/load_balanced/test_change_strategy.py
- testsuite/tests/singlecluster/gateway/dnspolicy/health_check/test_remove_endpoint.py
- testsuite/tests/singlecluster/gateway/reconciliation/test_gw_doesnt_exist.py
- testsuite/tests/singlecluster/gateway/reconciliation/test_invalid_issuer_reference.py
- testsuite/tests/singlecluster/gateway/reconciliation/test_same_target.py
- testsuite/tests/singlecluster/tracing/control_plane/test_control_plane_errors.py
- testsuite/tests/singlecluster/tracing/control_plane/test_control_plane_lifecycle.py
- testsuite/tests/singlecluster/observability/conftest.py
- testsuite/tests/singlecluster/egress/credentials_injection/conftest.py
- testsuite/tests/singlecluster/authorino/wristband/conftest.py
- testsuite/tests/singlecluster/gateway/dnspolicy/health_check/test_additional_headers.py
- testsuite/tests/singlecluster/authorino/identity/plain/test_jwt_user_story.py

</details>

###  Fix 

- `test_rlp_on_routes.py`: Fixed typos 1rp10m/2rp10m to 1rp10s/2rp10s (limit window is 10 seconds not minutes).

-  `observability/conftest.py`: Fixed `backoff.on_predicate` predicate inversion (== to !=), ensuring retry continues until 
    expected monitor count is reached.
 

## Verification

- make reformat: Passed
- make commit-acceptance: Passed
- All constant values match original hardcoded values exactly. No behavioral change.

## Note
**Intentionally left as hardcoded**
- `sleep(1)` in` test_jwt_user_story.py`: Fixed 1 second wait used between retries. It is only a small delay while the main configurable value is `JWT_STARTUP_MAX_RETRIES`.
- `max_tries=7` in `mtls/conftest.py`: Kept hardcoded because it is tied to the `backoff.fibo`. Making it a constant would make the retry behavior harder to understand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Centralised timing/delay values into shared constants to reduce duplication and make updates safer.
  * Replaced multiple hardcoded sleeps and wait timeouts with shared constants for DNS propagation, TLS/secret propagation, rate-limit and token-rate-limit resets, observability polling, and JWT startup retries.
  * Standardised common service port values (HTTP/HTTPS) and other test-suite timing parameters to improve consistency across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->