### PR TITLE
fix(egress): replace reruns with sleep in credential injection tests

### DIFF
--- a/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection.py
+++ b/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection.py
@@ -4,6 +4,8 @@ Replicates the deployment from the user guide:
 https://github.com/Kuadrant/kuadrant-operator/blob/main/doc/user-guides/egress/credential-injection.md
 """
 
+from time import sleep
+
 import pytest
 from dynaconf import ValidationError
 
@@ -17,11 +19,7 @@ from testsuite.kubernetes.vault import Vault
 
 from ..conftest import EGRESS_HOSTNAME
 
-pytestmark = [
-    pytest.mark.kuadrant_only,
-    pytest.mark.egress_gateway,
-    pytest.mark.flaky(reruns=3, reruns_delay=2, only_rerun=["AssertionError"]),
-]
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.egress_gateway]
 
 VAULT_API_KEY = "pretty-random-api-key-to-use-for-egress-credential-injection-test-41894726"
 K8S_TOKEN_AUDIENCE = "https://kubernetes.default.svc.cluster.local"
@@ -168,6 +166,12 @@ def authorization(cluster, route, blame, module_label, vault, vault_role):
         PlainResponse(plain=CelExpression('"Bearer " + auth.metadata.vault_secret.data.data.api_key')),
     )
     return auth
+
+
+@pytest.fixture(scope="module", autouse=True)
+def commit(commit):  # pylint: disable=unused-argument
+    """Wait a bit more for the policies to be 'actually' enforced"""
+    sleep(10)
 
 
 def test_egress_credential_injection_via_vault(client, sa_token, mockserver_expectation):

--- a/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection_by_destination.py
+++ b/testsuite/tests/singlecluster/egress/credentials_injection/test_credential_injection_by_destination.py
@@ -8,6 +8,8 @@ Uses MockServer to validate each route receives the correct credential.
 Credentials are fetched from Kubernetes Secrets via metadata.http.
 """
 
+from time import sleep
+
 import pytest
 
 from testsuite.gateway import CustomReference, URLRewriteFilter, RouteMatch, PathMatch, MatchType
@@ -18,11 +20,7 @@ from testsuite.kubernetes.secret import Secret
 
 from ..conftest import EGRESS_HOSTNAME
 
-pytestmark = [
-    pytest.mark.kuadrant_only,
-    pytest.mark.egress_gateway,
-    pytest.mark.flaky(reruns=3, reruns_delay=2, only_rerun=["AssertionError"]),
-]
+pytestmark = [pytest.mark.kuadrant_only, pytest.mark.egress_gateway]
 
 SERVICE1_API_KEY = "pretty-random-api-key-to-use-for-egress-test-41894726"
 SERVICE2_API_KEY = "sk-fake-service2-key-for-egress-test-9876543210"
@@ -184,6 +182,7 @@ def commit(request, authorization, authorization2):
         request.addfinalizer(auth.delete)
         auth.commit()
         auth.wait_for_ready()
+    sleep(10)  # policies are not actually being enforced when they report ready, so wait a bit more
 
 
 @pytest.mark.no_verify_denials


### PR DESCRIPTION
## Description

Reruns on this test break nightly runs for some reason. Replacing reruns with the small sleep

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of credential-injection scenarios by allowing policy changes sufficient time to take effect before validation.
  * Reduced dependence on automatic test reruns by improving test timing and stability.

* **Tests**
  * Updated egress credential-injection coverage to better reflect policy-enforcement timing.
  * Preserved existing authentication, routing, and credential validation behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->