### PR TITLE
refactor(tracing): rename wasm-shim to kuadrant-filter

### DIFF
--- a/testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing.py
+++ b/testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing.py
@@ -2,7 +2,7 @@
 Tests for distributed tracing integration across Kuadrant components.
 
 This module validates that tracing correctly captures request flows through the entire
-Kuadrant stack, including wasm-shim, Authorino, Limitador, and gateway services.
+Kuadrant stack, including kuadrant-filter, Authorino, Limitador, and gateway services.
 
 With OCP-managed Istio, gateway traces are not available because the Istio CR cannot be
 modified to enable tracing (meshConfig.enableTracing, extensionProviders) and the Telemetry
@@ -44,33 +44,33 @@ def trace_request_ids(client, auth):
 
 @pytest.fixture(scope="module")
 def trace_200(trace_request_ids, tracing, has_ocp_managed_istio):
-    """Fetches and caches the full wasm-shim trace for the 200 response."""
+    """Fetches and caches the full kuadrant-filter trace for the 200 response."""
     request_id = trace_request_ids[0]
     min_procs = 3 if has_ocp_managed_istio else 4
-    traces = tracing.get_traces(service="wasm-shim", min_processes=min_procs, tags={"request_id": request_id})
+    traces = tracing.get_traces(service="kuadrant-filter", min_processes=min_procs, tags={"request_id": request_id})
     assert len(traces) == 1, f"No trace was found in tracing backend with request_id: {request_id}"
     return traces[0]
 
 
 @pytest.fixture(scope="module")
 def trace_429(trace_request_ids, tracing, has_ocp_managed_istio):
-    """Fetches and caches the full wasm-shim trace for the 429 response."""
+    """Fetches and caches the full kuadrant-filter trace for the 429 response."""
     request_id = trace_request_ids[1]
     min_procs = 3 if has_ocp_managed_istio else 4
-    traces = tracing.get_traces(service="wasm-shim", min_processes=min_procs, tags={"request_id": request_id})
+    traces = tracing.get_traces(service="kuadrant-filter", min_processes=min_procs, tags={"request_id": request_id})
     assert len(traces) == 1, f"No trace was found in tracing backend with request_id: {request_id}"
     return traces[0]
 
 
 @pytest.fixture(scope="module")
 def trace_401(client, tracing, has_ocp_managed_istio):
-    """Sends request producing 401 response and fetches the full wasm-shim trace"""
+    """Sends request producing 401 response and fetches the full kuadrant-filter trace"""
     response_401 = client.get("/get", headers={"Traceparent": f"00-{os.urandom(16).hex()}-{os.urandom(8).hex()}-01"})
     assert response_401.status_code == 401
 
     request_id = response_401.headers.get("x-request-id")
     min_procs = 2 if has_ocp_managed_istio else 3
-    traces = tracing.get_traces(service="wasm-shim", min_processes=min_procs, tags={"request_id": request_id})
+    traces = tracing.get_traces(service="kuadrant-filter", min_processes=min_procs, tags={"request_id": request_id})
     assert len(traces) == 1, f"No trace was found in tracing backend with request_id: {request_id}"
     return traces[0]
 
