### PR TITLE
fix(egress): add reruns to the egress credential injection tests

### DIFF
--- a/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection.py
+++ b/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection.py
@@ -17,11 +17,7 @@ from testsuite.kubernetes.vault import Vault
 
 from ..conftest import EGRESS_HOSTNAME
 
-pytestmark = [
-    pytest.mark.kuadrant_only,
-    pytest.mark.egress_gateway,
-    pytest.mark.flaky(reruns=0),
-]
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.egress_gateway]
 
 VAULT_API_KEY = "pretty-random-api-key-to-use-for-egress-credential-injection-test-41894726"
 K8S_TOKEN_AUDIENCE = "https://kubernetes.default.svc.cluster.local"

--- a/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection_by_destination.py
+++ b/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection_by_destination.py
@@ -18,11 +18,7 @@ from testsuite.kubernetes.secret import Secret
 
 from ..conftest import EGRESS_HOSTNAME
 
-pytestmark = [
-    pytest.mark.kuadrant_only,
-    pytest.mark.egress_gateway,
-    pytest.mark.flaky(reruns=0),
-]
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.egress_gateway]
 
 SERVICE1_API_KEY = "pretty-random-api-key-to-use-for-egress-test-41894726"
 SERVICE2_API_KEY = "sk-fake-service2-key-for-egress-test-9876543210"


### PR DESCRIPTION
## Summary

Egress credentials injection tests are often failing in the nightly pipeline lately. Seemingly, policies used in these tests aren't getting truly enforced in the allocated test time. I'm enabling the default pytest reruns for them with this PR, which is currently defaults to [3 reruns with 2 seconds delay between](https://github.com/Kuadrant/testsuite/blob/41efc304e3ee2f7a40dbbd3c565d14b5030bed5e/Makefile#L14).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated egress credential injection test classifications.
  * Removed the no-rerun flaky-test setting from the affected test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->