### PR TITLE
feat(disconnected): add disconnected mark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: commit-acceptance pylint mypy black reformat test authorino poetry poetry-no-dev mgc container-image polish-junit reportportal authorino-standalone limitador kuadrant kuadrant-only disruptive kuadrantctl multicluster ui playwright-install collect grpc
+.PHONY: commit-acceptance pylint mypy black reformat test authorino poetry poetry-no-dev mgc container-image polish-junit reportportal authorino-standalone limitador kuadrant kuadrant-only disruptive disconnected kuadrantctl multicluster ui playwright-install collect grpc
 
 TB ?= short
 LOGLEVEL ?= INFO
@@ -67,6 +67,9 @@ ui: playwright-install ## Run UI (console plugin) tests
 
 disruptive: poetry-no-dev  ## Run disruptive tests
 	$(PYTEST) -m 'disruptive' $(flags) testsuite/tests/
+
+disconnected: poetry-no-dev  ## Run tests compatible with disconnected clusters
+	$(PYTEST) -n4 -m 'disconnected' --dist loadfile --enforce $(flags) testsuite/tests/
 
 egress-gateway: poetry-no-dev  ## Run egress gateway tests
 	$(PYTEST) -n4 -m 'egress_gateway' --dist loadfile --enforce $(flags) testsuite/tests/singlecluster/egress/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ markers = [
     "dnspolicy: Test is using DNSPolicy",
     "extensions: Test is using the extensions framework",
     "smoke: Build verification test",
+    "disconnected: Tests that can run on disconnected clusters",
     "disruptive: Test is disruptive",
     "multicluster: Test is specifc to Multicluster deployment",
     "coredns_one_primary: CoreDNS multicluster tests using one primary cluster",

--- a/testsuite/tests/singlecluster/authorino/identity/api_key/test_auth_credentials.py
+++ b/testsuite/tests/singlecluster/authorino/identity/api_key/test_auth_credentials.py
@@ -24,7 +24,12 @@ def authorization(authorization, api_key, credentials):
 
 @pytest.mark.parametrize(
     "credentials",
-    [pytest.param("authorizationHeader", marks=pytest.mark.smoke), "customHeader", "queryString", "cookie"],
+    [
+        pytest.param("authorizationHeader", marks=[pytest.mark.smoke, pytest.mark.disconnected]),
+        "customHeader",
+        "queryString",
+        "cookie",
+    ],
     indirect=True,
 )
 def test_custom_selector(client, auth, credentials):

--- a/testsuite/tests/singlecluster/authorino/identity/conftest.py
+++ b/testsuite/tests/singlecluster/authorino/identity/conftest.py
@@ -3,6 +3,8 @@
 import pytest
 
 from testsuite.kubernetes.service_account import ServiceAccount
+from testsuite.kuadrant.policy.authorization.auth_config import AuthConfig
+from testsuite.kuadrant.policy.authorization.auth_policy import AuthPolicy
 
 
 @pytest.fixture(scope="module")
@@ -19,7 +21,10 @@ def create_service_account(request, cluster, blame, module_label):
 
 
 @pytest.fixture(scope="module")
-def authorization(authorization):
-    """For Identity tests remove all identities previously setup"""
-    authorization.identity.clear_all()
-    return authorization
+def authorization(request, kuadrant, route, gateway, blame, cluster, label):  # pylint: disable=unused-argument
+    """Create a fresh AuthConfig/AuthPolicy for the identity tests"""
+    target_ref = request.getfixturevalue(getattr(request, "param", "route"))
+
+    if kuadrant is None:
+        return AuthConfig.create_instance(cluster, blame("authz"), route, labels={"testRun": label})
+    return AuthPolicy.create_instance(cluster, blame("authz"), target_ref, labels={"testRun": label})

--- a/testsuite/tests/singlecluster/limitador/test_basic_limit.py
+++ b/testsuite/tests/singlecluster/limitador/test_basic_limit.py
@@ -12,7 +12,9 @@ pytestmark = [pytest.mark.limitador]
 @pytest.fixture(
     scope="module",
     params=[
-        pytest.param(Limit(2, "15s"), id="2 requests every 15 sec", marks=[pytest.mark.smoke]),
+        pytest.param(
+            Limit(2, "15s"), id="2 requests every 15 sec", marks=[pytest.mark.smoke, pytest.mark.disconnected]
+        ),
         pytest.param(Limit(5, "10s"), id="5 requests every 10 sec"),
         pytest.param(Limit(3, "5s"), id="3 request every 5 sec"),
     ],


### PR DESCRIPTION
## Description

- Added a new disconnected pytest mark that right now runs the same tests as smoke but excludes DNSPolicy tests
- Created a fresh AuthPolicy for the `authorino/identity/` test group, so it doesn't utilize `oidc_provider` fixture and is not trying to contact the on-cluster Keycloak at all (compared to how it worked previously with oidc identity being always added and then cleared up for the `authorino/identity/` tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new `disconnected` test category for improved test organisation and execution.
  * Updated test markers to enable running disconnected test scenarios separately.

* **Chores**
  * Enhanced test infrastructure with new pytest marker configuration.
  * Refactored test fixtures to create fresh authorisation resources per test run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->