### PR TITLE
feat: patch kuadrant operator image via KUADRANT_OPERATOR_IMAGE

### DIFF
--- a/make/kuadrant.mk
+++ b/make/kuadrant.mk
@@ -30,6 +30,7 @@ endif
 	$(MAKE) patch-kuadrant-operator-env
 	@echo "Kuadrant Operator $(KUADRANT_OPERATOR_VERSION) installed from Helm"
 endif
+	$(MAKE) patch-kuadrant-operator-image
 ifeq ($(INSTALL_TRACING),true)
 	@echo "Configuring OTEL tracing on limitador-operator..."
 	@kubectl set env deployment/limitador-operator-controller-manager \
@@ -38,6 +39,19 @@ ifeq ($(INSTALL_TRACING),true)
 		OTEL_EXPORTER_OTLP_INSECURE=true
 	@kubectl rollout status deployment/limitador-operator-controller-manager \
 		-n $(KUADRANT_NAMESPACE) --timeout=$(KUBECTL_TIMEOUT)
+endif
+
+.PHONY: patch-kuadrant-operator-image
+patch-kuadrant-operator-image: ## Patch Kuadrant Operator deployment with custom image
+ifneq ($(KUADRANT_OPERATOR_IMAGE),)
+	@echo "Patching Kuadrant Operator image to $(KUADRANT_OPERATOR_IMAGE)..."
+	kubectl set image deployment/kuadrant-operator-controller-manager \
+		-n $(KUADRANT_NAMESPACE) \
+		manager=$(KUADRANT_OPERATOR_IMAGE)
+	kubectl -n $(KUADRANT_NAMESPACE) rollout status deployment/kuadrant-operator-controller-manager --timeout=$(KUBECTL_TIMEOUT)
+	@echo "Kuadrant Operator image patched"
+else
+	@echo "No custom operator image specified (KUADRANT_OPERATOR_IMAGE not set), skipping"
 endif
 
 .PHONY: patch-kuadrant-operator-env


### PR DESCRIPTION
## Summary
- Wire up the existing `KUADRANT_OPERATOR_IMAGE` variable (defined but unused in `vars.mk`) to actually patch the operator deployment image
- Add a `patch-kuadrant-operator-image` target that uses `kubectl set image` to swap the manager container image when the variable is set
- The patch runs after operator deployment (both components and helm modes), so you get the correct RBAC/CRDs/config from the gitref but run a custom-built image

## Usage
```bash
KUADRANT_OPERATOR_IMAGE=quay.io/kuadrant/kuadrant-operator:my-tag make local-setup
```

Or standalone on an existing cluster:
```bash
KUADRANT_OPERATOR_IMAGE=quay.io/kuadrant/kuadrant-operator:my-branch make patch-kuadrant-operator-image
```

## Test plan
- [ ] Run `make local-setup` without `KUADRANT_OPERATOR_IMAGE` — operator deploys as before, skip message printed
- [ ] Run `make local-setup` with `KUADRANT_OPERATOR_IMAGE=<custom-image>` — operator image is patched after deployment
- [ ] Run `make patch-kuadrant-operator-image` standalone on an existing cluster with the variable set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Kuadrant Operator deployment now automatically applies a configured container image after installation.
  * When a custom operator image is set, the deployment waits for the updated rollout to complete.
  * If no custom image is provided, the deployment now skips the image update gracefully with a clear message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->