### PR TITLE
revert: Mockserver readiness probe

### DIFF
--- a/testsuite/backend/mockserver.py
+++ b/testsuite/backend/mockserver.py
@@ -6,13 +6,7 @@ from testsuite.kubernetes import Selector
 from testsuite.kubernetes.config_map import ConfigMap
 from testsuite.kubernetes.deployment import Deployment, ContainerResources, ConfigMapVolume, VolumeMount
 from testsuite.kubernetes.service import Service, ServicePort
-from testsuite.utils.constants import (
-    MOCKSERVER_INTERNAL_PORT,
-    HTTP_API_PORT,
-    SERVICE_READY_TIMEOUT,
-    MOCKSERVER_READINESS_INITIAL_DELAY,
-    MOCKSERVER_READINESS_PERIOD,
-)
+from testsuite.utils.constants import MOCKSERVER_INTERNAL_PORT, HTTP_API_PORT, SERVICE_READY_TIMEOUT
 
 INIT_JSON_MOUNT = "/config/mockserver"
 
@@ -92,14 +86,8 @@ class MockserverBackend(Backend):
             volumes=self.config.volumes if self.config else None,
             volume_mounts=self.config.volume_mounts if self.config else None,
             env=env_limit | self.config.env if self.config else env_limit,
-            readiness_probe={
-                "httpGet": {"path": "/mockserver/ready", "port": MOCKSERVER_INTERNAL_PORT},
-                "initialDelaySeconds": MOCKSERVER_READINESS_INITIAL_DELAY,
-                "periodSeconds": MOCKSERVER_READINESS_PERIOD,
-            },
         )
         self.deployment.commit()
-        self.deployment.wait_for_ready()
 
         self.service = Service.create_instance(
             self.cluster,

--- a/testsuite/utils/constants.py
+++ b/testsuite/utils/constants.py
@@ -164,10 +164,6 @@ ENVOY_READINESS_PERIOD = 4
 
 # DNS propagation wait.
 DNS_PROPAGATION_WAIT = 300  # 5 minutes
-# --- Mockserver readiness (seconds) ---
-
-MOCKSERVER_READINESS_INITIAL_DELAY = 2
-MOCKSERVER_READINESS_PERIOD = 2
 
 # --- Miscellaneous Workarounds (seconds) ---
 


### PR DESCRIPTION
## Description
Previous PR https://github.com/Kuadrant/testsuite/pull/1010 added readiness probe for MockserverBackend but did not set configuration option for enabling it. `/mockserver/ready` endpoint is only valid in newer versions of mockserver, but we are using older version without this endpoint. This went unnoticed due to test expectation which made every endpoint valid, even `/mockserver` prefixed ones. Test `testsuite/tests/singlecluster/gateway/dnspolicy/health_check/test_additional_headers.py` does not use this test expectation so the readiness check never finished. 

After careful consideration and checking possibility of using newer Mockserver version 7.4.0 with the endpoint `/mockserver/ready` the job of readiness check is done by `init-mockserver` script https://github.com/3scale-qe/mockserver-container/blob/main/init-mockserver . The script wont finish until new expectations are confirmed to be set by API.

>The Container's status is not set to RUNNING until the postStart handler completes.
https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/#discussion

Only time the Mockserver behaves strangely with 503 responses is when CPU throttled. PR https://github.com/Kuadrant/testsuite/pull/1006 fixed that. 

## Changes
Reverted #1010

## Verification
```sh
make smoke
```
```sh
make testsuite/tests/singlecluster/gateway/dnspolicy/health_check/test_additional_headers.py
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container environment handling so existing settings are preserved and applied together.
  * Simplified service startup checks, avoiding redundant readiness handling during deployment.

* **Chores**
  * Updated timeout settings used by the test suite for DNS propagation and readiness-related waits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->