### PR TITLE
refactor: wait for AWS slow_loadbalancers actively

### DIFF
--- a/config/settings.local.yaml.tpl
+++ b/config/settings.local.yaml.tpl
@@ -72,7 +72,6 @@
 #        api_url: "https://api.kubernetes3.com"
 #        token: "KUADRANT_RULEZ"
 #        kubeconfig_path: "~/.kube/config3"
-#    slow_loadbalancers: false                     # For use in Openshift on AWS: If true, causes all Gateways and LoadBalancer Services to wait longer to become ready
 #    provider_secret: "aws-credentials"            # Name of the Secret resource that contains DNS provider credentials
 #    issuer:                                       # Issuer object for testing TLSPolicy
 #      name: "selfsigned-cluster-issuer"           # Name of Issuer CR

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -37,7 +37,6 @@ default:
       log_level: "debug"
   control_plane:
     cluster: {}
-    slow_loadbalancers: false
     provider_secret: "aws-credentials"
     issuer:
       name: "kuadrant-qe-issuer"

--- a/testsuite/backend/mockserver.py
+++ b/testsuite/backend/mockserver.py
@@ -114,4 +114,4 @@ class MockserverBackend(Backend):
     def wait_for_ready(self, timeout=SERVICE_READY_TIMEOUT):
         """Waits until Deployment and Service is marked as ready"""
         self.deployment.wait_for_ready(timeout)
-        self.service.wait_for_ready(timeout, settings["control_plane"]["slow_loadbalancers"])
+        self.service.wait_for_ready(timeout)

--- a/testsuite/gateway/envoy/__init__.py
+++ b/testsuite/gateway/envoy/__init__.py
@@ -6,7 +6,6 @@ from typing import Optional
 import openshift_client as oc
 
 from testsuite.certificates import Certificate
-from testsuite.config import settings
 from testsuite.gateway import Gateway
 from testsuite.kubernetes import Selector
 from testsuite.kubernetes.client import KubernetesClient
@@ -111,7 +110,7 @@ class Envoy(Gateway):  # pylint: disable=too-many-instance-attributes
             service_type="LoadBalancer",
         )
         self.service.commit()
-        self.service.wait_for_ready(slow_loadbalancers=settings["control_plane"]["slow_loadbalancers"])
+        self.service.wait_for_ready()
 
     def get_tls_cert(self, _) -> Optional[Certificate]:
         return None

--- a/testsuite/gateway/gateway_api/gateway.py
+++ b/testsuite/gateway/gateway_api/gateway.py
@@ -1,19 +1,17 @@
 """Module containing all gateway classes"""
 
-from time import sleep
 from typing import Any
 
 import openshift_client as oc
 
-from testsuite.config import settings
 from testsuite.certificates import Certificate
 from testsuite.gateway import Gateway, GatewayListener
 from testsuite.kubernetes.client import KubernetesClient
 from testsuite.kubernetes import KubernetesObject, modify
 from testsuite.kuadrant.policy import Policy
 from testsuite.kubernetes.deployment import Deployment
-from testsuite.utils import check_condition, asdict, domain_match
-from testsuite.utils.constants import GATEWAY_READY_TIMEOUT, SLOW_LOADBALANCER_WAIT
+from testsuite.utils import check_condition, asdict, domain_match, wait_for_dns_resolution
+from testsuite.utils.constants import GATEWAY_READY_TIMEOUT
 
 
 class KuadrantGateway(KubernetesObject, Gateway):
@@ -104,11 +102,13 @@ class KuadrantGateway(KubernetesObject, Gateway):
         return False
 
     def wait_for_ready(self, timeout: int = GATEWAY_READY_TIMEOUT):
-        """Waits for the gateway to be ready in the sense of is_ready(self)"""
+        """Waits for the gateway to be ready and its address to be DNS-resolvable"""
         success = self.wait_until(lambda obj: self.__class__(obj.model).is_ready(), timelimit=timeout)
         assert success, f"Gateway didn't reach required state, instead it was: {self.model.status.conditions}"
-        if settings["control_plane"]["slow_loadbalancers"]:
-            sleep(SLOW_LOADBALANCER_WAIT)
+        with self.context:
+            address = self.refresh().model.status.addresses[0].value
+        if address is not oc.Missing and any(c.isalpha() for c in str(address)):
+            wait_for_dns_resolution(str(address))
 
     def is_affected_by(self, policy: Policy) -> bool:
         """Returns True, if affected by status is found within the object for the specific policy"""

