### PR TITLE
test(OCP5): add centralized tls configuration test

### DIFF
--- a/testsuite/kubernetes/client.py
+++ b/testsuite/kubernetes/client.py
@@ -10,6 +10,7 @@ import yaml
 import openshift_client as oc
 from openshift_client import Context, OpenShiftPythonException
 
+from testsuite.kubernetes.openshift.api_server import APIServerCR
 from testsuite.kubernetes.openshift.route import OpenshiftRoute
 from testsuite.kubernetes.service import Service
 from .service_account import ServiceAccount
@@ -157,6 +158,12 @@ class KubernetesClient:
         """Returns dict-like structure for accessing deployment data"""
         with self.context:
             return oc.selector(f"deployment/{name}").object(cls=Deployment)
+
+    @property
+    def api_server_cr(self):
+        """Returns the cluster-scoped APIServer CR singleton"""
+        with self.context:
+            return oc.selector("apiserver.config.openshift.io/cluster").object(cls=APIServerCR)
 
     def do_action(self, verb: str, *args, stdin_str=None, auto_raise: bool = True, parse_output: bool = False):
         """Run an oc command."""

--- a/testsuite/kubernetes/openshift/api_server.py
+++ b/testsuite/kubernetes/openshift/api_server.py
@@ -1,0 +1,29 @@
+"""OpenShift APIServer CR for reading/modifying cluster TLS security profile"""
+
+from testsuite.kubernetes import KubernetesObject, modify
+
+
+class APIServerCR(KubernetesObject):
+    """Represents the OpenShift APIServer CR (config.openshift.io/v1, singleton named 'cluster')"""
+
+    @property
+    def tls_profile_type(self):
+        """Returns the TLS security profile type or None if unset (defaults to Intermediate)"""
+        if profile := self.model.spec.get("tlsSecurityProfile"):
+            return profile.get("type")
+        return None
+
+    @modify
+    def set_tls_profile(self, profile_type: str, min_version: str = None, ciphers: list = None):
+        """Sets the TLS security profile type (Intermediate, Modern, Old, Custom)"""
+        if profile_type != "Custom" and (min_version or ciphers):
+            raise ValueError(f"min_version and ciphers are only supported with Custom profile, got {profile_type}")
+
+        if profile_type is None:
+            self.model.spec["tlsSecurityProfile"] = None
+            return
+
+        tls_security_profile = {"type": profile_type, profile_type.lower(): {}}
+        if profile_type == "Custom":
+            tls_security_profile["custom"] = {"minTLSVersion": min_version, "ciphers": ciphers}
+        self.model.spec["tlsSecurityProfile"] = tls_security_profile

