### PR TITLE
fix: increase mockserver CPU limit

### DIFF
--- a/testsuite/backend/mockserver.py
+++ b/testsuite/backend/mockserver.py
@@ -80,7 +80,7 @@ class MockserverBackend(Backend):
             selector=Selector(matchLabels=match_labels),
             labels={"app": self.label},
             resources=ContainerResources(
-                limits_cpu="100m", requests_cpu="10m", limits_memory="300Mi", requests_memory="200Mi"
+                limits_cpu="500m", requests_cpu="10m", limits_memory="300Mi", requests_memory="200Mi"
             ),
             lifecycle={"postStart": {"exec": {"command": ["/bin/sh", "init-mockserver"]}}},
             volumes=self.config.volumes if self.config else None,


### PR DESCRIPTION
> [!IMPORTANT]
  > This PR modifies shared/core testsuite code that could potentially affect multiple test areas. 2 reviewers should review this PR to ensure adequate coverage.                                           

  ## Description
  - Increase `MockserverBackend` CPU limit from `100m` to `500m` to prevent JVM cold start timeouts
  - With only `100m` CPU, the mockserver JVM takes 20-30s to start processing requests, but the test client times out after 5s and retries automatically
  - Each retry still counts against the rate limit at the gateway level, so by the time mockserver is ready, the rate limit is already exhausted and the test fails
  - Confirmed with `curl` that the gateway and rate limiting work correctly — the issue is purely the slow mockserver + client retries
  - The issue was only caught when running a single test file (`test_rate_limit_authz.py`) in isolation, not during the full `make kuadrant` suite where mockserver is already warmed up by earlier tests

  ## Changes
  ### Bug Fix
  - Increased `limits_cpu` from `100m` to `500m` in `testsuite/backend/mockserver.py` to give the JVM enough CPU for cold start while still preventing cluster resource starvation that #990 was solving

  ## Verification steps
  ```sh
  poetry run pytest -vv testsuite/tests/singlecluster/test_rate_limit_authz.py
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimised backend test infrastructure resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->