@@ -81,7 +81,7 @@ def test_trace_includes_all_kuadrant_services(trace_200, label, has_ocp_managed_
 
     Verifies that a request flowing through the system generates a complete distributed
     trace with all expected service processes:
-    - wasm-shim: WASM plugin processing requests
+    - kuadrant-filter: WASM plugin processing requests
     - authorino: Authorization service
     - limitador: Rate limiting service
     - gateway: Istio/Envoy gateway service (not with OCP-managed Istio)
@@ -89,7 +89,7 @@ def test_trace_includes_all_kuadrant_services(trace_200, label, has_ocp_managed_
 
     process_services = trace_200.get_process_services()
 
-    services = ["wasm-shim", "authorino", "limitador"]
+    services = ["kuadrant-filter", "authorino", "limitador"]
     if not has_ocp_managed_istio:
         services.append(f"{label}.kuadrant")
     for service in services:
@@ -100,14 +100,14 @@ def test_relevant_services_on_auth_denied(trace_401, label, has_ocp_managed_isti
     """
     Test that auth-denied traces only include services up to the authorization step.
 
-    When a request is rejected with 401, the trace should contain wasm-shim and authorino
+    When a request is rejected with 401, the trace should contain kuadrant-filter and authorino
     but not limitador, since the request is short-circuited before reaching the rate limiter.
     Gateway service is not present with OCP-managed Istio.
     """
 
     process_services = trace_401.get_process_services()
 
-    services = ["wasm-shim", "authorino"]
+    services = ["kuadrant-filter", "authorino"]
     if not has_ocp_managed_istio:
         services.append(f"{label}.kuadrant")
     for service in services:
@@ -171,7 +171,7 @@ def test_send_reply_span_not_on_successful_response(trace_200):
     """
     Test that send_reply span is not present for successful (200) responses.
 
-    The send_reply span is only generated when the wasm-shim rejects a request
+    The send_reply span is only generated when the kuadrant-filter rejects a request
     (e.g., 401 or 429). For successful responses that pass through all policies,
     no send_reply span should be emitted.
     """
@@ -230,7 +230,7 @@ def assert_child(trace, parent_span, child_op, **tags):
 def test_span_hierarchy(trace_200):
     """
     Test that spans in a successful (200) trace form the expected parent-child hierarchy.
-    Validates parent-child relationships between spans across wasm-shim, authorino, and limitador.
+    Validates parent-child relationships between spans across kuadrant-filter, authorino, and limitador.
     """
 
     assert len(trace_200.spans) > 0, "No spans found in trace"

--- a/testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing_rate_limit_only.py
+++ b/testsuite/tests/singlecluster/tracing/data_plane_tracing/test_kuadrant_tracing_rate_limit_only.py
@@ -35,7 +35,7 @@ def commit(request, rate_limit):
 def trace_429(client, tracing, has_ocp_managed_istio):
     """
     Sends requests to exhaust the rate limit, produces a 429 response,
-    and fetches the full wasm-shim trace.
+    and fetches the full kuadrant-filter trace.
     """
     responses = client.get_many("/get", 3)
     responses.assert_all(200)
@@ -45,7 +45,7 @@ def trace_429(client, tracing, has_ocp_managed_istio):
 
     request_id = response_429.headers.get("x-request-id")
     min_procs = 2 if has_ocp_managed_istio else 3
-    traces = tracing.get_traces(service="wasm-shim", min_processes=min_procs, tags={"request_id": request_id})
+    traces = tracing.get_traces(service="kuadrant-filter", min_processes=min_procs, tags={"request_id": request_id})
     assert len(traces) == 1, f"No trace was found in tracing backend with request_id: {request_id}"
     return traces[0]
 
@@ -58,7 +58,7 @@ def test_relevant_services_rate_limit_only(trace_429, label, has_ocp_managed_ist
     """
 
     process_services = trace_429.get_process_services()
-    services = ["wasm-shim", "limitador"]
+    services = ["kuadrant-filter", "limitador"]
     if not has_ocp_managed_istio:
         services.append(f"{label}.kuadrant")
     for service in services:


### PR DESCRIPTION

  ## Description
  - Rename all references of `wasm-shim` to `kuadrant-filter` in data plane tracing tests, following the upstream rename in [Kuadrant/wasm-shim#399](https://github.com/Kuadrant/wasm-shim/pull/399)
  - Updates service name queries, assertion lists, and docstrings across both data plane tracing test modules

  Closes https://github.com/Kuadrant/testsuite/issues/1024
  
  ## Verification steps

  Run the data plane tracing tests against a cluster with the updated wasm-shim (kuadrant-filter):

  ```bash
  poetry run pytest -vv -n4 testsuite/tests/singlecluster/tracing/data_plane_tracing/
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated data-plane tracing tests to reference the `kuadrant-filter` component instead of `wasm-shim`.
  * Revised trace fixtures and service expectations to reflect the current tracing configuration.
  * Preserved validation for rate-limiting services and conditional gateway participation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->