### PR TITLE
fix(local-setup): auto-detect podman socket for cloud-provider-kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ else
 resultsdir ?= .
 endif
 
-ROOTLESS_NETNS := $(shell if $(CONTAINER_ENGINE) --version 2>/dev/null | grep -qi podman && $(CONTAINER_ENGINE) info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -q true; then echo "podman unshare --rootless-netns"; fi)
+ROOTLESS_NETNS := $(shell if [ "$$(uname)" = "Linux" ] && $(CONTAINER_ENGINE) --version 2>/dev/null | grep -qi podman && $(CONTAINER_ENGINE) info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -q true; then echo "podman unshare --rootless-netns"; fi)
 PYTEST = $(ROOTLESS_NETNS) poetry run python -m pytest --tb=$(TB) --reruns 3 --reruns-delay 2 -o cache_dir=$(resultsdir)/.pytest_cache.$(@F)
 RUNSCRIPT = poetry run ./scripts/
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ else
 resultsdir ?= .
 endif
 
-PYTEST = poetry run python -m pytest --tb=$(TB) --reruns 3 --reruns-delay 2 -o cache_dir=$(resultsdir)/.pytest_cache.$(@F)
+ROOTLESS_NETNS := $(shell if $(CONTAINER_ENGINE) --version 2>/dev/null | grep -qi podman && $(CONTAINER_ENGINE) info --format '{{.Host.Security.Rootless}}' 2>/dev/null | grep -q true; then echo "podman unshare --rootless-netns"; fi)
+PYTEST = $(ROOTLESS_NETNS) poetry run python -m pytest --tb=$(TB) --reruns 3 --reruns-delay 2 -o cache_dir=$(resultsdir)/.pytest_cache.$(@F)
 RUNSCRIPT = poetry run ./scripts/
 
 ifdef junit

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ For local development and testing, you can set up a complete Kuadrant environmen
 * [jq](https://jqlang.github.io/jq/download/) (JSON processor)
 
 > **Podman users:** Set `CONTAINER_ENGINE=podman` when running `make local-setup`. Docker is used by default.
+> On Linux, enable the podman socket first: `systemctl --user enable --now podman.socket`
 
 > **macOS container runtime:** Use [Podman Desktop](https://podman-desktop.io/) or [Docker Desktop](https://www.docker.com/products/docker-desktop/) as the container runtime. Other Docker-compatible runtimes (e.g. OrbStack) may not work due to LoadBalancer networking incompatibilities with `cloud-provider-kind`.
 

--- a/make/dependencies.mk
+++ b/make/dependencies.mk
@@ -18,14 +18,29 @@ start-cloud-provider: ## Start cloud-provider-kind for LoadBalancer services
 	fi
 	@if pgrep -x cloud-provider-kind >/dev/null 2>&1; then \
 		echo "cloud-provider-kind is already running"; \
-	elif [ "$$(uname)" = "Darwin" ]; then \
-		echo "Starting cloud-provider-kind (macOS, requires sudo)..."; \
-		sudo cloud-provider-kind > /tmp/cloud-provider-kind.log 2>&1 & \
-		sleep 2; \
-		echo "cloud-provider-kind started (log: /tmp/cloud-provider-kind.log)"; \
 	else \
+		DOCKER_HOST_ENV=""; \
+		if $(CONTAINER_ENGINE) --version 2>/dev/null | grep -qi podman; then \
+			if [ "$$(uname)" = "Darwin" ]; then \
+				SOCKET="$$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}' 2>/dev/null)"; \
+			else \
+				SOCKET="$$(podman info --format '{{.Host.RemoteSocket.Path}}' 2>/dev/null)"; \
+			fi; \
+			if [ -n "$$SOCKET" ] && [ -S "$$SOCKET" ]; then \
+				DOCKER_HOST_ENV="DOCKER_HOST=unix://$$SOCKET"; \
+				echo "Detected podman, using socket: $$SOCKET"; \
+			else \
+				echo "ERROR: Podman detected, but no Docker-compatible socket was found."; \
+				echo "  On Linux, enable the podman socket: systemctl --user start podman.socket"; \
+				exit 1; \
+			fi; \
+		fi; \
 		echo "Starting cloud-provider-kind..."; \
-		cloud-provider-kind > /tmp/cloud-provider-kind.log 2>&1 & \
+		if [ "$$(uname)" = "Darwin" ]; then \
+			sudo env $$DOCKER_HOST_ENV cloud-provider-kind > /tmp/cloud-provider-kind.log 2>&1 & \
+		else \
+			env $$DOCKER_HOST_ENV cloud-provider-kind > /tmp/cloud-provider-kind.log 2>&1 & \
+		fi; \
 		sleep 2; \
 		echo "cloud-provider-kind started (log: /tmp/cloud-provider-kind.log)"; \
 	fi

--- a/make/dependencies.mk
+++ b/make/dependencies.mk
@@ -16,42 +16,54 @@ start-cloud-provider: ## Start cloud-provider-kind for LoadBalancer services
 		echo "  or on macOS: brew install cloud-provider-kind"; \
 		exit 1; \
 	fi
-	@if pgrep -x cloud-provider-kind >/dev/null 2>&1; then \
-		echo "cloud-provider-kind is already running"; \
-	else \
-		DOCKER_HOST_ENV=""; \
-		if $(CONTAINER_ENGINE) --version 2>/dev/null | grep -qi podman; then \
-			if [ "$$(uname)" = "Darwin" ]; then \
-				SOCKET="$$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}' 2>/dev/null)"; \
-			else \
-				SOCKET="$$(podman info --format '{{.Host.RemoteSocket.Path}}' 2>/dev/null)"; \
-			fi; \
-			if [ -n "$$SOCKET" ] && [ -S "$$SOCKET" ]; then \
-				DOCKER_HOST_ENV="DOCKER_HOST=unix://$$SOCKET"; \
-				echo "Detected podman, using socket: $$SOCKET"; \
-			else \
-				echo "ERROR: Podman detected, but no Docker-compatible socket was found."; \
-				echo "  On Linux, enable the podman socket: systemctl --user start podman.socket"; \
-				exit 1; \
-			fi; \
-		fi; \
-		echo "Starting cloud-provider-kind..."; \
-		if [ "$$(uname)" = "Darwin" ]; then \
-			sudo env $$DOCKER_HOST_ENV cloud-provider-kind > /tmp/cloud-provider-kind.log 2>&1 & \
-		else \
-			env $$DOCKER_HOST_ENV cloud-provider-kind > /tmp/cloud-provider-kind.log 2>&1 & \
-		fi; \
-		sleep 2; \
-		echo "cloud-provider-kind started (log: /tmp/cloud-provider-kind.log)"; \
+	@if [ "$$(uname)" = "Darwin" ]; then \
+		sudo pkill -f cloud-provider-kind 2>/dev/null || true; \
+	elif [ -f /tmp/cloud-provider-kind.pid ]; then \
+		PID=$$(cat /tmp/cloud-provider-kind.pid); \
+		kill -9 $$PID 2>/dev/null || true; \
+		rm -f /tmp/cloud-provider-kind.pid; \
+		echo "Stopped existing cloud-provider-kind (PID $$PID)"; \
 	fi
+	@DOCKER_HOST_ENV=""; \
+	if $(CONTAINER_ENGINE) --version 2>/dev/null | grep -qi podman; then \
+		if [ "$$(uname)" = "Darwin" ]; then \
+			SOCKET="$$(podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}' 2>/dev/null)"; \
+		else \
+			SOCKET="$$(podman info --format '{{.Host.RemoteSocket.Path}}' 2>/dev/null)"; \
+		fi; \
+		if [ -n "$$SOCKET" ] && [ -S "$$SOCKET" ]; then \
+			DOCKER_HOST_ENV="DOCKER_HOST=unix://$$SOCKET"; \
+			echo "Detected podman, using socket: $$SOCKET"; \
+		else \
+			echo "ERROR: Podman detected, but no Docker-compatible socket was found."; \
+			if [ "$$(uname)" = "Darwin" ]; then \
+				echo "ERROR: Check 'podman machine start' or 'podman machine inspect'."; \
+			else \
+				echo "ERROR: Use 'systemctl --user status podman.socket' to check status."; \
+				echo "  On Linux, enable the podman socket: systemctl --user start podman.socket"; \
+			fi; \
+			exit 1; \
+		fi; \
+	fi; \
+	echo "Starting cloud-provider-kind..."; \
+	if [ "$$(uname)" = "Darwin" ]; then \
+		sudo env $$DOCKER_HOST_ENV cloud-provider-kind > /tmp/cloud-provider-kind.log 2>&1 & \
+	else \
+		env $$DOCKER_HOST_ENV cloud-provider-kind --enable-lb-port-mapping > /tmp/cloud-provider-kind.log 2>&1 & \
+		echo $$! > /tmp/cloud-provider-kind.pid; \
+	fi; \
+	sleep 2; \
+	echo "cloud-provider-kind started (log: /tmp/cloud-provider-kind.log)"
 
 .PHONY: stop-cloud-provider
 stop-cloud-provider: ## Stop cloud-provider-kind background process
 	@echo "Stopping cloud-provider-kind..."
 	@if [ "$$(uname)" = "Darwin" ]; then \
 		sudo pkill -f cloud-provider-kind 2>/dev/null || true; \
-	else \
-		kill [c]loud-provider-kind 2>/dev/null || true; \
+	elif [ -f /tmp/cloud-provider-kind.pid ]; then \
+		PID=$$(cat /tmp/cloud-provider-kind.pid); \
+		kill -9 $$PID 2>/dev/null || true; \
+		rm -f /tmp/cloud-provider-kind.pid; \
 	fi
 	@echo "cloud-provider-kind stopped"
 

--- a/make/kind.mk
+++ b/make/kind.mk
@@ -4,7 +4,7 @@
 .PHONY: kind-create-cluster
 kind-create-cluster: ## Create kind cluster
 	@echo "Creating kind cluster '$(KIND_CLUSTER_NAME)'..."
-	@if kind get clusters | grep -qx "$(KIND_CLUSTER_NAME)"; then \
+	@if KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) kind get clusters | grep -qx "$(KIND_CLUSTER_NAME)"; then \
 		echo "Cluster already exists"; \
 	else \
 		KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) kind create cluster --name $(KIND_CLUSTER_NAME); \


