### PR TITLE
chore: pin GitHub Actions to commit SHAs using ratchet

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -2,17 +2,17 @@ name: Code static analysis
 on:
   push:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # ratchet:actions/checkout@v3
       - name: Install poetry
         run: pip install poetry
       - name: Setup Python
         id: setup-python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4
         with:
           python-version: '3.11'
           cache: "poetry"

--- a/.github/workflows/build_unstable_image.yml
+++ b/.github/workflows/build_unstable_image.yml
@@ -17,14 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # ratchet:actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # ratchet:docker/setup-qemu-action@v3
 
       - name: Build unstable and sha images
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
         with:
           image: ${{ env.IMG_NAME }}
           tags: ${{ env.IMG_TAGS }}
@@ -34,7 +34,7 @@ jobs:
             ./Dockerfile
 
       - name: Push images to quay
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}

--- a/.github/workflows/build_unstable_ui_image.yml
+++ b/.github/workflows/build_unstable_ui_image.yml
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # ratchet:actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # ratchet:docker/setup-qemu-action@v3
 
       - name: Build unstable UI and sha images
         id: build-ui-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
         with:
           image: ${{ env.UI_IMG_NAME }}
           tags: ${{ env.IMG_TAGS }}
@@ -40,7 +40,7 @@ jobs:
             ./ui.Dockerfile
 
       - name: Push UI images to quay
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-ui-image.outputs.image }}
           tags: ${{ steps.build-ui-image.outputs.tags }}

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Move PR to ${{ env.review }}
-        uses: leonsteinhaeuser/project-beta-automations@v2.1.0
+        uses: leonsteinhaeuser/project-beta-automations@d1c1261558118c0876fdb2b57a649303925e5a70 # ratchet:leonsteinhaeuser/project-beta-automations@v2.1.0
         with:
           gh_token: ${{ secrets.UPDATE_ACTION_VARS_TOKEN }}
           organization: kuadrant

