### PR TITLE
fix: move flaky markers to param level

### DIFF
--- a/testsuite/tests/singlecluster/extensions/plan_policy/test_plan_policy.py
+++ b/testsuite/tests/singlecluster/extensions/plan_policy/test_plan_policy.py
@@ -82,15 +82,12 @@ def commit(request, plan_policy, authorization):
 @pytest.mark.parametrize(
     "user_with_plan, allowed_requests",
     [
-        pytest.param("gold", 5, id="gold"),
-        pytest.param("silver", 3, id="silver"),
+        pytest.param("gold", 5, id="gold", marks=pytest.mark.flaky(reruns=3, reruns_delay=15)),
+        pytest.param("silver", 3, id="silver", marks=pytest.mark.flaky(reruns=3, reruns_delay=25)),
         pytest.param("bronze", 2, id="bronze", marks=pytest.mark.flaky(reruns=0)),
     ],
     indirect=["user_with_plan"],
 )
-# 25s reruns_delay is enough for gold (10s) and silver (20s) windows to reset.
-# Bronze uses a daily limit, so reruns are disabled via param-level reruns=0.
-@pytest.mark.flaky(reruns=3, reruns_delay=25)
 def test_plan_policy(client, user_with_plan, allowed_requests):
     """
     Test PlanPolicy enforcement across different tiers and rate limits.

--- a/testsuite/tests/singlecluster/grpc/test_plan_policy.py
+++ b/testsuite/tests/singlecluster/grpc/test_plan_policy.py
@@ -72,13 +72,12 @@ def commit(request, plan_policy, authorization):
 @pytest.mark.parametrize(
     "user_with_plan, allowed_requests",
     [
-        pytest.param("gold", 5, id="gold"),
-        pytest.param("silver", 3, id="silver"),
+        pytest.param("gold", 5, id="gold", marks=pytest.mark.flaky(reruns=3, reruns_delay=15)),
+        pytest.param("silver", 3, id="silver", marks=pytest.mark.flaky(reruns=3, reruns_delay=25)),
         pytest.param("bronze", 2, id="bronze", marks=pytest.mark.flaky(reruns=0)),
     ],
     indirect=["user_with_plan"],
 )
-@pytest.mark.flaky(reruns=3, reruns_delay=25)
 def test_plan_policy(client, user_with_plan, allowed_requests):
     """Test PlanPolicy enforcement across different tiers and rate limits.
 


### PR DESCRIPTION
  ## Summary
  - Move `@pytest.mark.flaky` from function-level decorator to individual `pytest.param` marks
  - The function-level decorator was overriding the param-level `reruns=0` on the bronze tier, causing unwanted reruns
  - Applied to both `extensions/plan_policy` and `grpc` test modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated rate-limit test retry configuration to apply tier-specific settings. Gold and silver plan tiers now have configured rerun counts with tier-appropriate delays aligned to their reset windows, whilst bronze tier has reruns disabled. Retry policies are managed per-tier rather than globally.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/testsuite/pull/988?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->