### PR TITLE
fix(planpolicy): make keycloak attribute name with planID unique

### DIFF
--- a/testsuite/tests/singlecluster/extensions/plan_policy/test_plan_policy.py
+++ b/testsuite/tests/singlecluster/extensions/plan_policy/test_plan_policy.py
@@ -7,23 +7,33 @@ from testsuite.kuadrant.extensions.plan_policy import PlanPolicy, Plan
 
 pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only, pytest.mark.extensions]
 
-PLANS = {
-    "gold": Plan(
-        tier="gold",
-        predicate='has(auth.identity) && auth.identity.planID == "gold"',
-        limits={"custom": [{"limit": 5, "window": "10s"}]},
-    ),
-    "silver": Plan(
-        tier="silver",
-        predicate='has(auth.identity) && auth.identity.planID == "silver"',
-        limits={"custom": [{"limit": 3, "window": "20s"}]},
-    ),
-    "bronze": Plan(
-        tier="bronze",
-        predicate='has(auth.identity) && auth.identity.planID == "bronze"',
-        limits={"daily": 2},
-    ),
-}
+
+@pytest.fixture(scope="module")
+def plan_attribute(blame):
+    """Unique attribute name for the plan tier"""
+    return blame("planid")
+
+
+@pytest.fixture(scope="module")
+def plans(plan_attribute):
+    """PlanPolicy plan definitions matching the keycloak attribute name"""
+    return {
+        "gold": Plan(
+            tier="gold",
+            predicate=f'has(auth.identity) && auth.identity["{plan_attribute}"] == "gold"',
+            limits={"custom": [{"limit": 5, "window": "10s"}]},
+        ),
+        "silver": Plan(
+            tier="silver",
+            predicate=f'has(auth.identity) && auth.identity["{plan_attribute}"] == "silver"',
+            limits={"custom": [{"limit": 3, "window": "20s"}]},
+        ),
+        "bronze": Plan(
+            tier="bronze",
+            predicate=f'has(auth.identity) && auth.identity["{plan_attribute}"] == "bronze"',
+            limits={"daily": 2},
+        ),
+    }
 
 
 @pytest.fixture(scope="module")
@@ -33,22 +43,18 @@ def target(request):
 
 
 @pytest.fixture(scope="module")
-def keycloak(keycloak):
-    """
-    Ensure the realm allows a custom user attribute and configure client mapper.
-    """
-    keycloak.realm.add_user_attributes("planID", "Plan ID")
-    keycloak.client.add_user_attribute_mapper("planID", "planID")
+def keycloak(keycloak, plan_attribute):
+    """Ensure the realm allows a custom user attribute and configure client mapper."""
+    keycloak.realm.add_user_attributes(plan_attribute, "Plan ID")
+    keycloak.client.add_user_attribute_mapper(plan_attribute, plan_attribute)
     return keycloak
 
 
 @pytest.fixture(scope="module")
-def user_with_plan(request, keycloak, blame):
-    """
-    Creates new user with specified plan tier.
-    """
+def user_with_plan(request, keycloak, blame, plan_attribute):
+    """Creates new user with specified plan tier."""
     plan_tier = request.param
-    user = keycloak.realm.create_user(blame("someuser"), blame("password"), attributes={"planID": [plan_tier]})
+    user = keycloak.realm.create_user(blame("someuser"), blame("password"), attributes={plan_attribute: [plan_tier]})
     return HttpxOidcClientAuth.from_user(keycloak.get_token, user=user)
 
 
@@ -60,10 +66,10 @@ def authorization(authorization, keycloak):
 
 
 @pytest.fixture(scope="module")
-def plan_policy(cluster, blame, target):
+def plan_policy(cluster, blame, target, plans):
     """Create PlanPolicy targeting the route/gateway"""
     plan_policy = PlanPolicy.create_instance(cluster, blame("my-plan"), target)
-    for plan in PLANS.values():
+    for plan in plans.values():
         plan_policy.add_plan(plan)
     return plan_policy
 

