### PR TITLE
feat: Data race checker

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -33,6 +33,13 @@ default:
     authorino:
       deploy: true
       log_level: "debug"
+  data_race:
+    enabled: false
+    labels: # verify these match the actual pod labels in your cluster
+      - "authorino-resource=authorino"
+      - "app=limitador-operator"
+      - "control-plane=dns-operator-controller-manager"
+      - "app=kuadrant"
   control_plane:
     cluster: {}
     slow_loadbalancers: false

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -466,54 +466,43 @@ def check_user_managed_istio(request, cluster, skip_or_fail):
 
 def pytest_configure(config):
     """Record session start time for DATA_RACE detection."""
+    if not settings["data_race"]["enabled"]:
+        return
     config._data_race_start_time = time.time()
-    print(f"[DEBUG] pytest_configure: start time set to {config._data_race_start_time}")
 
 def _fetch_pod_errors(system_project, since_seconds=None):
     """Fetch pod logs from kuadrant-system and return lines matching error patterns."""
     matches = []
     labels = settings["data_race"]["labels"]
-    print(f"[DEBUG] _fetch_pod_errors: checking {len(labels)} labels, since_seconds={since_seconds}")
+
     for label in labels:
-        cmd = ["logs", "-l", label, "--all-containers", "--prefix"]
+        cmd = ["logs", "-l", label, "--all-containers", "--prefix", "--tail=-1"]
         if since_seconds is not None:
             cmd.append(f"--since={since_seconds}s")
-        print(f"[DEBUG] running: oc {' '.join(cmd)}")
         result = system_project.do_action(*cmd)
         lines = result.out().splitlines()
-        print(f"[DEBUG] label '{label}': got {len(lines)} log lines")
+
         for line in lines:
-            print(f"[DEBUG]   {line}")
-            if "DATA_RACE" in line:
-                print(f"[DEBUG] DATA_RACE match: {line}")
+            if "DATA RACE" in line:
                 matches.append(line)
-    print(f"[DEBUG] _fetch_pod_errors: total matches={len(matches)}")
     return matches
 
 
 def pytest_terminal_summary(terminalreporter, config):
     """Fetch pod logs once and print data race summary."""
-    print("[DEBUG] pytest_terminal_summary started")
-    print(f"[DEBUG] data_race settings: enabled={settings['data_race']['enabled']}, labels={settings['data_race']['labels']}")
     if not settings["data_race"]["enabled"]:
-        print("[DEBUG] data_race is not enabled, returning early")
         return
     try:
         cluster = settings["control_plane"]["cluster"]
         system_project = cluster.change_project(settings["service_protection"]["system_project"])
-        print(f"[DEBUG] system_project: {system_project.project}")
     except (KeyError, ValidationError) as e:
-        print(f"[DEBUG] failed to get cluster/project: {e}")
         return
 
     elapsed = int(time.time() - config._data_race_start_time) + 1
-    print(f"[DEBUG] fetching pod errors since {elapsed}s ago")
     # _fetch_pod_errors can raise OpenShiftPythonException if oc command fails (e.g. no pods match label)
     try:
         findings = _fetch_pod_errors(system_project, since_seconds=elapsed)
-        print(f"[DEBUG] found {len(findings)} matches")
     except Exception as e:
-        print(f"[DEBUG] _fetch_pod_errors raised: {e}")
         terminalreporter.write_line("ERROR: Failed to fetch pod logs for data race detection.")
         return
 

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -1,15 +1,13 @@
 """Root conftest"""
 
 import operator
-import os
-import re
 import signal
 import time
 
 from urllib.parse import urlparse
 
 import pytest
-from openshift_client import selector
+from openshift_client import OpenShiftPythonException, selector
 from pytest_metadata.plugin import metadata_key  # type: ignore
 from dynaconf import ValidationError
 from keycloak import KeycloakAuthenticationError
@@ -464,11 +462,13 @@ def check_user_managed_istio(request, cluster, skip_or_fail):
     if marker and KuadrantGateway.get_gateway_class_name(cluster) == "openshift-default":
         skip_or_fail("Test requires user-managed Istio installation")
 
