### PR TITLE
chore: Add readiness probe to mockserver backend

### DIFF
--- a/testsuite/backend/mockserver.py
+++ b/testsuite/backend/mockserver.py
@@ -6,7 +6,13 @@ from testsuite.kubernetes import Selector
 from testsuite.kubernetes.config_map import ConfigMap
 from testsuite.kubernetes.deployment import Deployment, ContainerResources, ConfigMapVolume, VolumeMount
 from testsuite.kubernetes.service import Service, ServicePort
-from testsuite.utils.constants import MOCKSERVER_INTERNAL_PORT, HTTP_API_PORT, SERVICE_READY_TIMEOUT
+from testsuite.utils.constants import (
+    MOCKSERVER_INTERNAL_PORT,
+    HTTP_API_PORT,
+    SERVICE_READY_TIMEOUT,
+    MOCKSERVER_READINESS_INITIAL_DELAY,
+    MOCKSERVER_READINESS_PERIOD,
+)
 
 INIT_JSON_MOUNT = "/config/mockserver"
 
@@ -86,8 +92,14 @@ class MockserverBackend(Backend):
             volumes=self.config.volumes if self.config else None,
             volume_mounts=self.config.volume_mounts if self.config else None,
             env=env_limit | self.config.env if self.config else env_limit,
+            readiness_probe={
+                "httpGet": {"path": "/mockserver/ready", "port": MOCKSERVER_INTERNAL_PORT},
+                "initialDelaySeconds": MOCKSERVER_READINESS_INITIAL_DELAY,
+                "periodSeconds": MOCKSERVER_READINESS_PERIOD,
+            },
         )
         self.deployment.commit()
+        self.deployment.wait_for_ready()
 
         self.service = Service.create_instance(
             self.cluster,

--- a/testsuite/utils/constants.py
+++ b/testsuite/utils/constants.py
@@ -115,6 +115,11 @@ ENVOY_READINESS_INITIAL_DELAY = 3
 # Envoy readiness probe period.
 ENVOY_READINESS_PERIOD = 4
 
+# --- Mockserver readiness (seconds) ---
+
+MOCKSERVER_READINESS_INITIAL_DELAY = 2
+MOCKSERVER_READINESS_PERIOD = 2
+
 # --- Miscellaneous Workarounds (seconds) ---
 
 # Workaround for https://github.com/Kuadrant/testsuite/issues/884 — remove when fixed


### PR DESCRIPTION
## Description
Added readiness probe and wait_for_ready on MockserverBackend as the startup takes some time (Java app).

Values taken from https://github.com/mock-server/mockserver-monorepo/blob/master/helm/mockserver/templates/deployment.yaml#L104

## Changes
Added readiness probe, wait for ready on deployment

## Verification
```sh
make smoke
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mock server startup reliability by waiting for readiness before continuing setup.
  * Added readiness probe configuration to the mock server deployment to reduce timing-related test failures.  
* **Chores**
  * Introduced dedicated readiness timing constants for the mock server test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->