### PR TITLE
fix: disable reruns for egress tests

### DIFF
--- a/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection.py
+++ b/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection.py
@@ -17,7 +17,7 @@ from testsuite.kubernetes.vault import Vault
 
 from ..conftest import EGRESS_HOSTNAME
 
-pytestmark = [pytest.mark.kuadrant_only, pytest.mark.egress_gateway]
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.egress_gateway, pytest.mark.flaky(reruns=0)]
 
 VAULT_API_KEY = "pretty-random-api-key-to-use-for-egress-credential-injection-test-41894726"
 K8S_TOKEN_AUDIENCE = "https://kubernetes.default.svc.cluster.local"

--- a/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection_by_destination.py
+++ b/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection_by_destination.py
@@ -18,7 +18,7 @@ from testsuite.kubernetes.secret import Secret
 
 from ..conftest import EGRESS_HOSTNAME
 
-pytestmark = [pytest.mark.kuadrant_only, pytest.mark.egress_gateway]
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.egress_gateway, pytest.mark.flaky(reruns=0)]
 
 SERVICE1_API_KEY = "pretty-random-api-key-to-use-for-egress-test-41894726"
 SERVICE2_API_KEY = "sk-fake-service2-key-for-egress-test-9876543210"

--- a/testsuite/tests/singlecluster/egress/test_egress.py
+++ b/testsuite/tests/singlecluster/egress/test_egress.py
@@ -16,7 +16,7 @@ from testsuite.httpx.auth import HttpxOidcClientAuth
 from testsuite.kuadrant.policy.rate_limit import Limit
 from .conftest import EGRESS_HOSTNAME
 
-pytestmark = [pytest.mark.kuadrant_only, pytest.mark.egress_gateway]
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.egress_gateway, pytest.mark.flaky(reruns=0)]
 
 LIMIT = Limit(3, "5s")
 
@@ -65,7 +65,6 @@ def test_egress_authorization(client, auth):
     assert response.status_code == 200
 
 
-@pytest.mark.flaky(reruns=3, reruns_delay=10)
 def test_egress_ratelimit(client, auth):
     """Test that RateLimitPolicy is enforced on egress gateway traffic"""
     sleep(5 + 1)  # make sure request limit quota is reset before starting the test


### PR DESCRIPTION
## Summary

  - Disabled test reruns (`reruns=0`) for all egress gateway tests
  - Removed the per-test `@pytest.mark.flaky(reruns=3, reruns_delay=10)` override from `test_egress_ratelimit`

  ## Why

  Egress tests have heavy module-scoped fixture setup (MockServer, Egress Gateway, ServiceEntry, DestinationRule, Vault, AuthPolicy). When fixture setup fails, `pytest-rerunfailures` re-executes the full fixture chain on each
  retry, with sequential timeouts adding up to ~18 minutes per attempt. With the default `--reruns 3`, a single fixture failure wastes ~54 minutes on retries that cannot recover.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test suite configurations to adjust flaky test handling mechanisms. No user-facing functionality affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->