### PR TITLE
test(failover): add happy path test for DNS Failover

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ RUN curl -L https://github.com/cloudflare/cfssl/releases/download/v1.6.4/cfssl_1
 RUN curl -sL https://github.com/kube-burner/kube-burner/releases/download/v1.16.4/kube-burner-V1.16.4-linux-x86_64.tar.gz |\
     tar -xz -C /usr/bin --wildcards 'kube-burner' && chmod 0755 /usr/bin/kube-burner
 
+RUN TAG=$(curl -sI https://github.com/Kuadrant/dns-operator/releases/latest | grep -i ^location: | sed 's|.*/||' | tr -d '\r') && \
+    curl -sL "https://github.com/Kuadrant/dns-operator/releases/download/${TAG}/kubectl-kuadrant_dns-${TAG}-linux-amd64.tar.gz" | \
+    tar -xz -C /usr/local/bin kubectl-kuadrant_dns && chmod +x /usr/local/bin/kubectl-kuadrant_dns
+
 RUN python3.11 -m pip --no-cache-dir install poetry
 
 WORKDIR /opt/workdir/kuadrant-testsuite

--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -1,7 +1,7 @@
 #default:
 #  tester: "someuser"                          # Optional: name of the user, who is running the tests, defaults to whoami/uid
 #  kuadrantctl: kuadrantctl
-#  kubectl-dns: "kubectl-dns"
+#  kubectl-dns: "kubectl-kuadrant_dns"
 #  console:
 #    username: "CONSOLE_USERNAME"              # OpenShift console username for UI test login
 #    password: "CONSOLE_PASSWORD"              # OpenShift console password for UI tests login

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -1,7 +1,7 @@
 default:
   dynaconf_merge: true
   kuadrantctl: "kuadrantctl"
-  kubectl-dns: "kubectl-dns"
+  kubectl-dns: "kubectl-kuadrant_dns"
   tools:
     project: "tools"
   cfssl: "cfssl"

--- a/testsuite/cli/kubectl_dns.py
+++ b/testsuite/cli/kubectl_dns.py
@@ -23,3 +23,44 @@ class KubectlDNS:
             kwargs["env"] = env
 
         return subprocess.run(args, **kwargs)  # pylint: disable= subprocess-run-check
+
+    def add_active_group(self, cluster, group, domain, provider_ref):
+        """Adds a group to the active groups TXT record"""
+        return self.run(
+            "add-active-group",
+            group,
+            "-y",
+            "--domain",
+            domain,
+            "--providerRef",
+            provider_ref,
+            env={"KUBECONFIG": cluster.kubeconfig_path},
+        )
+
+    def remove_active_group(self, cluster, group, domain, provider_ref):
+        """Removes a group from the active groups TXT record"""
+        return self.run(
+            "remove-active-group",
+            group,
+            "-y",
+            "--domain",
+            domain,
+            "--providerRef",
+            provider_ref,
+            env={"KUBECONFIG": cluster.kubeconfig_path},
+        )
+
+    def add_cluster_secret(self, name, context, namespace, service_account, kubeconfig):
+        """Generates a kubeconfig secret for a remote cluster"""
+        return self.run(
+            "add-cluster-secret",
+            "--name",
+            name,
+            "--context",
+            context,
+            "--namespace",
+            namespace,
+            "--service-account",
+            service_account,
+            env={"KUBECONFIG": kubeconfig},
+        )

--- a/testsuite/gateway/gateway_api/hostname.py
+++ b/testsuite/gateway/gateway_api/hostname.py
@@ -43,7 +43,8 @@ class DNSPolicyExposer(Exposer):
     """Exposing is done as part of DNSPolicy, so no work needs to be done here"""
 
     @cached_property
-    def base_domain(self) -> str:
+    def zone_domain(self) -> str:
+        """Returns the bare zone domain from the DNS provider secret annotation"""
         provider_secret_name = settings["control_plane"]["provider_secret"]
         try:
             secret = selector(f"secret/{provider_secret_name}", static_context=self.cluster.context).object()
@@ -51,7 +52,11 @@ class DNSPolicyExposer(Exposer):
             raise OpenShiftPythonException(
                 f"Unable to find secret/{provider_secret_name} in namespace {self.cluster.project}"
             ) from exc
-        return f'{generate_tail(5)}.{secret.model["metadata"]["annotations"]["base_domain"]}'
+        return secret.model["metadata"]["annotations"]["base_domain"]
+
+    @cached_property
+    def base_domain(self) -> str:
+        return f"{generate_tail(5)}.{self.zone_domain}"
 
     def expose_hostname(self, name, exposable: Exposable) -> Hostname:
         return StaticHostname(

--- a/testsuite/tests/multicluster/conftest.py
+++ b/testsuite/tests/multicluster/conftest.py
@@ -1,5 +1,6 @@
 """Conftest for Multicluster tests"""
 
+import shutil
 from importlib import resources
 
 import pytest
@@ -7,6 +8,7 @@ from dynaconf import ValidationError
 
 from testsuite.backend.mockserver import MockserverBackend, MockserverBackendConfig
 from testsuite.certificates import Certificate
+from testsuite.cli.kubectl_dns import KubectlDNS
 from testsuite.gateway import Exposer, Hostname
 from testsuite.gateway import TLSGatewayListener
 from testsuite.gateway.gateway_api.gateway import KuadrantGateway
@@ -24,6 +26,15 @@ def dns_server(testconfig, skip_or_fail):
         return testconfig["dns"]["dns_server"]
     except ValidationError as exc:
         return skip_or_fail(f"DNS servers configuration is missing: {exc}")
+
+
+@pytest.fixture(scope="session")
+def kubectl_dns(testconfig, skip_or_fail):
+    """Return kubectl-kuadrant_dns CLI wrapper"""
+    binary_path = testconfig["kubectl-dns"]
+    if not shutil.which(binary_path):
+        skip_or_fail("kubectl-dns binary not found")
+    return KubectlDNS(binary_path)
 
 
 @pytest.fixture(scope="session")

--- a/testsuite/tests/multicluster/coredns/two_clusters/kubectl_dns/test_secret_generation.py
+++ b/testsuite/tests/multicluster/coredns/two_clusters/kubectl_dns/test_secret_generation.py
@@ -1,23 +1,11 @@
 """Test kubectl-dns add-cluster-secret command with basic coredns setup with 1 primary and 1 secondary clusters"""
 
-import shutil
-
 import dns.resolver
 import pytest
 
-from testsuite.cli.kubectl_dns import KubectlDNS
 from testsuite.tests.multicluster.coredns.conftest import IP1, IP2
 
 pytestmark = [pytest.mark.cli]
-
-
-@pytest.fixture(scope="session")
-def kubectl_dns(testconfig, skip_or_fail):
-    """Return Kuadrantctl wrapper with merged kubeconfig"""
-    binary_path = testconfig["kubectl-dns"]
-    if not shutil.which(binary_path):
-        skip_or_fail("kubectl-dns binary not found")
-    return KubectlDNS(binary_path)
 
 
 @pytest.fixture(scope="module")
@@ -29,17 +17,12 @@ def kubeconfig_secrets(request, system_project, cluster, cluster2, kubectl_dns, 
     )
 
     merged_kubeconfig = cluster.create_merged_kubeconfig(cluster2)
-    result = kubectl_dns.run(
-        "add-cluster-secret",
-        "--name",
-        secret_name,
-        "--context",
-        cluster2.current_context_name,
-        "--namespace",
-        system_project.project,
-        "--service-account",
-        "coredns",
-        env={"KUBECONFIG": merged_kubeconfig},
+    result = kubectl_dns.add_cluster_secret(
+        name=secret_name,
+        context=cluster2.current_context_name,
+        namespace=system_project.project,
+        service_account="coredns",
+        kubeconfig=merged_kubeconfig,
     )
     assert result.returncode == 0, f"kubectl-dns couldn't generate kubeconfig secret: {result.stderr}"
     return []

--- a/testsuite/tests/multicluster/failover/conftest.py
+++ b/testsuite/tests/multicluster/failover/conftest.py
@@ -1,0 +1,104 @@
+"""Conftest for DNS failover tests using groups"""
+
+import pytest
+
+from testsuite.kuadrant.policy.dns import has_record_condition
+from testsuite.utils import generate_tail
+
+MAX_REQUEUE_TIME = 10
+
+
+@pytest.fixture(scope="module")
+def dns_operator_deployment(request, cluster, system_project):
+    """DNS Operator deployment on the first cluster"""
+    sys_ns = cluster.change_project(system_project.project)
+    deployment = sys_ns.get_deployment("dns-operator-controller-manager")
+    original_replicas = deployment.replicas
+    request.addfinalizer(lambda: deployment.set_replicas(original_replicas))
+    return deployment
+
+
+@pytest.fixture(scope="module")
+def group1():
+    """Random group name for cluster 1"""
+    return f"group1-{generate_tail(5)}"
+
+
+@pytest.fixture(scope="module")
+def group2():
+    """Random group name for cluster 2"""
+    return f"group2-{generate_tail(5)}"
+
+
+@pytest.fixture(scope="module")
+def configure_dns_failover_groups(request, cluster, cluster2, system_project, group1, group2):
+    """Configure DNS Operator GROUP and MAX_REQUEUE_TIME on both clusters"""
+    for cluster_client, group_id in [(cluster, group1), (cluster2, group2)]:
+        sys_ns = cluster_client.change_project(system_project.project)
+
+        dns_deployment = sys_ns.get_deployment("dns-operator-controller-manager")
+
+        # add finalizer to remove the added variables and restart the controller, ORDER MATTERS
+        request.addfinalizer(dns_deployment.restart)
+        remove_patch = '{"data":{"GROUP":null,"MAX_REQUEUE_TIME":null}}'
+        request.addfinalizer(
+            lambda sys=sys_ns, p=remove_patch: sys.do_action(
+                "patch", "configmap", "dns-operator-controller-env", "--type=merge", "-p", p
+            )
+        )
+
+        # Patch the configmap to add/update GROUP and MAX_REQUEUE_TIME variables
+        add_patch = f'{{"data":{{"GROUP":"{group_id}","MAX_REQUEUE_TIME":"{MAX_REQUEUE_TIME}s"}}}}'
+        sys_ns.do_action("patch", "configmap", "dns-operator-controller-env", "--type=merge", "-p", add_patch)
+
+        dns_deployment.restart()
+
+
+@pytest.fixture(scope="module")
+def add_active_groups(
+    request, configure_dns_failover_groups, kubectl_dns, exposer, dns_provider_secret, cluster, group1, group2
+):  # pylint: disable=unused-argument
+    """Create active-groups TXT record with group1 as the initial active group"""
+    provider_ref = f"{cluster.project}/{dns_provider_secret}"
+
+    def _cleanup():
+        for group in [group1, group2]:
+            kubectl_dns.remove_active_group(cluster, group, domain=exposer.zone_domain, provider_ref=provider_ref)
+
+    request.addfinalizer(_cleanup)
+    result = kubectl_dns.add_active_group(cluster, group1, domain=exposer.zone_domain, provider_ref=provider_ref)
+    assert result.returncode == 0, f"Failed to add active group: {result.stderr}"
+
+
+@pytest.fixture(scope="module", autouse=True)
+def commit(
+    request,
+    routes,
+    gateway,
+    gateway2,
+    dns_policy,
+    dns_policy2,
+    tls_policy,
+    tls_policy2,
+    add_active_groups,
+):  # pylint: disable=unused-argument
+    """Commits gateways and all policies required for the test"""
+    components = [gateway, gateway2, dns_policy, dns_policy2, tls_policy, tls_policy2]
+    for component in components:
+        request.addfinalizer(component.delete)
+        component.commit()
+
+    for component in [gateway, gateway2, tls_policy, tls_policy2]:
+        component.wait_for_ready()
+
+    dns_policy.wait_for_ready()
+
+    dns_policy2.wait_for_accepted()
+    assert dns_policy2.wait_until(
+        has_record_condition("Active", "False", "NotMemberOfActiveGroup", "Group is not included in active groups")
+    ), f"dns_policy2 should report inactive group, got: {dns_policy2.model.status.recordConditions}"
+    assert dns_policy2.wait_until(
+        has_record_condition(
+            "Ready", "False", "MemberOfInactiveGroup", "No further actions to take while in inactive group"
+        )
+    ), f"dns_policy2 should report inactive group not ready, got: {dns_policy2.model.status.recordConditions}"

--- a/testsuite/tests/multicluster/failover/conftest.py
+++ b/testsuite/tests/multicluster/failover/conftest.py
@@ -5,8 +5,6 @@ import pytest
 from testsuite.kuadrant.policy.dns import has_record_condition
 from testsuite.utils import generate_tail
 
-MAX_REQUEUE_TIME = 10
-
 
 @pytest.fixture(scope="module")
 def dns_operator_deployment(request, cluster, system_project):
@@ -48,7 +46,8 @@ def configure_dns_failover_groups(request, cluster, cluster2, system_project, gr
         )
 
         # Patch the configmap to add/update GROUP and MAX_REQUEUE_TIME variables
-        add_patch = f'{{"data":{{"GROUP":"{group_id}","MAX_REQUEUE_TIME":"{MAX_REQUEUE_TIME}s"}}}}'
+        # Reduce time DNS operator re-queues the dns records to 10s to speed up the test execution
+        add_patch = f'{{"data":{{"GROUP":"{group_id}","MAX_REQUEUE_TIME":"10s"}}}}'
         sys_ns.do_action("patch", "configmap", "dns-operator-controller-env", "--type=merge", "-p", add_patch)
 
         dns_deployment.restart()

--- a/testsuite/tests/multicluster/failover/test_dns_failover.py
+++ b/testsuite/tests/multicluster/failover/test_dns_failover.py
@@ -1,0 +1,64 @@
+"""Test DNS failover from one cluster to another using DNS Operator active groups"""
+
+import time
+
+import dns.resolver
+import pytest
+
+from testsuite.tests.multicluster.failover.conftest import MAX_REQUEUE_TIME
+from testsuite.utils import sleep_ttl
+
+pytestmark = [pytest.mark.multicluster, pytest.mark.disruptive, pytest.mark.flaky(reruns=0)]
+
+
+def test_dns_failover(
+    cluster,
+    exposer,
+    client,
+    hostname,
+    dns_provider_secret,
+    gateway,
+    gateway2,
+    dns_policy2,
+    dns_operator_deployment,
+    kubectl_dns,
+    group1,
+    group2,
+):  # pylint: disable=too-many-locals
+    """
+    Test DNS failover from group1 (cluster1) to group2 (cluster2):
+    1. Verify initial state with DNS resolving to cluster1
+    2. Scale down DNS operator on cluster1 to simulate failure
+    3. Switch active group from group1 to group2
+    4. Verify DNS resolves to cluster2 after failover
+    """
+    gw1_ip = gateway.external_ip().split(":")[0]
+    gw2_ip = gateway2.external_ip().split(":")[0]
+
+    response = client.get("/get")
+    assert not response.has_dns_error(), response.error
+    assert response.status_code == 200
+
+    dns_ips = {ip.address for ip in dns.resolver.resolve(hostname.hostname)}
+    assert {gw1_ip} == dns_ips, f"Initially DNS should only resolve to cluster1 IP ({gw1_ip}), got {dns_ips}"
+
+    # scale down DNS operator on cluster1 to simulate failure
+    dns_operator_deployment.set_replicas(0)
+
+    # make second cluster group active and first cluster group inactive
+    provider_ref = f"{cluster.project}/{dns_provider_secret}"
+    result = kubectl_dns.add_active_group(cluster, group2, domain=exposer.zone_domain, provider_ref=provider_ref)
+    assert result.returncode == 0, f"Failed to add group2 to active groups: {result.stderr}"
+    result = kubectl_dns.remove_active_group(cluster, group1, domain=exposer.zone_domain, provider_ref=provider_ref)
+    assert result.returncode == 0, f"Failed to remove group1 from active groups: {result.stderr}"
+
+    time.sleep(MAX_REQUEUE_TIME)  # wait for DNS operator to process the change
+    dns_policy2.wait_for_ready()
+    sleep_ttl(hostname.hostname)
+
+    response = client.get("/get")
+    assert not response.has_dns_error(), response.error
+    assert response.status_code == 200
+
+    dns_ips = {ip.address for ip in dns.resolver.resolve(hostname.hostname)}
+    assert {gw2_ip} == dns_ips, f"After failover DNS should only resolve to cluster2 IP ({gw2_ip}), got {dns_ips}"

--- a/testsuite/tests/multicluster/failover/test_dns_failover.py
+++ b/testsuite/tests/multicluster/failover/test_dns_failover.py
@@ -5,7 +5,7 @@ import time
 import dns.resolver
 import pytest
 
-from testsuite.tests.multicluster.failover.conftest import MAX_REQUEUE_TIME
+from testsuite.kuadrant.policy import has_condition
 from testsuite.utils import sleep_ttl
 
 pytestmark = [pytest.mark.multicluster, pytest.mark.disruptive, pytest.mark.flaky(reruns=0)]
@@ -19,6 +19,7 @@ def test_dns_failover(
     dns_provider_secret,
     gateway,
     gateway2,
+    dns_policy,
     dns_policy2,
     dns_operator_deployment,
     kubectl_dns,
@@ -28,37 +29,64 @@ def test_dns_failover(
     """
     Test DNS failover from group1 (cluster1) to group2 (cluster2):
     1. Verify initial state with DNS resolving to cluster1
-    2. Scale down DNS operator on cluster1 to simulate failure
-    3. Switch active group from group1 to group2
+    2. Add group2 to active groups and verify DNS resolves to both clusters
+    3. Scale down DNS operator on cluster1 and remove group1 from active groups
     4. Verify DNS resolves to cluster2 after failover
+    5. Scale up DNS operator on cluster1 and verify it reports inactive group
     """
     gw1_ip = gateway.external_ip().split(":")[0]
     gw2_ip = gateway2.external_ip().split(":")[0]
 
+    dns_records = dns_policy.get_dns_records()
+    dns_records2 = dns_policy2.get_dns_records()
+    assert len(dns_records) == 1
+    assert len(dns_records2) == 1
+    dns_record = dns_records[0]
+    dns_record2 = dns_records2[0]
+
     response = client.get("/get")
     assert not response.has_dns_error(), response.error
     assert response.status_code == 200
-
     dns_ips = {ip.address for ip in dns.resolver.resolve(hostname.hostname)}
     assert {gw1_ip} == dns_ips, f"Initially DNS should only resolve to cluster1 IP ({gw1_ip}), got {dns_ips}"
 
-    # scale down DNS operator on cluster1 to simulate failure
-    dns_operator_deployment.set_replicas(0)
-
-    # make second cluster group active and first cluster group inactive
+    # add second cluster group to active groups and verify that both clusters are in the active groups now
     provider_ref = f"{cluster.project}/{dns_provider_secret}"
     result = kubectl_dns.add_active_group(cluster, group2, domain=exposer.zone_domain, provider_ref=provider_ref)
     assert result.returncode == 0, f"Failed to add group2 to active groups: {result.stderr}"
+    assert dns_record.wait_until(
+        has_condition("Active", "True", "MemberOfActiveGroup", "Group is included in active groups")
+    ), f"dns_record should report active group, got: {dns_record.model.status.conditions}"
+    assert dns_record2.wait_until(
+        has_condition("Active", "True", "MemberOfActiveGroup", "Group is included in active groups")
+    ), f"dns_record2 should report active group, got: {dns_record2.model.status.conditions}"
+    sleep_ttl(hostname.hostname)
+    time.sleep(10)  # arbitrary sleep after all the required waits because test won't succeed without it for some reason
+
+    dns_ips = {ip.address for ip in dns.resolver.resolve(hostname.hostname)}
+    assert {
+        gw1_ip,
+        gw2_ip,
+    } == dns_ips, f"After adding group2 DNS should resolve to both cluster IPs ({gw1_ip}, {gw2_ip}), got {dns_ips}"
+
+    # scale down DNS operator on cluster1 to simulate failure and remove the first cluster group from active groups
+    dns_operator_deployment.set_replicas(0)
     result = kubectl_dns.remove_active_group(cluster, group1, domain=exposer.zone_domain, provider_ref=provider_ref)
     assert result.returncode == 0, f"Failed to remove group1 from active groups: {result.stderr}"
-
-    time.sleep(MAX_REQUEUE_TIME)  # wait for DNS operator to process the change
-    dns_policy2.wait_for_ready()
+    assert dns_record2.wait_until(
+        has_condition("Active", "True", "MemberOfActiveGroup", "Group is included in active groups")
+    ), f"dns_record2 should report active group, got: {dns_record2.model.status.conditions}"
     sleep_ttl(hostname.hostname)
+    time.sleep(40)  # arbitrary sleep after all the required waits because test won't succeed without it for some reason
 
     response = client.get("/get")
     assert not response.has_dns_error(), response.error
     assert response.status_code == 200
-
     dns_ips = {ip.address for ip in dns.resolver.resolve(hostname.hostname)}
     assert {gw2_ip} == dns_ips, f"After failover DNS should only resolve to cluster2 IP ({gw2_ip}), got {dns_ips}"
+
+    # scale up DNS operator back to the working state and verify that the first cluster DNS operator updated the status
+    dns_operator_deployment.set_replicas(1)
+    assert dns_record.wait_until(
+        has_condition("Active", "False", "NotMemberOfActiveGroup", "Group is not included in active groups")
+    ), f"dns_record should report inactive group, got: {dns_record.model.status.conditions}"


### PR DESCRIPTION
## Summary
Add a basic happy path E2E test for DNS failover via active groups to verify regressions as the feature progresses toward Tech Preview. The test sets up two clusters with distinct DNS Operator groups, confirms the initial active group resolves correctly, switches the active group to trigger failover, and validates that DNS resolves to the correct cluster while the other reports inactive record conditions. Related to [Kuadrant/dns-operator#783](https://github.com/Kuadrant/dns-operator/issues/783).

## Changes

- Add E2E multi-cluster test for DNS failover switching the DNS Operator active group from one to another
- Add `kubectl-kuadrant_dns` binary to the container image (auto-fetches latest release)
- Extract `zone_domain` property on `DNSPolicyExposer` for direct access to the provider's base domain
- Move `kubectl_dns` fixture from coredns tests to the shared multicluster conftest

## Verification
Configure 2 clusters in the testsuite settings file, and the correct name for `kubectl-kuadrant_dns` binary on your system. Then execute the test with:
```bash
make testsuite/tests/multicluster/failover/ flags="-vv"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Kuadrant DNS CLI installation to the container environment.
  * Updated default configuration to use `kubectl-kuadrant_dns`.
  * Added multicluster DNS failover coverage with active-group switching and endpoint validation.
* **Bug Fixes**
  * Improved DNS base-domain derivation from provider secrets.
* **Tests**
  * Centralised `kubectl-dns` executable discovery for multicluster tests.
  * Added helpers for active-group management and cluster-secret creation.
  * Added failover fixtures and a dedicated failover scenario test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->