### PR TITLE
fix(extensions): add 5s wait for PipelinePolicy

### DIFF
--- a/testsuite/kuadrant/extensions/pipeline_policy.py
+++ b/testsuite/kuadrant/extensions/pipeline_policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 from functools import cached_property
 from typing import Dict, List, Optional
 
@@ -10,6 +11,7 @@ from testsuite.gateway import Referencable
 from testsuite.kubernetes import modify
 from testsuite.kubernetes.client import KubernetesClient
 from testsuite.kuadrant.policy import Policy
+from testsuite.utils.constants import EXTENSION_POLICY_ENFORCEMENT_WAIT
 
 
 class ActionSection:
@@ -109,6 +111,11 @@ class PipelinePolicy(Policy):
             model["spec"]["targetRef"]["sectionName"] = section_name
 
         return cls(model, context=cluster.context)
+
+    def wait_for_ready(self):
+        """Wait for PipelinePolicy to be enforced, then wait for propagation to the data plane."""
+        super().wait_for_ready()
+        time.sleep(EXTENSION_POLICY_ENFORCEMENT_WAIT)
 
     @cached_property
     def on_http_request(self) -> ActionSection:

--- a/testsuite/utils/constants.py
+++ b/testsuite/utils/constants.py
@@ -175,6 +175,9 @@ THREAT_ASSESSMENT_THRESHOLD = 50
 
 # --- Extension Policy ---
 
+# Wait for extension policy to propagate to the data plane after enforcement.
+EXTENSION_POLICY_ENFORCEMENT_WAIT = 5
+
 # Wait for EnvoyFilter to propagate before checking isolation (testing absence of leaking).
 EXTENSION_POLICY_PROPAGATION_WAIT = 10
 


### PR DESCRIPTION
## Mitigate PipelinePolicy test flakiness in nightly runs
  
  PipelinePolicy tests intermittently fail in nightly CI with `500 Internal Server Error` instead of the expected status code. The root cause is that the `Enforced` status condition is reported prematurely — the kuadrant control plane marks the policy as enforced without waiting for the WASM shim to confirm that the EnvoyFilter has actually been applied. This means the gateway may not yet be ready to handle requests through the pipeline when tests start sending traffic.

  Add a 5-second wait after `wait_for_ready()` in `PipelinePolicy` to give the EnvoyFilter time to be actually enforced on the data plane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved extension policy readiness checks by allowing time for enforcement changes to propagate before validation.
  * Increased reliability of automated tests that verify policy behaviour on the data plane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->