### PR TITLE
fix(test): resolve duplicate parametrization of credentials fixture

### DIFF
--- a/testsuite/tests/singlecluster/authorino/identity/api_key/test_auth_credentials.py
+++ b/testsuite/tests/singlecluster/authorino/identity/api_key/test_auth_credentials.py
@@ -7,7 +7,7 @@ from testsuite.kuadrant.policy.authorization import Credentials
 pytestmark = [pytest.mark.authorino]
 
 
-@pytest.fixture(scope="module", params=["authorizationHeader", "customHeader", "queryString", "cookie"])
+@pytest.fixture(scope="module")
 def credentials(request):
     """Location where are auth credentials passed"""
     return request.param
@@ -36,6 +36,11 @@ def test_custom_selector(client, auth, credentials):
         assert response.status_code == 401
 
 
+@pytest.mark.parametrize(
+    "credentials",
+    ["authorizationHeader", "customHeader", "queryString", "cookie"],
+    indirect=True,
+)
 def test_custom_header(client, auth, credentials):
     """Test if auth credentials are stored in right place"""
     response = client.get("/get", headers={"APIKEY": auth.api_key})
@@ -45,6 +50,11 @@ def test_custom_header(client, auth, credentials):
         assert response.status_code == 401
 
 
+@pytest.mark.parametrize(
+    "credentials",
+    ["authorizationHeader", "customHeader", "queryString", "cookie"],
+    indirect=True,
+)
 def test_query(client, auth, credentials):
     """Test if auth credentials are stored in right place"""
     response = client.get("/get", params={"APIKEY": auth.api_key})
@@ -54,6 +64,11 @@ def test_query(client, auth, credentials):
         assert response.status_code == 401
 
 
+@pytest.mark.parametrize(
+    "credentials",
+    ["authorizationHeader", "customHeader", "queryString", "cookie"],
+    indirect=True,
+)
 def test_cookie(hostname, auth, credentials):
     """Test if auth credentials are stored in right place"""
     with hostname.client(cookies={"APIKEY": auth.api_key}) as client:


### PR DESCRIPTION
 ## Description
  - Fix `pytest 9.1.0` collection error: "duplicate parametrization of `credentials`" in `test_auth_credentials.py`
  - The `credentials` fixture had `params=` and `test_custom_selector` also used `@pytest.mark.parametrize("credentials", ..., indirect=True)`, which `pytest 9.1.0` now rejects
  - Moves parametrization from the fixture to each test function via `@pytest.mark.parametrize(..., indirect=True)`

  ## Changes
  ### Bug Fixes
  - Removed `params=` from the `credentials` fixture to eliminate the duplicate parametrization conflict
  - Added `@pytest.mark.parametrize("credentials", ..., indirect=True)` to `test_custom_header`, `test_query`, and `test_cookie`
  - Preserved the `pytest.mark.smoke` marker on `test_custom_selector[authorizationHeader]`

  ## Verification steps
  ```bash
  poetry run pytest -vv testsuite/tests/singlecluster/authorino/identity/api_key/test_auth_credentials.py