### PR TITLE
fix: make issuer type error assertion compatible with OCP 4.22

### DIFF
--- a/testsuite/tests/singlecluster/gateway/reconciliation/test_invalid_issuer_reference.py
+++ b/testsuite/tests/singlecluster/gateway/reconciliation/test_invalid_issuer_reference.py
@@ -32,10 +32,9 @@ def test_wrong_issuer_type(request, gateway, blame, module_label, cluster):
     request.addfinalizer(policy.delete)
     res = cluster.do_action("create", "-f", "-", stdin_str=policy.as_json(), auto_raise=False)
     assert res.status() == 1, "Policy should not be created with invalid issuerRef.kind"
-    assert res.err().strip() == (
-        f'The TLSPolicy "{policy.model.metadata.name}" is invalid: spec.issuerRef: Invalid value: "object": '
-        f"Invalid issuerRef.kind. The only supported values are blank, 'Issuer' and 'ClusterIssuer'"
-    )
+    error = res.err().strip()
+    assert f'The TLSPolicy "{policy.model.metadata.name}" is invalid: spec.issuerRef' in error
+    assert "Invalid issuerRef.kind. The only supported values are blank, 'Issuer' and 'ClusterIssuer'" in error
 
 
 def test_non_existing_issuer(request, gateway, cluster, blame, module_label):


### PR DESCRIPTION
## Description
  - OCP 4.22 changed the validation error message for invalid `issuerRef.kind` in TLSPolicy, removing the word `"object"` from the output
  - Updated `test_wrong_issuer_type` to use substring assertions instead of an exact string match, making it compatible with both pre-4.22 and 4.22+ clusters

  ## Changes
  ### Bug Fixes
  - Replaced exact error message comparison in `test_wrong_issuer_type` with two `in` checks:
    - Verifies the error references the correct policy name and `spec.issuerRef` field
    - Verifies the error contains the full invalid kind message with supported values

  ## Verification steps
Run the test on both an OCP < 4.22 and an OCP 4.22+ cluster to verify compatibility:
  ```bash
  poetry run pytest -vv testsuite/tests/singlecluster/gateway/reconciliation/test_invalid_issuer_reference.py::test_wrong_issuer_type
  ```
Closes #996 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated error validation in issuer reference tests to use substring matching for more flexible and robust error message verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->