### PR TITLE
fix(egress): fix reruns on credential injection tests

### DIFF
--- a/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection.py
+++ b/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection.py
@@ -17,7 +17,11 @@ from testsuite.kubernetes.vault import Vault
 
 from ..conftest import EGRESS_HOSTNAME
 
-pytestmark = [pytest.mark.kuadrant_only, pytest.mark.egress_gateway]
+pytestmark = [
+    pytest.mark.kuadrant_only,
+    pytest.mark.egress_gateway,
+    pytest.mark.flaky(reruns=3, reruns_delay=2, only_rerun=["AssertionError"]),
+]
 
 VAULT_API_KEY = "pretty-random-api-key-to-use-for-egress-credential-injection-test-41894726"
 K8S_TOKEN_AUDIENCE = "https://kubernetes.default.svc.cluster.local"
@@ -169,23 +173,23 @@ def authorization(cluster, route, blame, module_label, vault, vault_role):
 def test_egress_credential_injection_via_vault(client, sa_token, mockserver_expectation):
     """Test that Vault credential is injected and the overwritten header reaches the backend"""
     response = client.get(mockserver_expectation, headers={"Authorization": f"Bearer {sa_token}"})
-    assert response.status_code == 200
+    assert response is not None and response.status_code == 200
     assert response.headers["authorization"] == f"Bearer {VAULT_API_KEY}"
 
 
 def test_egress_unauthorized_namespace_rejected(client, sa_token2, mockserver_expectation):
     """Test that a valid SA token from an unauthorized namespace is rejected by Vault"""
     response = client.get(mockserver_expectation, headers={"Authorization": f"Bearer {sa_token2}"})
-    assert response.status_code == 403
+    assert response is not None and response.status_code == 403
 
 
 def test_egress_invalid_token_rejected(client, mockserver_expectation):
     """Test that requests with an invalid SA token are rejected"""
     response = client.get(mockserver_expectation, headers={"Authorization": "Bearer xyz"})
-    assert response.status_code == 401
+    assert response is not None and response.status_code == 401
 
 
 def test_egress_no_token_rejected(client, mockserver_expectation):
     """Test that requests without a valid SA token are rejected"""
     response = client.get(mockserver_expectation)
-    assert response.status_code == 401
+    assert response is not None and response.status_code == 401

--- a/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection_by_destination.py
+++ b/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection_by_destination.py
@@ -18,7 +18,11 @@ from testsuite.kubernetes.secret import Secret
 
 from ..conftest import EGRESS_HOSTNAME
 
-pytestmark = [pytest.mark.kuadrant_only, pytest.mark.egress_gateway]
+pytestmark = [
+    pytest.mark.kuadrant_only,
+    pytest.mark.egress_gateway,
+    pytest.mark.flaky(reruns=3, reruns_delay=2, only_rerun=["AssertionError"]),
+]
 
 SERVICE1_API_KEY = "pretty-random-api-key-to-use-for-egress-test-41894726"
 SERVICE2_API_KEY = "sk-fake-service2-key-for-egress-test-9876543210"
@@ -186,11 +190,11 @@ def commit(request, authorization, authorization2):
 def test_credential_injection_by_destination(client):
     """Test that /service1 and /service2 routes inject the correct credential for their respective destinations"""
     response = client.get("/service1")
-    assert response.status_code == 200
+    assert response is not None and response.status_code == 200
     response = client.get("/service1", headers={"dont-inject": "true"})
-    assert response.status_code == 401
+    assert response is not None and response.status_code == 401
 
     response = client.get("/service2")
-    assert response.status_code == 200
+    assert response is not None and response.status_code == 200
     response = client.get("/service2", headers={"dont-inject": "true"})
-    assert response.status_code == 401
+    assert response is not None and response.status_code == 401


### PR DESCRIPTION
## Summary 

Fix the reruns configuration, added in https://github.com/Kuadrant/testsuite/pull/1015, on the egress credential injection tests.

Also added an assert for a response object, in case of a request timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved credential-injection test validation with clearer checks for HTTP responses and authorisation headers.
  * Added automatic retries for assertion-related failures to improve test reliability.
  * Expanded coverage for authorised, unauthorised, invalid-token, missing-token, and destination-specific requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->