### PR TITLE
fix(ui): scope pagination locators to top container

### DIFF
--- a/testsuite/page_objects/policies/policies_list_page.py
+++ b/testsuite/page_objects/policies/policies_list_page.py
@@ -35,8 +35,9 @@ class BasePolicyListPage(Navigable):
 
     def is_policy_listed(self, name: str) -> bool:
         """Searches all paginated list pages and returns True if the policy appears"""
-        prev_button = self.page.locator("button[data-action='previous'][aria-label='Go to previous page']")
-        next_button = self.page.locator("button[data-action='next'][aria-label='Go to next page']")
+        top_pagination = self.page.locator("#options-menu-top-pagination")
+        prev_button = top_pagination.locator("button[data-action='previous'][aria-label='Go to previous page']")
+        next_button = top_pagination.locator("button[data-action='next'][aria-label='Go to next page']")
 
         # Ensure we start on the first page
         while prev_button.is_visible() and prev_button.is_enabled():


### PR DESCRIPTION
## Description
- PatternFly renders pagination controls twice (top and bottom of the list), causing Playwright strict mode violations when locating next/previous page buttons
- Scoping pagination locators to `#options-menu-top-pagination` ensures exactly one element is matched
- Fixes nightly failures in TLS policy UI tests; also prevents the same failure in DNS and other policy list pages

## Changes
- **Bug Fix**: Scoped `prev_button` and `next_button` locators in `BasePolicyListPage.is_policy_listed` to the top pagination container

## Verification steps
- Run TLS and DNS UI policy tests to confirm no strict mode violations:
```
poetry run pytest -vv testsuite/tests/singlecluster/ui/console_plugin/policies/dnstls/
```