### PR TITLE
feat(tests): handle clusters without OSSM Istio installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ markers = [
     "egress_gateway: Test is using egress gateway",
     "min_ocp_version: Minimum OpenShift version required for test (e.g., @pytest.mark.min_ocp_version((4, 20)))",
     "gateway_api_version: Gateway API version requirement (e.g., @pytest.mark.gateway_api_version((1, 5, 0)) or @pytest.mark.gateway_api_version((1, 5, 0), operator.eq))",
-    "required_ossm: Test requires user-managed OSSM3 Istio that can be modified (skipped with Gateway API-managed Istio)",
+    "user_managed_istio: Test requires user-managed Istio that can be modified (skipped with OCP-managed Istio)",
 ]
 filterwarnings = [
     "ignore: WARNING the new order is not taken into account:UserWarning",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ markers = [
     "egress_gateway: Test is using egress gateway",
     "min_ocp_version: Minimum OpenShift version required for test (e.g., @pytest.mark.min_ocp_version((4, 20)))",
     "gateway_api_version: Gateway API version requirement (e.g., @pytest.mark.gateway_api_version((1, 5, 0)) or @pytest.mark.gateway_api_version((1, 5, 0), operator.eq))",
+    "required_ossm: Test requires user-managed OSSM3 Istio that can be modified (skipped with Gateway API-managed Istio)",
 ]
 filterwarnings = [
     "ignore: WARNING the new order is not taken into account:UserWarning",

--- a/testsuite/component_metadata.py
+++ b/testsuite/component_metadata.py
@@ -132,8 +132,8 @@ class ReportPortalMetadataCollector:
         """Determine Istio installation type and namespace from cluster-wide Istio CRs.
 
         Returns (istio_type, namespace) where istio_type is one of:
-        - "gateway-api-managed" with namespace from the Istio CR spec
-        - "user-managed-ossm" with namespace from the Istio CR spec
+        - "ocp-managed" with namespace from the Istio CR spec
+        - "user-managed" with namespace from the Istio CR spec
         - "none" with None
         """
         try:
@@ -143,14 +143,13 @@ class ReportPortalMetadataCollector:
                     return "none", None
                 gateway_istio = next((i for i in istios if i.name() == "openshift-gateway"), None)
                 if gateway_istio:
-                    return "gateway-api-managed", gateway_istio.model.spec.namespace
-                ossm_istio = next((i for i in istios if i.name() == "default"), None)
-                if ossm_istio:
-                    return "user-managed-ossm", ossm_istio.model.spec.namespace
-                return "none", None
+                    return "ocp-managed", gateway_istio.model.spec.namespace
+                default_istio = next((i for i in istios if i.name() == "default"), None)
+                if default_istio:
+                    return "user-managed", default_istio.model.spec.namespace
         except (oc.OpenShiftPythonException, AttributeError, KeyError) as e:
             logger.warning("Failed to detect Istio type: %s", e)
-            return "none", None
+        return "none", None
 
     @staticmethod
     def get_istio_metadata(project) -> dict[str, str]:

--- a/testsuite/component_metadata.py
+++ b/testsuite/component_metadata.py
@@ -128,6 +128,31 @@ class ReportPortalMetadataCollector:
         return images
 
     @staticmethod
+    def get_istio_type(cluster) -> tuple[str, Optional[str]]:
+        """Determine Istio installation type and namespace from cluster-wide Istio CRs.
+
+        Returns (istio_type, namespace) where istio_type is one of:
+        - "gateway-api-managed" with namespace from the Istio CR spec
+        - "user-managed-ossm" with namespace from the Istio CR spec
+        - "none" with None
+        """
+        try:
+            with cluster.context:
+                istios = oc.selector("Istio", all_namespaces=True).objects()
+                if not istios:
+                    return "none", None
+                gateway_istio = next((i for i in istios if i.name() == "openshift-gateway"), None)
+                if gateway_istio:
+                    return "gateway-api-managed", gateway_istio.model.spec.namespace
+                ossm_istio = next((i for i in istios if i.name() == "default"), None)
+                if ossm_istio:
+                    return "user-managed-ossm", ossm_istio.model.spec.namespace
+                return "none", None
+        except (oc.OpenShiftPythonException, AttributeError, KeyError) as e:
+            logger.warning("Failed to detect Istio type: %s", e)
+            return "none", None
+
+    @staticmethod
     def get_istio_metadata(project) -> dict[str, str]:
         """Get Istio version and istiod image from the cluster."""
         metadata: dict[str, str] = {}

--- a/testsuite/component_metadata.py
+++ b/testsuite/component_metadata.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 import openshift_client as oc
 
 from testsuite.config import settings
+from testsuite.gateway.gateway_api.gateway import KuadrantGateway
 
 logger = logging.getLogger(__name__)
 
@@ -129,27 +130,22 @@ class ReportPortalMetadataCollector:
 
     @staticmethod
     def get_istio_type(cluster) -> tuple[str, Optional[str]]:
-        """Determine Istio installation type and namespace from cluster-wide Istio CRs.
+        """Determine Istio installation type via GatewayClass and namespace from Istio CRs.
 
         Returns (istio_type, namespace) where istio_type is one of:
-        - "ocp-managed" with namespace from the Istio CR spec
-        - "user-managed" with namespace from the Istio CR spec
+        - "ocp-managed" if 'openshift-default' GatewayClass exists
+        - "user-managed" if 'istio' GatewayClass exists
         - "none" with None
         """
         try:
-            with cluster.context:
-                istios = oc.selector("Istio", all_namespaces=True).objects()
-                if not istios:
-                    return "none", None
-                gateway_istio = next((i for i in istios if i.name() == "openshift-gateway"), None)
-                if gateway_istio:
-                    return "ocp-managed", gateway_istio.model.spec.namespace
-                default_istio = next((i for i in istios if i.name() == "default"), None)
-                if default_istio:
-                    return "user-managed", default_istio.model.spec.namespace
-        except (oc.OpenShiftPythonException, AttributeError, KeyError) as e:
-            logger.warning("Failed to detect Istio type: %s", e)
-        return "none", None
+            gw_class = KuadrantGateway.get_gateway_class_name(cluster)
+        except (KeyError, oc.OpenShiftPythonException) as e:
+            logger.warning("Failed to detect GatewayClass: %s", e)
+            return "none", None
+
+        if gw_class == "openshift-default":
+            return "ocp-managed", "openshift-ingress"
+        return "user-managed", "istio-system"
 
     @staticmethod
     def get_istio_metadata(project) -> dict[str, str]:
@@ -168,6 +164,10 @@ class ReportPortalMetadataCollector:
                     image = pods[0].model.spec.containers[0].image
                     if image:
                         metadata["istiod_image"] = image
+                    if "istio_version" not in metadata:
+                        version = pods[0].model.metadata.labels.get("app.kubernetes.io/version")
+                        if version:
+                            metadata["istio_version"] = version
         except (oc.OpenShiftPythonException, AttributeError, KeyError, IndexError, ValueError) as e:
             logger.warning("Failed to get Istio metadata: %s", e)
         return metadata

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -446,3 +446,20 @@ def check_min_ocp_version(request, openshift_version):
             pytest.skip("Could not detect OpenShift version")
         if openshift_version < required_version:
             pytest.skip(f"Requires OCP {'.'.join(map(str, required_version))}+")
+
+
+@pytest.fixture(scope="session")
+def has_ossm(cluster):
+    """True if a full OSSM3 Istio installation exists (not just Gateway API-managed Istio)"""
+    with cluster.context:
+        istios = selector("Istio", all_namespaces=True).objects()
+        return bool(istios) and not any(i.name() == "openshift-gateway" for i in istios)
+
+
+@pytest.fixture(autouse=True)
+def check_required_ossm(request, has_ossm, skip_or_fail):
+    """Skip tests that require a user-managed OSSM3 Istio (e.g. mTLS, sidecar injection).
+    Gateway API-managed Istio does not allow modifications to the Istio CR."""
+    marker = request.node.get_closest_marker("required_ossm")
+    if marker and not has_ossm:
+        skip_or_fail("Test requires user-managed OSSM3 Istio; Gateway API-managed Istio cannot be modified")

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -449,17 +449,17 @@ def check_min_ocp_version(request, openshift_version):
 
 
 @pytest.fixture(scope="session")
-def has_ossm(cluster):
-    """True if a full OSSM3 Istio installation exists (not just Gateway API-managed Istio)"""
+def has_user_managed_istio(cluster):
+    """True if a user-managed Istio installation exists (not OCP-managed Istio)"""
     with cluster.context:
         istios = selector("Istio", all_namespaces=True).objects()
         return bool(istios) and not any(i.name() == "openshift-gateway" for i in istios)
 
 
 @pytest.fixture(autouse=True)
-def check_required_ossm(request, has_ossm, skip_or_fail):
-    """Skip tests that require a user-managed OSSM3 Istio (e.g. mTLS, sidecar injection).
-    Gateway API-managed Istio does not allow modifications to the Istio CR."""
-    marker = request.node.get_closest_marker("required_ossm")
-    if marker and not has_ossm:
-        skip_or_fail("Test requires user-managed OSSM3 Istio; Gateway API-managed Istio cannot be modified")
+def check_user_managed_istio(request, has_user_managed_istio, skip_or_fail):
+    """Skip tests that require a user-managed Istio (e.g. mTLS, sidecar injection).
+    OCP-managed Istio does not allow modifications to the Istio CR."""
+    marker = request.node.get_closest_marker("user_managed_istio")
+    if marker and not has_user_managed_istio:
+        skip_or_fail("Test requires user-managed Istio installation")

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -14,6 +14,7 @@ from testsuite.capabilities import has_kuadrant, kuadrant_version
 from testsuite.certificates import CFSSLClient
 from testsuite.config import settings
 from testsuite.gateway import Exposer, CustomReference
+from testsuite.gateway.gateway_api.gateway import KuadrantGateway
 from testsuite.httpx import KuadrantClient
 from testsuite.mockserver import Mockserver
 from testsuite.oidc import OIDCProvider
@@ -448,18 +449,10 @@ def check_min_ocp_version(request, openshift_version):
             pytest.skip(f"Requires OCP {'.'.join(map(str, required_version))}+")
 
 
-@pytest.fixture(scope="session")
-def has_user_managed_istio(cluster):
-    """True if a user-managed Istio installation exists (not OCP-managed Istio)"""
-    with cluster.context:
-        istios = selector("Istio", all_namespaces=True).objects()
-        return bool(istios) and not any(i.name() == "openshift-gateway" for i in istios)
-
-
 @pytest.fixture(autouse=True)
-def check_user_managed_istio(request, has_user_managed_istio, skip_or_fail):
+def check_user_managed_istio(request, cluster, skip_or_fail):
     """Skip tests that require a user-managed Istio (e.g. mTLS, sidecar injection).
     OCP-managed Istio does not allow modifications to the Istio CR."""
     marker = request.node.get_closest_marker("user_managed_istio")
-    if marker and not has_user_managed_istio:
+    if marker and KuadrantGateway.get_gateway_class_name(cluster) == "openshift-default":
         skip_or_fail("Test requires user-managed Istio installation")

--- a/testsuite/tests/info_collector.py
+++ b/testsuite/tests/info_collector.py
@@ -130,14 +130,22 @@ def test_kuadrant_properties(record_testsuite_property):
 
 
 def test_istio_properties(record_testsuite_property):
-    """Record Istio related properties from all clusters."""
+    """Record Istio installation type and metadata from all clusters."""
     properties = []
     cluster_data = {}
-    for cluster_name, _, project in _all_cluster_projects("istio-system"):
-        if project is None:
-            cluster_data[cluster_name] = ["namespace 'istio-system' not found"]
+    for cluster_name, cluster, _ in _all_cluster_projects("default"):
+        istio_type, namespace = ReportPortalMetadataCollector.get_istio_type(cluster)
+        cluster_data[cluster_name] = [f"istio_type:{istio_type}"]
+        properties.append(("istio_type", istio_type))
+
+        if namespace is None:
             continue
-        cluster_data[cluster_name] = []
+
+        project = cluster.change_project(namespace)
+        if not project.connected:
+            cluster_data[cluster_name].append(f"namespace '{namespace}' not found")
+            continue
+
         istio_metadata = ReportPortalMetadataCollector.get_istio_metadata(project)
         for key, value in istio_metadata.items():
             cluster_data[cluster_name].append(f"{key}:{value}")

--- a/testsuite/tests/singlecluster/authorino/identity/x509/test_xfcc_forwarding.py
+++ b/testsuite/tests/singlecluster/authorino/identity/x509/test_xfcc_forwarding.py
@@ -12,7 +12,7 @@ from testsuite.gateway import GatewayListener
 from testsuite.gateway.gateway_api.gateway import KuadrantGateway
 from .conftest import XFCC_HEADER_NAME
 
-pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only]
+pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only, pytest.mark.required_ossm]
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/singlecluster/authorino/identity/x509/test_xfcc_forwarding.py
+++ b/testsuite/tests/singlecluster/authorino/identity/x509/test_xfcc_forwarding.py
@@ -12,7 +12,7 @@ from testsuite.gateway import GatewayListener
 from testsuite.gateway.gateway_api.gateway import KuadrantGateway
 from .conftest import XFCC_HEADER_NAME
 
-pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only, pytest.mark.required_ossm]
+pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only, pytest.mark.user_managed_istio]
 
 
 @pytest.fixture(scope="module")

--- a/testsuite/tests/singlecluster/gateway/mtls/test_mtls_behaviour.py
+++ b/testsuite/tests/singlecluster/gateway/mtls/test_mtls_behaviour.py
@@ -4,7 +4,7 @@ Tests the enabling and disabling of mTLS configuration via the Kuadrant CR
 
 import pytest
 
-pytestmark = [pytest.mark.disruptive]
+pytestmark = [pytest.mark.disruptive, pytest.mark.required_ossm]
 
 component_cases = [
     pytest.param(["limitador"], id="limitador-only"),

--- a/testsuite/tests/singlecluster/gateway/mtls/test_mtls_behaviour.py
+++ b/testsuite/tests/singlecluster/gateway/mtls/test_mtls_behaviour.py
@@ -4,7 +4,7 @@ Tests the enabling and disabling of mTLS configuration via the Kuadrant CR
 
 import pytest
 
-pytestmark = [pytest.mark.disruptive, pytest.mark.required_ossm]
+pytestmark = [pytest.mark.disruptive, pytest.mark.user_managed_istio]
 
 component_cases = [
     pytest.param(["limitador"], id="limitador-only"),

--- a/testsuite/tests/singlecluster/gateway/mtls/test_mtls_configuration.py
+++ b/testsuite/tests/singlecluster/gateway/mtls/test_mtls_configuration.py
@@ -5,7 +5,7 @@ Tests mTLS configuration and readiness after Kuadrant CR changes
 import pytest
 from openshift_client import selector
 
-pytestmark = [pytest.mark.disruptive]
+pytestmark = [pytest.mark.disruptive, pytest.mark.required_ossm]
 
 component_cases = [
     pytest.param(["limitador"], id="limitador-only"),

--- a/testsuite/tests/singlecluster/gateway/mtls/test_mtls_configuration.py
+++ b/testsuite/tests/singlecluster/gateway/mtls/test_mtls_configuration.py
@@ -5,7 +5,7 @@ Tests mTLS configuration and readiness after Kuadrant CR changes
 import pytest
 from openshift_client import selector
 
-pytestmark = [pytest.mark.disruptive, pytest.mark.required_ossm]
+pytestmark = [pytest.mark.disruptive, pytest.mark.user_managed_istio]
 
 component_cases = [
     pytest.param(["limitador"], id="limitador-only"),

--- a/testsuite/tests/singlecluster/observability/test_kuadrant_operator_health_metrics.py
+++ b/testsuite/tests/singlecluster/observability/test_kuadrant_operator_health_metrics.py
@@ -1,8 +1,8 @@
 """Tests for Kuadrant operator health metrics (existence, readiness, component and dependency status)."""
 
 import pytest
-from openshift_client import selector
 
+from testsuite.gateway.gateway_api.gateway import KuadrantGateway
 from testsuite.prometheus import has_label
 
 pytestmark = [pytest.mark.observability]
@@ -11,7 +11,9 @@ pytestmark = [pytest.mark.observability]
 @pytest.fixture(scope="module")
 def is_istio(cluster, skip_or_fail):
     """Skip if Istio is not installed on the cluster"""
-    if not selector("Istio", all_namespaces=True, static_context=cluster.context).objects():
+    try:
+        KuadrantGateway.get_gateway_class_name(cluster)
+    except KeyError:
         skip_or_fail("Istio is not installed on the cluster")
 
 

--- a/testsuite/tests/singlecluster/tracing/data_plane_tracing/conftest.py
+++ b/testsuite/tests/singlecluster/tracing/data_plane_tracing/conftest.py
@@ -2,6 +2,14 @@
 
 import pytest
 
+from testsuite.gateway.gateway_api.gateway import KuadrantGateway
+
+
+@pytest.fixture(scope="session")
+def has_ocp_managed_istio(cluster):
+    """True if the cluster uses 'openshift-default' GatewayClass (OCP-managed Istio)"""
+    return KuadrantGateway.get_gateway_class_name(cluster) == "openshift-default"
+
 
 @pytest.fixture(scope="module", autouse=True)
 def require_tracing_enabled(kuadrant, skip_or_fail):

--- a/testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing.py
+++ b/testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing.py
@@ -43,39 +43,39 @@ def trace_request_ids(client, auth):
 
 
 @pytest.fixture(scope="module")
-def trace_200(trace_request_ids, tracing, has_user_managed_istio):
+def trace_200(trace_request_ids, tracing, has_ocp_managed_istio):
     """Fetches and caches the full wasm-shim trace for the 200 response."""
     request_id = trace_request_ids[0]
-    min_procs = 4 if has_user_managed_istio else 3
+    min_procs = 3 if has_ocp_managed_istio else 4
     traces = tracing.get_traces(service="wasm-shim", min_processes=min_procs, tags={"request_id": request_id})
     assert len(traces) == 1, f"No trace was found in tracing backend with request_id: {request_id}"
     return traces[0]
 
 
 @pytest.fixture(scope="module")
-def trace_429(trace_request_ids, tracing, has_user_managed_istio):
+def trace_429(trace_request_ids, tracing, has_ocp_managed_istio):
     """Fetches and caches the full wasm-shim trace for the 429 response."""
     request_id = trace_request_ids[1]
-    min_procs = 4 if has_user_managed_istio else 3
+    min_procs = 3 if has_ocp_managed_istio else 4
     traces = tracing.get_traces(service="wasm-shim", min_processes=min_procs, tags={"request_id": request_id})
     assert len(traces) == 1, f"No trace was found in tracing backend with request_id: {request_id}"
     return traces[0]
 
 
 @pytest.fixture(scope="module")
-def trace_401(client, tracing, has_user_managed_istio):
+def trace_401(client, tracing, has_ocp_managed_istio):
     """Sends request producing 401 response and fetches the full wasm-shim trace"""
     response_401 = client.get("/get", headers={"Traceparent": f"00-{os.urandom(16).hex()}-{os.urandom(8).hex()}-01"})
     assert response_401.status_code == 401
 
     request_id = response_401.headers.get("x-request-id")
-    min_procs = 3 if has_user_managed_istio else 2
+    min_procs = 2 if has_ocp_managed_istio else 3
     traces = tracing.get_traces(service="wasm-shim", min_processes=min_procs, tags={"request_id": request_id})
     assert len(traces) == 1, f"No trace was found in tracing backend with request_id: {request_id}"
     return traces[0]
 
 
-def test_trace_includes_all_kuadrant_services(trace_200, label, has_user_managed_istio):
+def test_trace_includes_all_kuadrant_services(trace_200, label, has_ocp_managed_istio):
     """
     Test that distributed tracing captures all Kuadrant components in a single trace.
 
@@ -84,31 +84,31 @@ def test_trace_includes_all_kuadrant_services(trace_200, label, has_user_managed
     - wasm-shim: WASM plugin processing requests
     - authorino: Authorization service
     - limitador: Rate limiting service
-    - gateway: Istio/Envoy gateway service (only with user-managed Istio)
+    - gateway: Istio/Envoy gateway service (not with OCP-managed Istio)
     """
 
     process_services = trace_200.get_process_services()
 
     services = ["wasm-shim", "authorino", "limitador"]
-    if has_user_managed_istio:
+    if not has_ocp_managed_istio:
         services.append(f"{label}.kuadrant")
     for service in services:
         assert service in process_services, f"Service '{service}' not found in trace processes: {process_services}"
 
 
-def test_relevant_services_on_auth_denied(trace_401, label, has_user_managed_istio):
+def test_relevant_services_on_auth_denied(trace_401, label, has_ocp_managed_istio):
     """
     Test that auth-denied traces only include services up to the authorization step.
 
     When a request is rejected with 401, the trace should contain wasm-shim and authorino
     but not limitador, since the request is short-circuited before reaching the rate limiter.
-    Gateway service is only present with user-managed Istio.
+    Gateway service is not present with OCP-managed Istio.
     """
 
     process_services = trace_401.get_process_services()
 
     services = ["wasm-shim", "authorino"]
-    if has_user_managed_istio:
+    if not has_ocp_managed_istio:
         services.append(f"{label}.kuadrant")
     for service in services:
         assert service in process_services, f"Service '{service}' not found in trace processes: {process_services}"

--- a/testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing.py
+++ b/testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing.py
@@ -3,6 +3,10 @@ Tests for distributed tracing integration across Kuadrant components.
 
 This module validates that tracing correctly captures request flows through the entire
 Kuadrant stack, including wasm-shim, Authorino, Limitador, and gateway services.
+
+With Gateway API-managed Istio, gateway traces are not available because the Istio CR cannot be
+modified to enable tracing (meshConfig.enableTracing, extensionProviders) and the Telemetry
+resource cannot be created. Gateway service assertions are conditional on has_ossm.
 """
 
 import os
@@ -39,37 +43,39 @@ def trace_request_ids(client, auth):
 
 
 @pytest.fixture(scope="module")
-def trace_200(trace_request_ids, tracing):
+def trace_200(trace_request_ids, tracing, has_ossm):
     """Fetches and caches the full wasm-shim trace for the 200 response."""
     request_id = trace_request_ids[0]
-    traces = tracing.get_traces(service="wasm-shim", min_processes=4, tags={"request_id": request_id})
+    min_procs = 4 if has_ossm else 3
+    traces = tracing.get_traces(service="wasm-shim", min_processes=min_procs, tags={"request_id": request_id})
     assert len(traces) == 1, f"No trace was found in tracing backend with request_id: {request_id}"
     return traces[0]
 
 
 @pytest.fixture(scope="module")
-def trace_429(trace_request_ids, tracing):
+def trace_429(trace_request_ids, tracing, has_ossm):
     """Fetches and caches the full wasm-shim trace for the 429 response."""
     request_id = trace_request_ids[1]
-    traces = tracing.get_traces(service="wasm-shim", min_processes=4, tags={"request_id": request_id})
+    min_procs = 4 if has_ossm else 3
+    traces = tracing.get_traces(service="wasm-shim", min_processes=min_procs, tags={"request_id": request_id})
     assert len(traces) == 1, f"No trace was found in tracing backend with request_id: {request_id}"
     return traces[0]
 
 
 @pytest.fixture(scope="module")
-def trace_401(client, tracing):
-    """
-    Sends request producing 401 response and fetches the full wasm-shim trace"""
+def trace_401(client, tracing, has_ossm):
+    """Sends request producing 401 response and fetches the full wasm-shim trace"""
     response_401 = client.get("/get", headers={"Traceparent": f"00-{os.urandom(16).hex()}-{os.urandom(8).hex()}-01"})
     assert response_401.status_code == 401
 
     request_id = response_401.headers.get("x-request-id")
-    traces = tracing.get_traces(service="wasm-shim", min_processes=3, tags={"request_id": request_id})
+    min_procs = 3 if has_ossm else 2
+    traces = tracing.get_traces(service="wasm-shim", min_processes=min_procs, tags={"request_id": request_id})
     assert len(traces) == 1, f"No trace was found in tracing backend with request_id: {request_id}"
     return traces[0]
 
 
-def test_trace_includes_all_kuadrant_services(trace_200, label):
+def test_trace_includes_all_kuadrant_services(trace_200, label, has_ossm):
     """
     Test that distributed tracing captures all Kuadrant components in a single trace.
 
@@ -78,28 +84,32 @@ def test_trace_includes_all_kuadrant_services(trace_200, label):
     - wasm-shim: WASM plugin processing requests
     - authorino: Authorization service
     - limitador: Rate limiting service
-    - gateway: Istio/Envoy gateway service
+    - gateway: Istio/Envoy gateway service (only with full OSSM3)
     """
 
     process_services = trace_200.get_process_services()
 
-    services = ["wasm-shim", "authorino", "limitador", f"{label}.kuadrant"]
+    services = ["wasm-shim", "authorino", "limitador"]
+    if has_ossm:
+        services.append(f"{label}.kuadrant")
     for service in services:
         assert service in process_services, f"Service '{service}' not found in trace processes: {process_services}"
 
 
-def test_relevant_services_on_auth_denied(trace_401, label):
+def test_relevant_services_on_auth_denied(trace_401, label, has_ossm):
     """
     Test that auth-denied traces only include services up to the authorization step.
 
     When a request is rejected with 401, the trace should contain wasm-shim and authorino
     but not limitador, since the request is short-circuited before reaching the rate limiter.
-    Note: gateway service is not included since the request was sent without traceparent header.
+    Gateway service is only present with full OSSM3 Istio installation.
     """
 
     process_services = trace_401.get_process_services()
 
-    services = ["wasm-shim", "authorino", f"{label}.kuadrant"]
+    services = ["wasm-shim", "authorino"]
+    if has_ossm:
+        services.append(f"{label}.kuadrant")
     for service in services:
         assert service in process_services, f"Service '{service}' not found in trace processes: {process_services}"
 

--- a/testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing.py
+++ b/testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing.py
@@ -4,9 +4,9 @@ Tests for distributed tracing integration across Kuadrant components.
 This module validates that tracing correctly captures request flows through the entire
 Kuadrant stack, including wasm-shim, Authorino, Limitador, and gateway services.
 
-With Gateway API-managed Istio, gateway traces are not available because the Istio CR cannot be
+With OCP-managed Istio, gateway traces are not available because the Istio CR cannot be
 modified to enable tracing (meshConfig.enableTracing, extensionProviders) and the Telemetry
-resource cannot be created. Gateway service assertions are conditional on has_ossm.
+resource cannot be created. Gateway service assertions are conditional on user-managed Istio.
 """
 
 import os
@@ -43,39 +43,39 @@ def trace_request_ids(client, auth):
 
 
 @pytest.fixture(scope="module")
-def trace_200(trace_request_ids, tracing, has_ossm):
+def trace_200(trace_request_ids, tracing, has_user_managed_istio):
     """Fetches and caches the full wasm-shim trace for the 200 response."""
     request_id = trace_request_ids[0]
-    min_procs = 4 if has_ossm else 3
+    min_procs = 4 if has_user_managed_istio else 3
     traces = tracing.get_traces(service="wasm-shim", min_processes=min_procs, tags={"request_id": request_id})
     assert len(traces) == 1, f"No trace was found in tracing backend with request_id: {request_id}"
     return traces[0]
 
 
 @pytest.fixture(scope="module")
-def trace_429(trace_request_ids, tracing, has_ossm):
+def trace_429(trace_request_ids, tracing, has_user_managed_istio):
     """Fetches and caches the full wasm-shim trace for the 429 response."""
     request_id = trace_request_ids[1]
-    min_procs = 4 if has_ossm else 3
+    min_procs = 4 if has_user_managed_istio else 3
     traces = tracing.get_traces(service="wasm-shim", min_processes=min_procs, tags={"request_id": request_id})
     assert len(traces) == 1, f"No trace was found in tracing backend with request_id: {request_id}"
     return traces[0]
 
 
 @pytest.fixture(scope="module")
-def trace_401(client, tracing, has_ossm):
+def trace_401(client, tracing, has_user_managed_istio):
     """Sends request producing 401 response and fetches the full wasm-shim trace"""
     response_401 = client.get("/get", headers={"Traceparent": f"00-{os.urandom(16).hex()}-{os.urandom(8).hex()}-01"})
     assert response_401.status_code == 401
 
     request_id = response_401.headers.get("x-request-id")
-    min_procs = 3 if has_ossm else 2
+    min_procs = 3 if has_user_managed_istio else 2
     traces = tracing.get_traces(service="wasm-shim", min_processes=min_procs, tags={"request_id": request_id})
     assert len(traces) == 1, f"No trace was found in tracing backend with request_id: {request_id}"
     return traces[0]
 
 
-def test_trace_includes_all_kuadrant_services(trace_200, label, has_ossm):
+def test_trace_includes_all_kuadrant_services(trace_200, label, has_user_managed_istio):
     """
     Test that distributed tracing captures all Kuadrant components in a single trace.
 
@@ -84,31 +84,31 @@ def test_trace_includes_all_kuadrant_services(trace_200, label, has_ossm):
     - wasm-shim: WASM plugin processing requests
     - authorino: Authorization service
     - limitador: Rate limiting service
-    - gateway: Istio/Envoy gateway service (only with full OSSM3)
+    - gateway: Istio/Envoy gateway service (only with user-managed Istio)
     """
 
     process_services = trace_200.get_process_services()
 
     services = ["wasm-shim", "authorino", "limitador"]
-    if has_ossm:
+    if has_user_managed_istio:
         services.append(f"{label}.kuadrant")
     for service in services:
         assert service in process_services, f"Service '{service}' not found in trace processes: {process_services}"
 
 
-def test_relevant_services_on_auth_denied(trace_401, label, has_ossm):
+def test_relevant_services_on_auth_denied(trace_401, label, has_user_managed_istio):
     """
     Test that auth-denied traces only include services up to the authorization step.
 
     When a request is rejected with 401, the trace should contain wasm-shim and authorino
     but not limitador, since the request is short-circuited before reaching the rate limiter.
-    Gateway service is only present with full OSSM3 Istio installation.
+    Gateway service is only present with user-managed Istio.
     """
 
     process_services = trace_401.get_process_services()
 
     services = ["wasm-shim", "authorino"]
-    if has_ossm:
+    if has_user_managed_istio:
         services.append(f"{label}.kuadrant")
     for service in services:
         assert service in process_services, f"Service '{service}' not found in trace processes: {process_services}"

--- a/testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing_rate_limit_only.py
+++ b/testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing_rate_limit_only.py
@@ -32,7 +32,7 @@ def commit(request, rate_limit):
 
 
 @pytest.fixture(scope="module")
-def trace_429(client, tracing, has_user_managed_istio):
+def trace_429(client, tracing, has_ocp_managed_istio):
     """
     Sends requests to exhaust the rate limit, produces a 429 response,
     and fetches the full wasm-shim trace.
@@ -44,22 +44,22 @@ def trace_429(client, tracing, has_user_managed_istio):
     assert response_429.status_code == 429
 
     request_id = response_429.headers.get("x-request-id")
-    min_procs = 3 if has_user_managed_istio else 2
+    min_procs = 2 if has_ocp_managed_istio else 3
     traces = tracing.get_traces(service="wasm-shim", min_processes=min_procs, tags={"request_id": request_id})
     assert len(traces) == 1, f"No trace was found in tracing backend with request_id: {request_id}"
     return traces[0]
 
 
-def test_relevant_services_rate_limit_only(trace_429, label, has_user_managed_istio):
+def test_relevant_services_rate_limit_only(trace_429, label, has_ocp_managed_istio):
     """
     Test that traces with only a RateLimitPolicy include relevant Kuadrant services.
-    Gateway service is only present with user-managed Istio.
+    Gateway service is not present with OCP-managed Istio.
     Trace should not contain authorino since no authorization is involved.
     """
 
     process_services = trace_429.get_process_services()
     services = ["wasm-shim", "limitador"]
-    if has_user_managed_istio:
+    if not has_ocp_managed_istio:
         services.append(f"{label}.kuadrant")
     for service in services:
         assert service in process_services, f"Service '{service}' not found in trace processes: {process_services}"

--- a/testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing_rate_limit_only.py
+++ b/testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing_rate_limit_only.py
@@ -1,9 +1,9 @@
 """
 Tests for distributed tracing with only a RateLimitPolicy configured (no AuthPolicy).
 
-With Gateway API-managed Istio, gateway traces are not available because the Istio CR cannot be
+With OCP-managed Istio, gateway traces are not available because the Istio CR cannot be
 modified to enable tracing (meshConfig.enableTracing, extensionProviders) and the Telemetry
-resource cannot be created. Gateway service assertions are conditional on has_ossm.
+resource cannot be created. Gateway service assertions are conditional on user-managed Istio.
 """
 
 import os
@@ -32,7 +32,7 @@ def commit(request, rate_limit):
 
 
 @pytest.fixture(scope="module")
-def trace_429(client, tracing, has_ossm):
+def trace_429(client, tracing, has_user_managed_istio):
     """
     Sends requests to exhaust the rate limit, produces a 429 response,
     and fetches the full wasm-shim trace.
@@ -44,22 +44,22 @@ def trace_429(client, tracing, has_ossm):
     assert response_429.status_code == 429
 
     request_id = response_429.headers.get("x-request-id")
-    min_procs = 3 if has_ossm else 2
+    min_procs = 3 if has_user_managed_istio else 2
     traces = tracing.get_traces(service="wasm-shim", min_processes=min_procs, tags={"request_id": request_id})
     assert len(traces) == 1, f"No trace was found in tracing backend with request_id: {request_id}"
     return traces[0]
 
 
-def test_relevant_services_rate_limit_only(trace_429, label, has_ossm):
+def test_relevant_services_rate_limit_only(trace_429, label, has_user_managed_istio):
     """
     Test that traces with only a RateLimitPolicy include relevant Kuadrant services.
-    Gateway service is only present with full OSSM3 Istio installation.
+    Gateway service is only present with user-managed Istio.
     Trace should not contain authorino since no authorization is involved.
     """
 
     process_services = trace_429.get_process_services()
     services = ["wasm-shim", "limitador"]
-    if has_ossm:
+    if has_user_managed_istio:
         services.append(f"{label}.kuadrant")
     for service in services:
         assert service in process_services, f"Service '{service}' not found in trace processes: {process_services}"

--- a/testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing_rate_limit_only.py
+++ b/testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing_rate_limit_only.py
@@ -1,5 +1,9 @@
 """
 Tests for distributed tracing with only a RateLimitPolicy configured (no AuthPolicy).
+
+With Gateway API-managed Istio, gateway traces are not available because the Istio CR cannot be
+modified to enable tracing (meshConfig.enableTracing, extensionProviders) and the Telemetry
+resource cannot be created. Gateway service assertions are conditional on has_ossm.
 """
 
 import os
@@ -28,7 +32,7 @@ def commit(request, rate_limit):
 
 
 @pytest.fixture(scope="module")
-def trace_429(client, tracing):
+def trace_429(client, tracing, has_ossm):
     """
     Sends requests to exhaust the rate limit, produces a 429 response,
     and fetches the full wasm-shim trace.
@@ -40,19 +44,23 @@ def trace_429(client, tracing):
     assert response_429.status_code == 429
 
     request_id = response_429.headers.get("x-request-id")
-    traces = tracing.get_traces(service="wasm-shim", min_processes=3, tags={"request_id": request_id})
+    min_procs = 3 if has_ossm else 2
+    traces = tracing.get_traces(service="wasm-shim", min_processes=min_procs, tags={"request_id": request_id})
     assert len(traces) == 1, f"No trace was found in tracing backend with request_id: {request_id}"
     return traces[0]
 
 
-def test_relevant_services_rate_limit_only(trace_429, label):
+def test_relevant_services_rate_limit_only(trace_429, label, has_ossm):
     """
-    Test that traces with only a RateLimitPolicy include all relevant services (wasm-shim, limitador, and gateway).
+    Test that traces with only a RateLimitPolicy include relevant Kuadrant services.
+    Gateway service is only present with full OSSM3 Istio installation.
     Trace should not contain authorino since no authorization is involved.
     """
 
     process_services = trace_429.get_process_services()
-    services = ["wasm-shim", "limitador", f"{label}.kuadrant"]
+    services = ["wasm-shim", "limitador"]
+    if has_ossm:
+        services.append(f"{label}.kuadrant")
     for service in services:
         assert service in process_services, f"Service '{service}' not found in trace processes: {process_services}"
 


### PR DESCRIPTION
> [!IMPORTANT]
  > This PR modifies shared/core testsuite code that could potentially affect multiple test areas. 2 reviewers should review this PR to ensure adequate coverage.

  ## Description
  - Add support for clusters with Gateway API-managed Istio (auto-provisioned `openshift-gateway` CR) that cannot be modified like a user-managed OSSM3 installation
  - mTLS and xfcc tests are skipped on Gateway API-managed Istio since they require modifying the Istio CR (sidecar injection, PeerAuthentication)
  - Data plane tracing tests are adjusted to work without gateway traces, since `meshConfig.enableTracing`, `extensionProviders`, and `Telemetry` resources cannot be configured on Gateway API-managed Istio


   ## Changes

   ### Istio detection via GatewayClass

   - `check_user_managed_istio` autouse fixture in `testsuite/tests/conftest.py` now uses `KuadrantGateway.get_gateway_class_name()` to detect OCP-managed Istio instead of querying Istio CRs
   - Removed `has_user_managed_istio` session fixture from root conftest (no longer needed there)
   - `is_istio` fixture in `test_kuadrant_operator_health_metrics.py` updated to use GatewayClass detection

   ### Tracing test adjustments

   - Added `has_ocp_managed_istio` session fixture in `testsuite/tests/singlecluster/tracing/data_plane_tracing/conftest.py`
   - Adjusted `test_kuadrant_tracing.py` and `test_kuadrant_tracing_rate_limit_only.py` to make gateway service assertions conditional on `has_ocp_managed_istio` and lower `min_processes` thresholds when gateway traces are unavailable

   ### Info collector

   - `get_istio_type()` in `ReportPortalMetadataCollector` now uses `KuadrantGateway.get_gateway_class_name()` to determine installation type
   - Hardcoded namespaces: `openshift-ingress` for OCP-managed, `istio-system` for user-managed (no Istio CR lookup needed)
   - `get_istio_metadata()` falls back to `app.kubernetes.io/version` pod label for Istio version when no Istio CR exists


## Known failures (unrelated to this PR)

  The following data plane tracing tests fail due to a known wasm-shim issue with missing `send_reply` spans and span hierarchy:
  - `test_send_reply_span_on_request_rejection[429-trace_429]`
  - `test_send_reply_span_on_request_rejection[401-trace_401]`
  - `test_span_hierarchy`


 ## Verification steps

  Run on a cluster with **Gateway API-managed Istio** (auto-provisioned `openshift-gateway` CR, no user-managed OSSM3):
  
  - mTLS and xfcc tests should be **skipped**
  - Tracing tests should **pass** without gateway service assertions

  ```bash
  poetry run pytest -vv -n4 \
    testsuite/tests/singlecluster/gateway/mtls/test_mtls_configuration.py \
    testsuite/tests/singlecluster/gateway/mtls/test_mtls_behaviour.py \
    testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing.py \
    testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing_rate_limit_only.py \
    testsuite/tests/singlecluster/authorino/identity/x509/test_xfcc_forwarding.py

  On a cluster with user-managed OSSM3, all tests should run and pass as before (no behavioral change).
  ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new pytest marker to flag tests that require a user-managed (not OCP-managed) Istio installation.
  * Enhanced the test harness to detect the cluster’s Istio type/namespace and skip or enforce those marker-tagged tests accordingly.
  * Updated gateway and tracing expectations to conditionally include gateway-related services/traces only when user-managed Istio is available.
  * Improved Istio properties/metadata reporting to use dynamically determined Istio namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->