--- a/testsuite/kubernetes/service.py
+++ b/testsuite/kubernetes/service.py
@@ -1,13 +1,13 @@
 """Service related objects"""
 
-from time import sleep
 from dataclasses import dataclass, asdict
 from typing import Literal
 
 from openshift_client import timeout, Missing
 
 from testsuite.kubernetes import KubernetesObject
-from testsuite.utils.constants import SERVICE_DELETE_TIMEOUT, SERVICE_READY_TIMEOUT, SLOW_LOADBALANCER_WAIT
+from testsuite.utils import wait_for_dns_resolution
+from testsuite.utils.constants import SERVICE_DELETE_TIMEOUT, SERVICE_READY_TIMEOUT
 
 
 @dataclass
@@ -78,8 +78,8 @@ class Service(KubernetesObject):
             deleted = super(KubernetesObject, self).delete(ignore_not_found, cmd_args)
             return deleted
 
-    def wait_for_ready(self, timeout=SERVICE_READY_TIMEOUT, slow_loadbalancers=False):
-        """Waits until LoadBalancer service gets ready."""
+    def wait_for_ready(self, timeout=SERVICE_READY_TIMEOUT):
+        """Waits until LoadBalancer service gets ready and its address is reachable."""
         if self.model.spec.type != "LoadBalancer":
             return
         success = self.wait_until(
@@ -88,5 +88,9 @@ class Service(KubernetesObject):
             timelimit=timeout,
         )
         assert success, f"Service {self.name()} did not get ready in time"
-        if slow_loadbalancers:
-            sleep(SLOW_LOADBALANCER_WAIT)
+
+        # AWS load-balancers return hostnames instead of IP addresses
+        address = self.external_ip
+        if any(c.isalpha() for c in address):
+            # If the address is a hostname, wait for it to be resolvable via DNS
+            wait_for_dns_resolution(address)

--- a/testsuite/utils/__init__.py
+++ b/testsuite/utils/__init__.py
@@ -6,7 +6,7 @@ import json
 import os
 import getpass
 import secrets
-from time import sleep
+from time import sleep, time
 from collections.abc import Collection
 from copy import deepcopy
 from dataclasses import is_dataclass, fields
@@ -19,6 +19,7 @@ import dns.resolver
 from weakget import weakget
 
 from testsuite.certificates import Certificate, CFSSLClient, CertInfo
+from testsuite.utils.constants import DNS_RESOLUTION_TIMEOUT
 
 MESSAGE_1KB = resources.files("testsuite.resources.performance.files").joinpath("message_1kb.txt")
 
@@ -189,6 +190,25 @@ def hostname_to_ip(address: str) -> str:
         except dns.resolver.NXDOMAIN as e:
             raise ValueError(f"Hostname {address} can't be resolved to an IP address") from e
     return address
+
+
+def wait_for_dns_resolution(hostname: str, timeout: int = DNS_RESOLUTION_TIMEOUT):
+    """Polls DNS until a hostname becomes resolvable.
+    Cloud providers like AWS assign LoadBalancer hostnames before DNS propagation completes."""
+    deadline = time() + timeout
+    interval = 5
+    while True:
+        try:
+            dns.resolver.resolve(hostname)
+            return
+        except (
+            dns.resolver.NXDOMAIN,
+            dns.resolver.NoAnswer,
+            dns.resolver.NoNameservers,
+        ) as exc:
+            if time() >= deadline:
+                raise TimeoutError(f"Hostname {hostname} did not become DNS-resolvable within {timeout}s") from exc
+            sleep(interval)
 
 
 def is_nxdomain(hostname: str):

--- a/testsuite/utils/constants.py
+++ b/testsuite/utils/constants.py
@@ -2,8 +2,8 @@
 
 # --- Kubernetes Resource Timeouts (seconds) ---
 
-# Additional wait after LoadBalancer IP is assigned on slow cloud providers.
-SLOW_LOADBALANCER_WAIT = 60
+# Timeout for polling DNS resolution of LoadBalancer hostnames (e.g. AWS ELB).
+DNS_RESOLUTION_TIMEOUT = 60
 
 # Default timeout for K8s wait_until condition checks.
 K8S_WAIT_UNTIL_TIMEOUT = 60


### PR DESCRIPTION
### Description

Change slow_loadbalancers wait to periodically check the for the dns resolution on assigned loadbalancer hostname, instead of statically waiting for a predefined time. 