--- a/testsuite/tests/singlecluster/authorino/tls_profile/conftest.py
+++ b/testsuite/tests/singlecluster/authorino/tls_profile/conftest.py
@@ -1,0 +1,98 @@
+"""Conftest for TLS security profile propagation tests"""
+
+import pytest
+
+from testsuite.gateway.exposers import OpenShiftExposer
+from testsuite.kubernetes.openshift.route import OpenshiftRoute
+from testsuite.kubernetes.secret import TLSSecret
+
+
+@pytest.fixture(scope="module", autouse=True)
+def commit(kuadrant, exposer, skip_or_fail):
+    """No policies to commit for TLS profile tests"""
+    if not kuadrant:
+        skip_or_fail("Test requires Kuadrant")
+    if not isinstance(exposer, OpenShiftExposer):
+        skip_or_fail("Test requires OpenShift cluster to access the APIServer CR configuration")
+
+
+@pytest.fixture(scope="module")
+def tls_cert(request, cfssl, authorino, system_project, blame):
+    """CFSSL-generated TLS certificate for Authorino servers"""
+    cert_name = blame("tls")
+    certificate = cfssl.create("authorino-tls", hosts=[authorino.oidc_url, authorino.authorization_url])
+    tls_secret = TLSSecret.create_instance(system_project, cert_name, certificate)
+    request.addfinalizer(tls_secret.delete)
+    tls_secret.commit()
+    return cert_name
+
+
+@pytest.fixture(scope="module")
+def configure_authorino_tls(request, kuadrant, authorino, tls_cert):  # pylint: disable=unused-argument
+    """Enables TLS on Authorino CR using the CFSSL-generated certificate"""
+    original_listener_tls = dict(authorino.model.spec.get("listener", {}).get("tls", {}))
+    original_oidc_tls = dict(authorino.model.spec.get("oidcServer", {}).get("tls", {}))
+
+    def _restore_tls(obj):
+        obj.model.spec["listener"]["tls"] = original_listener_tls
+        obj.model.spec["oidcServer"]["tls"] = original_oidc_tls
+
+    request.addfinalizer(lambda: authorino.apply(_restore_tls))
+
+    def _enable_tls(obj):
+        tls_config = {"enabled": True, "certSecretRef": {"name": tls_cert}}
+        obj.model.spec["listener"]["tls"] = tls_config
+        obj.model.spec["oidcServer"]["tls"] = tls_config
+
+    authorino.apply(_enable_tls)
+
+    authorino.deployment.wait_for_ready()
+
+
+@pytest.fixture(scope="module")
+def tls_profile(request, cluster, authorino, configure_authorino_tls):  # pylint: disable=unused-argument
+    """Sets the APIServer TLS profile and waits for Authorino propagation"""
+    profile_type, min_version, ciphers = request.param
+    api_server = cluster.api_server_cr
+
+    original_profile = api_server.tls_profile_type
+    request.addfinalizer(lambda: api_server.set_tls_profile(original_profile))
+    ocp_version = f"VersionTLS{min_version.replace('.', '')}" if ciphers else None
+    api_server.set_tls_profile(profile_type, min_version=ocp_version, ciphers=ciphers)
+
+    assert authorino.wait_until(
+        lambda obj: obj.model.spec.get("listener", {}).get("tls", {}).get("minVersion") == min_version
+    ), f"Authorino CR TLS config was not updated for {profile_type} profile within 60s"
+    authorino.deployment.wait_for_ready()
+
+
+@pytest.fixture(scope="module")
+def oidc_route(request, authorino, system_project, blame):
+    """Passthrough Route exposing Authorino OIDC endpoint for direct TLS probing"""
+    route = OpenshiftRoute.create_instance(
+        system_project,
+        blame("oidc"),
+        authorino.oidc_url.split(".")[0],
+        target_port="http",
+        tls=True,
+        termination="passthrough",
+    )
+    request.addfinalizer(route.delete)
+    route.commit()
+    return route
+
+
+@pytest.fixture(scope="module")
+def authorization_route(request, authorino, system_project, blame):
+    """Passthrough Route exposing Authorino authorization endpoint for direct TLS probing"""
+    route = OpenshiftRoute.create_instance(
+        system_project,
+        blame("auth"),
+        authorino.authorization_url.split(".")[0],
+        target_port="grpc",
+        tls=True,
+        termination="passthrough",
+    )
+    request.addfinalizer(route.delete)
+    route.commit()
+    return route