--- a/testsuite/tests/singlecluster/grpc/test_plan_policy.py
+++ b/testsuite/tests/singlecluster/grpc/test_plan_policy.py
@@ -8,38 +8,48 @@ from testsuite.kuadrant.extensions.plan_policy import PlanPolicy, Plan
 
 pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only, pytest.mark.extensions]
 
-PLANS = {
-    "gold": Plan(
-        tier="gold",
-        predicate='has(auth.identity) && auth.identity.planID == "gold"',
-        limits={"custom": [{"limit": 5, "window": "10s"}]},
-    ),
-    "silver": Plan(
-        tier="silver",
-        predicate='has(auth.identity) && auth.identity.planID == "silver"',
-        limits={"custom": [{"limit": 3, "window": "20s"}]},
-    ),
-    "bronze": Plan(
-        tier="bronze",
-        predicate='has(auth.identity) && auth.identity.planID == "bronze"',
-        limits={"daily": 2},
-    ),
-}
+
+@pytest.fixture(scope="module")
+def plan_attribute(blame):
+    """Unique attribute name for the plan tier."""
+    return blame("planid")
 
 
 @pytest.fixture(scope="module")
-def keycloak(keycloak):
+def plans(plan_attribute):
+    """PlanPolicy plan definitions matching the keycloak attribute name"""
+    return {
+        "gold": Plan(
+            tier="gold",
+            predicate=f'has(auth.identity) && auth.identity["{plan_attribute}"] == "gold"',
+            limits={"custom": [{"limit": 5, "window": "10s"}]},
+        ),
+        "silver": Plan(
+            tier="silver",
+            predicate=f'has(auth.identity) && auth.identity["{plan_attribute}"] == "silver"',
+            limits={"custom": [{"limit": 3, "window": "20s"}]},
+        ),
+        "bronze": Plan(
+            tier="bronze",
+            predicate=f'has(auth.identity) && auth.identity["{plan_attribute}"] == "bronze"',
+            limits={"daily": 2},
+        ),
+    }
+
+
+@pytest.fixture(scope="module")
+def keycloak(keycloak, plan_attribute):
     """Ensure the realm allows a custom user attribute and configure client mapper."""
-    keycloak.realm.add_user_attributes("planID", "Plan ID")
-    keycloak.client.add_user_attribute_mapper("planID", "planID")
+    keycloak.realm.add_user_attributes(plan_attribute, "Plan ID")
+    keycloak.client.add_user_attribute_mapper(plan_attribute, plan_attribute)
     return keycloak
 
 
 @pytest.fixture(scope="module")
-def user_with_plan(request, keycloak, blame):
+def user_with_plan(request, keycloak, blame, plan_attribute):
     """Creates new user with specified plan tier."""
     plan_tier = request.param
-    user = keycloak.realm.create_user(blame("someuser"), blame("password"), attributes={"planID": [plan_tier]})
+    user = keycloak.realm.create_user(blame("someuser"), blame("password"), attributes={plan_attribute: [plan_tier]})
     return HttpxOidcClientAuth.from_user(keycloak.get_token, user=user)
 
 
@@ -51,10 +61,10 @@ def authorization(authorization, keycloak):
 
 
 @pytest.fixture(scope="module")
-def plan_policy(cluster, blame, route):
+def plan_policy(cluster, blame, route, plans):
     """Create PlanPolicy targeting the route"""
     plan_policy = PlanPolicy.create_instance(cluster, blame("my-plan"), route)
-    for plan in PLANS.values():
+    for plan in plans.values():
         plan_policy.add_plan(plan)
     return plan_policy
 


### PR DESCRIPTION
## Description

Fix the `Attribute configuration already exists with 'name':'planID'` happening on planpolicy tests in pipelines, by making the keycloak attribute name unique

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored plan policy test suites to use dynamic fixture-based configuration instead of static definitions, improving test flexibility and maintainability. This update applies to both single-cluster and gRPC test implementations, enabling more robust validation of plan tier configurations and rate-limiting policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->