+
 def pytest_configure(config):
     """Record session start time for DATA_RACE detection."""
     if not settings["data_race"]["enabled"]:
         return
-    config._data_race_start_time = time.time()
+    config.data_race_start_time = time.time()
+
 
 def _fetch_pod_errors(system_project, since_seconds=None):
     """Fetch pod logs from kuadrant-system and return lines matching error patterns."""
@@ -495,14 +495,14 @@ def pytest_terminal_summary(terminalreporter, config):
     try:
         cluster = settings["control_plane"]["cluster"]
         system_project = cluster.change_project(settings["service_protection"]["system_project"])
-    except (KeyError, ValidationError) as e:
+    except (KeyError, ValidationError):
         return
 
-    elapsed = int(time.time() - config._data_race_start_time) + 1
+    elapsed = int(time.time() - config.data_race_start_time) + 1
     # _fetch_pod_errors can raise OpenShiftPythonException if oc command fails (e.g. no pods match label)
     try:
         findings = _fetch_pod_errors(system_project, since_seconds=elapsed)
-    except Exception as e:
+    except OpenShiftPythonException:
         terminalreporter.write_line("ERROR: Failed to fetch pod logs for data race detection.")
         return
 

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -470,7 +470,7 @@ def pytest_configure(config):
     config.data_race_start_time = time.time()
 
 
-def _fetch_pod_errors(system_project, since_seconds=None):
+def _fetch_pod_errors(terminalreporter, system_project, since_seconds=None):
     """Fetch pod logs from kuadrant-system and return lines matching error patterns."""
     matches = []
     labels = settings["data_race"]["labels"]
@@ -479,12 +479,17 @@ def _fetch_pod_errors(system_project, since_seconds=None):
         cmd = ["logs", "-l", label, "--all-containers", "--prefix", "--tail=-1"]
         if since_seconds is not None:
             cmd.append(f"--since={since_seconds}s")
-        result = system_project.do_action(*cmd)
-        lines = result.out().splitlines()
+        try:
+            result = system_project.do_action(*cmd)
+            lines = result.out().splitlines()
 
-        for line in lines:
-            if "DATA RACE" in line:
-                matches.append(line)
+            for line in lines:
+                if "DATA RACE" in line:
+                    matches.append(line)
+
+        except OpenShiftPythonException:
+            terminalreporter.write_line("ERROR: Failed to fetch pod logs for data race detection.")
+
     return matches
 
 
@@ -500,11 +505,7 @@ def pytest_terminal_summary(terminalreporter, config):
 
     elapsed = int(time.time() - config.data_race_start_time) + 1
     # _fetch_pod_errors can raise OpenShiftPythonException if oc command fails (e.g. no pods match label)
-    try:
-        findings = _fetch_pod_errors(system_project, since_seconds=elapsed)
-    except OpenShiftPythonException:
-        terminalreporter.write_line("ERROR: Failed to fetch pod logs for data race detection.")
-        return
+    findings = _fetch_pod_errors(terminalreporter, system_project, since_seconds=elapsed)
 
     terminalreporter.write_line("######################################")
     terminalreporter.write_line("Pod Log Error Summary")

--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -1,7 +1,11 @@
 """Root conftest"""
 
 import operator
+import os
+import re
 import signal
+import time
+
 from urllib.parse import urlparse
 
 import pytest
@@ -459,3 +463,69 @@ def check_user_managed_istio(request, cluster, skip_or_fail):
     marker = request.node.get_closest_marker("user_managed_istio")
     if marker and KuadrantGateway.get_gateway_class_name(cluster) == "openshift-default":
         skip_or_fail("Test requires user-managed Istio installation")