--- a/.github/workflows/ratchet-check.yaml
+++ b/.github/workflows/ratchet-check.yaml
@@ -1,0 +1,26 @@
+name: Ratchet Check
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+jobs:
+  ratchet:
+    runs-on: ubuntu-latest
+    name: Check pinned actions
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: sethvargo/ratchet@8b4ca256dbed184350608a3023620f267f0a5253 # ratchet:sethvargo/ratchet@v0.11.4
+        with:
+          files: |
+            .github/workflows/*.yaml
+            .github/workflows/*.yml

--- a/.github/workflows/re-enable-disabled-workflows.yml
+++ b/.github/workflows/re-enable-disabled-workflows.yml
@@ -12,123 +12,123 @@ jobs:
       actions: write
 
     steps:
-    - name: Re-enable disabled workflows across repositories
-      env:
-        TOKEN: ${{ secrets.ENABLE_WORKFLOWS_TOKEN }}
+      - name: Re-enable disabled workflows across repositories
+        env:
+          TOKEN: ${{ secrets.ENABLE_WORKFLOWS_TOKEN }}
 
-      run: |
-        set -uo pipefail
-
-        failure=false
-        failure_messages=()
-
-        echo "Checking for disabled workflows..."
-
-        # Search for repos
-        REPO_LIST=""
-
-        tmplist=/tmp/repos_code_search.txt
-        : > "$tmplist"
-
-        public_repos=$(curl -s -w "%{http_code}" -o /tmp/search_normal.json \
-          -H "Authorization: Bearer $TOKEN" \
-          -H "Accept: application/vnd.github+json" \
-          "https://api.github.com/search/code?q=org:Kuadrant+path:.github/workflows+schedule%3A&per_page=100")
-        if [ "$public_repos" != "200" ]; then
-          echo "Failed to search repositories (non-forks) (HTTP $public_repos)"
-          failure_messages+=("Failed to search repositories (non-forks) (HTTP $public_repos)")
-          failure=true
-        else
-          jq -r '.items[].repository.name' /tmp/search_normal.json >> "$tmplist" || true
-        fi
-
-        fork_repos=$(curl -s -w "%{http_code}" -o /tmp/search_forks.json \
-          -H "Authorization: Bearer $TOKEN" \
-          -H "Accept: application/vnd.github+json" \
-          "https://api.github.com/search/code?q=org:Kuadrant+fork:true+path:.github/workflows+schedule%3A&per_page=100")
-        if [ "$fork_repos" != "200" ]; then
-          echo "Failed to search repositories (forks) (HTTP $fork_repos)"
-          failure_messages+=("Failed to search repositories (forks) (HTTP $fork_repos)")
-          failure=true
-        else
-          jq -r '.items[].repository.name' /tmp/search_forks.json >> "$tmplist" || true
-        fi
-
-        if [ -s "$tmplist" ]; then
-          REPO_LIST="$(sort -u "$tmplist")"
-        fi
-
-        if [ -z "$REPO_LIST" ]; then
-          echo "No repositories found."
-          for msg in "${failure_messages[@]}"; do
-            echo "- $msg"
-          done
-          exit 1
-        fi
-        
-        echo "Repositories found:"
-        echo "$REPO_LIST"
-  
-        # Check repos for disabled workflows
-        while IFS= read -r repo; do
-          repo="$(echo "$repo" | xargs || true)"
-          [ -z "$repo" ] && continue
+        run: "set -uo pipefail\n\nfailure=false\nfailure_messages=()\n\necho \"Checking for disabled workflows...\"\n\n# Search for repos\nREPO_LIST=\"\"\n\ntmplist=/tmp/repos_code_search.txt\n: > \"$tmplist\"\n\npublic_repos=$(curl -s -w \"%{http_code}\" -o /tmp/search_normal.json \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Accept: application/vnd.github+json\" \\\n  \"https://api.github.com/search/code?q=org:Kuadrant+path:.github/workflows+schedule%3A&per_page=100\")\nif [ \"$public_repos\" != \"200\" ]; then\n  echo \"Failed to search repositories (non-forks) (HTTP $public_repos)\"\n  failure_messages+=(\"Failed to search repositories (non-forks) (HTTP $public_repos)\")\n  failure=true\nelse\n  jq -r '.items[].repository.name' /tmp/search_normal.json >> \"$tmplist\" || true\nfi\n\nfork_repos=$(curl -s -w \"%{http_code}\" -o /tmp/search_forks.json \\\n  -H \"Authorization: Bearer $TOKEN\" \\\n  -H \"Accept: application/vnd.github+json\" \\\n  \"https://api.github.com/search/code?q=org:Kuadrant+fork:true+path:.github/workflows+schedule%3A&per_page=100\")\nif [ \"$fork_repos\" != \"200\" ]; then\n  echo \"Failed to search repositories (forks) (HTTP $fork_repos)\"\n  failure_messages+=(\"Failed to search repositories (forks) (HTTP $fork_repos)\")\n  failure=true\nelse\n  jq -r '.items[].repository.name' /tmp/search_forks.json >> \"$tmplist\" || true\nfi\n\nif [ -s \"$tmplist\" ]; then\n  REPO_LIST=\"$(sort -u \"$tmplist\")\"\nfi\n\nif [ -z \"$REPO_LIST\" ]; then\n  echo \"No repositories found.\"\n  for msg in \"${failure_messages[@]}\"; do\n    echo \"- $msg\"\n  done\n  exit 1\nfi\n\necho \"Repositories found:\"\necho \"$REPO_LIST\"\n\n# Check repos for disabled workflows\nwhile IFS= read -r repo; do\n  repo=\"$(echo \"$repo\" | xargs || true)\"\n  [ -z \"$repo\" ] && continue\n\n\n  printf \"\\n=== Repository: Kuadrant/%s ===\\n\" \"$repo\"\n\n  url=\"https://api.github.com/repos/Kuadrant/$repo/actions/workflows?per_page=100\"\n  response_code=$(curl -s -w \"%{http_code}\" -o /tmp/workflows.json \\\n    -H \"Authorization: Bearer $TOKEN\" \\\n    -H \"Accept: application/vnd.github+json\" \\\n    \"$url\")\n\n  if [ \"$response_code\" -ne 200 ]; then\n    echo \"Failed to fetch workflows for $repo (HTTP $response_code)\"\n    cat /tmp/workflows.json || true\n    resp_snippet=$(head -c 500 /tmp/workflows.json 2>/dev/null | tr '\\n' ' ')\n    failure_messages+=(\"[$repo] list workflows failed (HTTP $response_code): ${resp_snippet:-<no body>}\")\n    failure=true\n    continue\n  fi\n\n  workflows=$(cat /tmp/workflows.json)\n  disabled_ids=$(echo \"$workflows\" | jq -r '.workflows[] | select(.state == \"disabled_inactivity\") | .id')\n\n  [ -z \"$disabled_ids\" ] && continue\n  \n  # Re-enable disabled workflows\n  while IFS= read -r workflow_id; do\n    [ -n \"$workflow_id\" ] || continue\n    workflow_name=$(echo \"$workflows\" | jq -r --arg id \"$workflow_id\" '.workflows[] | select(.id == ($id | tonumber)) | .name')\n    echo \"$workflow_name\"\n    response=$(curl -s -w \"%{http_code}\" -o /tmp/response.json \\\n      -X PUT \\\n      -H \"Authorization: Bearer $TOKEN\" \\\n      -H \"Accept: application/vnd.github+json\" \\\n      \"https://api.github.com/repos/Kuadrant/$repo/actions/workflows/$workflow_id/enable\")\n    if [ \"$response\" -ne 204 ]; then\n      echo \"Failed to re-enable: $workflow_name (HTTP $response)\"\n      cat /tmp/response.json || true\n      resp_snippet=$(head -c 500 /tmp/response.json 2>/dev/null | tr '\\n' ' ')\n      failure_messages+=(\"[$repo] enable '$workflow_name' (id $workflow_id) failed (HTTP $response): ${resp_snippet:-<no body>}\")\n      failure=true\n    fi\n  done <<< \"$disabled_ids\"\ndone <<< \"$REPO_LIST\"\n\n# Cleanup temporary files\nrm -f /tmp/workflows.json /tmp/response.json /tmp/search_normal.json /tmp/search_forks.json /tmp/repos_code_search.txt || true\n\nif [ \"$failure\" = true ]; then\n  echo \"Completed with ${#failure_messages[@]} failure(s).\"\n  echo \"Failures detail:\"\n  for msg in \"${failure_messages[@]}\"; do\n    echo \"- $msg\"\n  done\n  exit 1\nfi\n\necho \"Workflow re-enablement completed successfully!\"\n"
 
 
-          printf "\n=== Repository: Kuadrant/%s ===\n" "$repo"
 
-          url="https://api.github.com/repos/Kuadrant/$repo/actions/workflows?per_page=100"
-          response_code=$(curl -s -w "%{http_code}" -o /tmp/workflows.json \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "$url")
 
-          if [ "$response_code" -ne 200 ]; then
-            echo "Failed to fetch workflows for $repo (HTTP $response_code)"
-            cat /tmp/workflows.json || true
-            resp_snippet=$(head -c 500 /tmp/workflows.json 2>/dev/null | tr '\n' ' ')
-            failure_messages+=("[$repo] list workflows failed (HTTP $response_code): ${resp_snippet:-<no body>}")
-            failure=true
-            continue
-          fi
 
-          workflows=$(cat /tmp/workflows.json)
-          disabled_ids=$(echo "$workflows" | jq -r '.workflows[] | select(.state == "disabled_inactivity") | .id')
 
-          [ -z "$disabled_ids" ] && continue
-          
-          # Re-enable disabled workflows
-          while IFS= read -r workflow_id; do
-            [ -n "$workflow_id" ] || continue
-            workflow_name=$(echo "$workflows" | jq -r --arg id "$workflow_id" '.workflows[] | select(.id == ($id | tonumber)) | .name')
-            echo "$workflow_name"
-            response=$(curl -s -w "%{http_code}" -o /tmp/response.json \
-              -X PUT \
-              -H "Authorization: Bearer $TOKEN" \
-              -H "Accept: application/vnd.github+json" \
-              "https://api.github.com/repos/Kuadrant/$repo/actions/workflows/$workflow_id/enable")
-            if [ "$response" -ne 204 ]; then
-              echo "Failed to re-enable: $workflow_name (HTTP $response)"
-              cat /tmp/response.json || true
-              resp_snippet=$(head -c 500 /tmp/response.json 2>/dev/null | tr '\n' ' ')
-              failure_messages+=("[$repo] enable '$workflow_name' (id $workflow_id) failed (HTTP $response): ${resp_snippet:-<no body>}")
-              failure=true
-            fi
-          done <<< "$disabled_ids"
-        done <<< "$REPO_LIST"
 
-        # Cleanup temporary files
-        rm -f /tmp/workflows.json /tmp/response.json /tmp/search_normal.json /tmp/search_forks.json /tmp/repos_code_search.txt || true
 
-        if [ "$failure" = true ]; then
-          echo "Completed with ${#failure_messages[@]} failure(s)."
-          echo "Failures detail:"
-          for msg in "${failure_messages[@]}"; do
-            echo "- $msg"
-          done
-          exit 1
-        fi
 
-        echo "Workflow re-enablement completed successfully!"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # ratchet:actions/checkout@v3
         with:
-          fetch-depth: 0  # fetch tags to generate release notes
+          fetch-depth: 0 # fetch tags to generate release notes
 
       - name: Create tag if triggered from github
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -37,11 +37,11 @@ jobs:
           git push origin ${{ github.event.inputs.version_tag }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # ratchet:docker/setup-qemu-action@v3
 
       - name: Build testsuite image
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
         with:
           image: ${{ env.IMG_NAME }}
           tags: ${{ env.IMG_TAGS }}
@@ -51,7 +51,7 @@ jobs:
             ./Dockerfile
 
       - name: Push testsuite image to quay
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Build UI testsuite image
         id: build-ui-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
         with:
           image: ${{ env.UI_IMG_NAME }}
           tags: ${{ env.IMG_TAGS }}
@@ -71,7 +71,7 @@ jobs:
             ./ui.Dockerfile
 
       - name: Push UI testsuite image to quay
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-ui-image.outputs.image }}
           tags: ${{ steps.build-ui-image.outputs.tags }}
@@ -80,7 +80,7 @@ jobs:
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # ratchet:softprops/action-gh-release@v1
         with:
           # ternary operation to choose tag input based on how this workflow was triggered
           tag_name: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version_tag || github.ref_name }}

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -5,32 +5,32 @@ on:
 
 jobs:
   kuadrant-test:
-    if: |
-      github.event.issue.pull_request && 
-      startsWith(github.event.comment.body, '/make ')
+    if: "github.event.issue.pull_request && \nstartsWith(github.event.comment.body, '/make ')\n"
     runs-on: ubuntu-latest
     timeout-minutes: 120
-
     steps:
       - name: Extract and validate Make target
+
         id: extract-target
         run: |
           # Extract target from comment
           TARGET=$(echo "${{ github.event.comment.body }}" | awk '{print $2}')
-          
+
           # Validate target
+
           ALLOWED_TARGETS="test kuadrant authorino authorino-standalone limitador dnstls smoke disruptive kuadrantctl extensions observability defaults_overrides"
           if [[ ! " ${ALLOWED_TARGETS} " =~ " ${TARGET} " ]]; then
             echo "::error::Invalid target '${TARGET}'. Allowed targets: ${ALLOWED_TARGETS}"
             exit 1
           fi
-          
+
+
           echo "target=${TARGET}" >> $GITHUB_OUTPUT
           echo "Running make ${TARGET}"
 
       - name: Post comment with run link
         id: post-comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -44,7 +44,7 @@ jobs:
 
       - name: Get PR branch SHA
         id: pr-branch-sha
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -56,7 +56,7 @@ jobs:
             return response.data.head.sha;
 
       - name: Checkout PR code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
         with:
           ref: ${{ fromJSON(steps.pr-branch-sha.outputs.result) }}
 
@@ -68,12 +68,12 @@ jobs:
           sudo curl -L https://github.com/cloudflare/cfssl/releases/download/v1.6.4/cfssl_1.6.4_linux_amd64 -o /usr/local/bin/cfssl && sudo chmod +x /usr/local/bin/cfssl
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # ratchet:actions/setup-go@v4
         with:
           go-version: '1.24'
 
       - name: Create KIND cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # ratchet:helm/kind-action@v1
         with:
           version: "v0.27.0"
 
@@ -83,29 +83,7 @@ jobs:
           kubectl patch deployment metrics-server -n kube-system --type=json -p '[{"op":"add","path":"/spec/template/spec/containers/0/args/-","value":"--kubelet-insecure-tls"}]'
 
       - name: Install MetalLB
-        run: |
-          kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.15.2/config/manifests/metallb-native.yaml
-          kubectl wait --namespace metallb-system --for=condition=ready pod --selector=app=metallb --timeout=90s
-                
-          kubectl apply -f - <<EOF
-          apiVersion: metallb.io/v1beta1
-          kind: IPAddressPool
-          metadata:
-            name: default
-            namespace: metallb-system
-          spec:
-            addresses:
-            - 172.18.255.200-172.18.255.250
-          EOF
-
-          kubectl apply -f - <<EOF
-          apiVersion: metallb.io/v1beta1
-          kind: L2Advertisement
-          metadata:
-            name: default
-            namespace: metallb-system
-          EOF
-
+        run: "kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.15.2/config/manifests/metallb-native.yaml\nkubectl wait --namespace metallb-system --for=condition=ready pod --selector=app=metallb --timeout=90s\n      \nkubectl apply -f - <<EOF\napiVersion: metallb.io/v1beta1\nkind: IPAddressPool\nmetadata:\n  name: default\n  namespace: metallb-system\nspec:\n  addresses:\n  - 172.18.255.200-172.18.255.250\nEOF\n\nkubectl apply -f - <<EOF\napiVersion: metallb.io/v1beta1\nkind: L2Advertisement\nmetadata:\n  name: default\n  namespace: metallb-system\nEOF\n"
       - name: Install Gateway API CRDs
         run: kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.3.0/standard-install.yaml
 
@@ -113,27 +91,29 @@ jobs:
         run: |
           kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.18.2/cert-manager.yaml
           kubectl wait --namespace cert-manager --for=condition=Available deployment/cert-manager --timeout=120s
-
       - name: Install Sail Operator
         run: |
           helm repo add sail-operator https://istio-ecosystem.github.io/sail-operator --force-update
           helm install sail-operator \
             --create-namespace \
             --namespace istio-system \
+
             --wait \
             --timeout=300s \
             sail-operator/sail-operator \
             --version 1.27.0
-
       - name: Create Istio objects
         run: |
           kubectl apply -f - <<EOF
+
           apiVersion: sailoperator.io/v1
           kind: Istio
+
           metadata:
             name: default
           spec:
             namespace: istio-system
+
             updateStrategy:
               type: InPlace
             values:
@@ -141,12 +121,11 @@ jobs:
                 autoscaleMin: 2
             version: v1.24.3
           EOF
-
       - name: Create namespaces for testing
         run: |
           kubectl create namespace kuadrant
-          kubectl create namespace kuadrant2
 
+          kubectl create namespace kuadrant2
       - name: Create testsuite secrets
         run: |
           kubectl apply -f - <<EOF
@@ -160,17 +139,19 @@ jobs:
             tls.key: ${{ secrets.CA_TLS_KEY }}
           type: Opaque
           EOF
-          
+
           kubectl apply -f - <<EOF
+
           apiVersion: cert-manager.io/v1
           kind: ClusterIssuer
           metadata:
             name: kuadrant-qe-issuer
+
           spec:
             ca:
               secretName: kuadrant-qe-ca
           EOF
-          
+
           kubectl apply -f - <<EOF
           apiVersion: v1
           kind: Secret
@@ -179,19 +160,19 @@ jobs:
             namespace: kuadrant
             annotations:
               base_domain: ${{ secrets.AWS_BASE_DOMAIN }}
+
           stringData:
             AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
             AWS_REGION: eu-north-1
             AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           type: kuadrant.io/aws
           EOF
-
       - name: Deploy Kuadrant
         run: |
           helm repo add kuadrant https://kuadrant.io/helm-charts/ --force-update
+
           helm install kuadrant-operator kuadrant/kuadrant-operator --create-namespace --namespace kuadrant-system
           kubectl -n kuadrant-system wait --timeout=300s --for=condition=Available deployments --all
-
       - name: Add kuadrant-sample
         run: |
           kubectl apply -f - <<EOF
@@ -202,7 +183,7 @@ jobs:
             namespace: kuadrant-system
           spec: {}
           EOF
-          
+
           kubectl wait kuadrant/kuadrant-sample --for=condition=Ready=True -n kuadrant-system
 
       - name: Deploy testsuite tools
@@ -210,9 +191,8 @@ jobs:
           kubectl create namespace tools
           kubectl -n tools create secret docker-registry redhat-registry-secret --docker-server=registry.redhat.io --docker-username="${{ secrets.RH_REGISTRY_USERNAME }}" --docker-password="${{ secrets.RH_REGISTRY_PASSWORD }}"
           kubectl -n tools patch serviceaccount default -p '{"imagePullSecrets": [{"name": "redhat-registry-secret"}]}'
-          
-          helm install --repo https://kuadrant.io/helm-charts-olm --set=tools.keycloak.keycloakProvider=deployment --set=tools.coredns.enable=false --debug --wait --timeout=10m0s tools tools-instances
 
+          helm install --repo https://kuadrant.io/helm-charts-olm --set=tools.keycloak.keycloakProvider=deployment --set=tools.coredns.enable=false --debug --wait --timeout=10m0s tools tools-instances
       - name: Run Make target
         id: run-make
         run: |
@@ -222,49 +202,69 @@ jobs:
 
           {
             echo 'make_output<<EOF'
+
             cat /tmp/make_output.log
+
             echo EOF
           } >> $GITHUB_OUTPUT
 
           export SUMMARY=$(sed -n '/short test summary info/,/^====== [0-9]/p' /tmp/make_output.log | head -n -1)
           {
+
             echo 'summary<<EOF'
+
             echo "${SUMMARY}"
             echo EOF
           } >> $GITHUB_OUTPUT
-
       - name: Update comment with test results
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # ratchet:actions/github-script@v7
         with:
+
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const commentId = ${{ steps.post-comment.outputs.result }};
             const makeOutput = ${{ toJSON(steps.run-make.outputs.make_output) }};
             const summary = ${{ toJSON(steps.run-make.outputs.summary) }};
-            
+
             let body = `Test run completed (\`make ${{ steps.extract-target.outputs.target }}\`) and can be found [here](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            
+
             <details>
             <summary>Short Test Summary</summary>
-            
+
             \`\`\`
+
             ${summary}
             \`\`\`
-            
+
             </details>
-            
+
             <details>
             <summary>Full Output</summary>
-            
+
+
             \`\`\`
+
             ${makeOutput}
             \`\`\`
-            
+
             </details>`;
-            
+
             await github.rest.issues.updateComment({
+
               owner: context.repo.owner,
+
               repo: context.repo.repo,
               comment_id: commentId,
+
               body: body
             });
+
+
+
+
+
+
+
+
+
+

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # ratchet:amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
  - Pin all GitHub Action references to commit SHAs using [ratchet](https://github.com/sethvargo/ratchet)
  - Add a `ratchet-check` CI workflow that lints pull requests for unpinned action references

Part of the work on https://github.com/Kuadrant/kuadrant-operator/issues/2055

## Motivation
Tags are mutable — action maintainers can force-push them, silently changing the code our CI runs. Pinning to commit SHAs makes each reference immutable, mitigating supply-chain attacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Pinned third-party automation components to immutable versions for more predictable and secure workflow execution.
  * Added automated checks to ensure workflow dependencies remain pinned.
* **Bug Fixes**
  * Improved validation of requested test commands by restricting them to supported targets.
* **Maintenance**
  * Updated workflow triggers and formatting while preserving existing behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->