### PR TITLE
fix: guard against missing source in rerun failure formatting

### DIFF
--- a/testsuite/tests/conftest.py
+++ b/testsuite/tests/conftest.py
@@ -78,7 +78,11 @@ def _format_failure_message(call, report):
     tb_lines = []
     for entry in call.excinfo.traceback:
         if "site-packages" not in str(entry.path):
-            tb_lines.append(f"{entry.path}:{entry.lineno}: in {entry.name}\n    {entry.statement}")
+            try:
+                statement = entry.statement
+            except (AssertionError, OSError):
+                statement = "<source unavailable>"
+            tb_lines.append(f"{entry.path}:{entry.lineno}: in {entry.name}\n    {statement}")
 
     exc = call.excinfo.value
     exc_message = str(exc)


### PR DESCRIPTION
## Summary

  - Guard `entry.statement` access in `_format_failure_message` against traceback entries from frozen/compiled modules (e.g. `<frozen os>`) where source code is unavailable
  - Without the guard, `entry.statement` raises `AssertionError` inside the `pytest_runtest_makereport` hook, which pytest escalates to an `INTERNALERROR` that kills the entire test session

  ## Problem

When a test fails with a traceback that includes frames from frozen CPython modules, `_format_failure_message` crashes trying to read the source statement. This turns a single test failure into a session-wide `INTERNALERROR`, aborting all remaining tests. This was observed in the `disruptive` CI target where only 1 of 40 selected tests ran before the session was killed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure-report formatting when source statements cannot be retrieved.
  * Reports now display a fallback placeholder instead of raising an additional error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->