+
+def pytest_configure(config):
+    """Record session start time for DATA_RACE detection."""
+    config._data_race_start_time = time.time()
+    print(f"[DEBUG] pytest_configure: start time set to {config._data_race_start_time}")
+
+def _fetch_pod_errors(system_project, since_seconds=None):
+    """Fetch pod logs from kuadrant-system and return lines matching error patterns."""
+    matches = []
+    labels = settings["data_race"]["labels"]
+    print(f"[DEBUG] _fetch_pod_errors: checking {len(labels)} labels, since_seconds={since_seconds}")
+    for label in labels:
+        cmd = ["logs", "-l", label, "--all-containers", "--prefix"]
+        if since_seconds is not None:
+            cmd.append(f"--since={since_seconds}s")
+        print(f"[DEBUG] running: oc {' '.join(cmd)}")
+        result = system_project.do_action(*cmd)
+        lines = result.out().splitlines()
+        print(f"[DEBUG] label '{label}': got {len(lines)} log lines")
+        for line in lines:
+            print(f"[DEBUG]   {line}")
+            if "DATA_RACE" in line:
+                print(f"[DEBUG] DATA_RACE match: {line}")
+                matches.append(line)
+    print(f"[DEBUG] _fetch_pod_errors: total matches={len(matches)}")
+    return matches
+
+
+def pytest_terminal_summary(terminalreporter, config):
+    """Fetch pod logs once and print data race summary."""
+    print("[DEBUG] pytest_terminal_summary started")
+    print(f"[DEBUG] data_race settings: enabled={settings['data_race']['enabled']}, labels={settings['data_race']['labels']}")
+    if not settings["data_race"]["enabled"]:
+        print("[DEBUG] data_race is not enabled, returning early")
+        return
+    try:
+        cluster = settings["control_plane"]["cluster"]
+        system_project = cluster.change_project(settings["service_protection"]["system_project"])
+        print(f"[DEBUG] system_project: {system_project.project}")
+    except (KeyError, ValidationError) as e:
+        print(f"[DEBUG] failed to get cluster/project: {e}")
+        return
+
+    elapsed = int(time.time() - config._data_race_start_time) + 1
+    print(f"[DEBUG] fetching pod errors since {elapsed}s ago")
+    # _fetch_pod_errors can raise OpenShiftPythonException if oc command fails (e.g. no pods match label)
+    try:
+        findings = _fetch_pod_errors(system_project, since_seconds=elapsed)
+        print(f"[DEBUG] found {len(findings)} matches")
+    except Exception as e:
+        print(f"[DEBUG] _fetch_pod_errors raised: {e}")
+        terminalreporter.write_line("ERROR: Failed to fetch pod logs for data race detection.")
+        return
+
+    terminalreporter.write_line("######################################")
+    terminalreporter.write_line("Pod Log Error Summary")
+    terminalreporter.write_line("######################################")
+
+    if not findings:
+        terminalreporter.write_line("No DATA_RACE errors detected during test session.")
+        return
+
+    terminalreporter.write_line(f"DATA_RACE occurrences: {len(findings)}")
+    terminalreporter.write_line("")
+    for line in findings:
+        terminalreporter.write_line(f"  {line}")


### PR DESCRIPTION
## Description
This feature introduces new function that checks for DATA RACE string in the logs of pods, that are written in the config file. If it finds match, it will output to the terminal.

## Changes
- **Data race detection hooks** in `testsuite/tests/conftest.py`:
- `pytest_configure` hook records the session start time when data race detection is enabled
- `_fetch_pod_errors()` helper iterates over configured pod labels in the `kuadrant-system` namespace and collects log lines containing `DATA RACE`
- `pytest_terminal_summary` hook fetches pod logs scoped to the session duration and prints a summary of any data race findings
- **Configuration** in `config/settings.yaml`:
- New `data_race` section with `enabled` flag and configurable `labels` list targeting Authorino, Limitador, DNS operator, and Kuadrant controller pods

## Verification steps
- Enable the feature by setting `data_race.enabled: true` in `config/settings.local.yaml`
- Run any test suite target (e.g., `make kuadrant`) and verify the terminal summary section appears at the end:
  
```
  ######################################
  Pod Log Error Summary
  ######################################
  No DATA_RACE errors detected during test session.
 ```
- With the feature disabled (default), verify no additional output is printed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional data-race detection configuration with Kubernetes pod label selectors.
  * Test runs can now report matching “DATA RACE” messages from relevant pod logs in the terminal.

* **Bug Fixes**
  * Improved handling of failures when locating projects or retrieving pod logs during reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->