### PR TITLE
fix: exclude extensions from make kuadrant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ smoke: poetry-no-dev  ## Run a small amount of selected tests to verify basic fu
 	$(PYTEST) -n4 -m 'smoke' --dist loadfile --enforce $(flags) testsuite/tests/
 
 kuadrant: poetry-no-dev  ## Run all tests available on Kuadrant
-	$(PYTEST) -n4 -m 'not standalone_only and not disruptive and not ui' --dist loadfile --enforce $(flags) testsuite/tests/singlecluster
+	$(PYTEST) -n4 -m 'not standalone_only and not disruptive and not ui and not extensions' --dist loadfile --enforce $(flags) testsuite/tests/singlecluster
 
 authorino: poetry-no-dev  ## Run only Authorino related tests
 	$(PYTEST) -n4 -m 'authorino and not disruptive' --dist loadfile --enforce $(flags) testsuite/tests/singlecluster/

--- a/testsuite/tests/singlecluster/limitador/metrics/trlp_metrics/test_trlp_metrics.py
+++ b/testsuite/tests/singlecluster/limitador/metrics/trlp_metrics/test_trlp_metrics.py
@@ -9,7 +9,7 @@ import pytest
 
 from .conftest import MODEL_NAME, USERS
 
-pytestmark = [pytest.mark.observability, pytest.mark.limitador]
+pytestmark = [pytest.mark.observability, pytest.mark.limitador, pytest.mark.extensions]
 
 
 basic_request = {

--- a/testsuite/tests/singlecluster/limitador/metrics/trlp_metrics/test_trlp_metrics_stream.py
+++ b/testsuite/tests/singlecluster/limitador/metrics/trlp_metrics/test_trlp_metrics_stream.py
@@ -8,7 +8,7 @@ import pytest
 
 from .conftest import MODEL_NAME, USERS
 
-pytestmark = [pytest.mark.observability, pytest.mark.limitador]
+pytestmark = [pytest.mark.observability, pytest.mark.limitador, pytest.mark.extensions]
 
 streaming_request = {
     "model": MODEL_NAME,


### PR DESCRIPTION
## Summary
  - Exclude extension tests from the `make kuadrant` target by adding `not extensions` marker filter
  - Extension tests remain runnable via the dedicated `make extensions` target
  - Temporary measure until the extension framework is stabilized
  
- Added `extensions` marker to `trlp_metrics` tests since they depend on `TelemetryPolicy` from the extension framework

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the standard test run to exclude extension-specific tests, alongside standalone, disruptive, and UI tests.
  * Existing parallel test execution and test distribution remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->