--- a/testsuite/tests/singlecluster/authorino/tls_profile/test_tls_profile.py
+++ b/testsuite/tests/singlecluster/authorino/tls_profile/test_tls_profile.py
@@ -1,0 +1,63 @@
+"""Tests that TLS security profiles are propagated from APIServer CR to Authorino endpoints"""
+
+import ssl
+import socket
+
+import pytest
+
+pytestmark = [pytest.mark.authorino, pytest.mark.kuadrant_only, pytest.mark.disruptive]
+
+
+@pytest.fixture(scope="module")
+def probe_tls():
+    """
+    Returns a callable that probes a TLS endpoint with a specific TLS version,
+    and returns the negotiated TLS version and cipher.
+    https://docs.python.org/3/library/ssl.html#socket-creation
+    """
+
+    def _probe(hostname, max_version=None):
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        if max_version is not None:
+            context.minimum_version = max_version
+            context.maximum_version = max_version
+        try:
+            with socket.create_connection((hostname, 443), timeout=10) as sock:
+                with context.wrap_socket(sock, server_hostname=hostname) as ssock:
+                    return ssock.version(), ssock.cipher()[0]
+        except ssl.SSLError:
+            return None, None
+
+    return _probe
+
+
+@pytest.mark.parametrize(
+    "tls_profile, accept_version, reject_version, expected_cipher",
+    [
+        pytest.param(("Modern", "1.3", None), ssl.TLSVersion.TLSv1_3, ssl.TLSVersion.TLSv1_2, None, id="modern"),
+        pytest.param(
+            ("Intermediate", "1.2", None), ssl.TLSVersion.TLSv1_2, ssl.TLSVersion.TLSv1_1, None, id="intermediate"
+        ),
+        pytest.param(
+            ("Custom", "1.2", ["ECDHE-RSA-AES128-GCM-SHA256"]),
+            ssl.TLSVersion.TLSv1_2,
+            ssl.TLSVersion.TLSv1_1,
+            "ECDHE-RSA-AES128-GCM-SHA256",
+            id="custom",
+        ),
+    ],
+    indirect=["tls_profile"],
+)
+def test_tls_profile(
+    tls_profile, accept_version, reject_version, expected_cipher, probe_tls, oidc_route, authorization_route
+):  # pylint: disable=unused-argument
+    """OIDC and authorization endpoints accept the profile's TLS version and reject lower versions"""
+    for hostname in [oidc_route.hostname, authorization_route.hostname]:
+        ver, cipher = probe_tls(hostname, max_version=accept_version)
+        assert ver == accept_version.name.replace("_", ".")
+        if expected_cipher is not None:
+            assert cipher == expected_cipher
+        if reject_version is not None:
+            assert probe_tls(hostname, max_version=reject_version)[0] is None

--- a/testsuite/tests/singlecluster/authorino/tls_profile/test_tls_profile.py
+++ b/testsuite/tests/singlecluster/authorino/tls_profile/test_tls_profile.py
@@ -55,9 +55,11 @@ def test_tls_profile(
 ):  # pylint: disable=unused-argument
     """OIDC and authorization endpoints accept the profile's TLS version and reject lower versions"""
     for hostname in [oidc_route.hostname, authorization_route.hostname]:
-        ver, cipher = probe_tls(hostname, max_version=accept_version)
-        assert ver == accept_version.name.replace("_", ".")
+        version, cipher = probe_tls(hostname, max_version=accept_version)
+        expected_ver = accept_version.name.replace("_", ".")
+        assert version == expected_ver, f"Expected TLS version {expected_ver}, got {version}"
         if expected_cipher is not None:
-            assert cipher == expected_cipher
+            assert cipher == expected_cipher, f"Expected cipher {expected_cipher}, got {cipher}"
         if reject_version is not None:
-            assert probe_tls(hostname, max_version=reject_version)[0] is None
+            rejected_ver = reject_version.name.replace("_", ".")
+            assert probe_tls(hostname, max_version=reject_version)[0] is None, f"TLS {rejected_ver} should be rejected"


### PR DESCRIPTION
## Summary
  - Add `APIServerCR` model for reading/modifying the OpenShift cluster-wide TLS security profile
  - Add `api_server_cr` property to `KubernetesClient` for accessing the APIServer singleton
  - Add parametrized test covering Modern, Intermediate, and Custom TLS profile propagation from the OpenShift APIServer CR to Authorino's OIDC and authorization endpoints

Closes #1023 

## Verification
```bash
make testsuite/tests/singlecluster/authorino/tls_profile/test_tls_profile.py
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for viewing and configuring OpenShift API server TLS security profiles.
  - Supports Modern, Intermediate and Custom profiles, including minimum TLS versions and cipher suites.
  - Added validation for profile-specific configuration settings.

- **Tests**
  - Added coverage for TLS settings across Authorino OIDC and authorisation endpoints.
  - Verifies that supported TLS versions and ciphers are accepted, while weaker configurations are rejected.
  - Added coverage for TLS profile propagation and endpoint behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->