### PR DESCRIPTION
## Description

  - `cloud-provider-kind` hardcodes `docker` commands internally and fails when using podman unless `DOCKER_HOST` is explicitly set ([upstream issue](https://github.com/kubernetes-sigs/cloud-provider-kind/issues/221))
  - The `start-cloud-provider` target now auto-detects podman and resolves the correct socket path, so `make local-setup` works out of the box with podman without requiring manual symlinks or docker context configuration

  ## Changes

  ### Bug Fix
  - Detect podman runtime via `$(CONTAINER_ENGINE) --version` output
  - Resolve podman socket path per platform:
    - **macOS**: `podman machine inspect --format '{{.ConnectionInfo.PodmanSocket.Path}}'`
    - **Linux (rootful)**: `/run/podman/podman.sock`
    - **Linux (rootless)**: `/run/user/<uid>/podman/podman.sock`
  - Pass `DOCKER_HOST` through `sudo env` on macOS so the env var reaches the `cloud-provider-kind` process
  - Docker users are unaffected — the podman detection is skipped when docker is the container engine

  ## Verification steps

  1. With podman: `CONTAINER_ENGINE=podman make local-setup` — verify LoadBalancer services get external IPs assigned
  2. With docker: `make local-setup` — verify no change in behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved cloud-provider start/stop for Podman by auto-selecting a Docker-compatible socket, using PID-based shutdown on non-macOS, and providing clearer OS-specific guidance when required sockets aren’t available.
  * Refined cluster existence checks to match the selected container runtime.
  * Updated test execution to better support Podman rootless networking.
* **Documentation**
  * Added Linux Podman instructions to ensure the Podman socket is enabled before running local setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->